### PR TITLE
fix: inference timeout + pipeline gap false 503 + connecting UX

### DIFF
--- a/crates/arc-node/src/rpc.rs
+++ b/crates/arc-node/src/rpc.rs
@@ -4301,10 +4301,15 @@ async fn inference_run_sharded(
         return Err(api_error(StatusCode::SERVICE_UNAVAILABLE, "No shards announced. Need shard registry to be populated."));
     }
 
-    // Verify the pipeline is contiguous and covers all layers
+    // Verify the pipeline is contiguous and covers all layers.
+    // Stop early once coverage is complete — stale extra shards in the
+    // registry beyond n_layers must not cause a false gap error.
     let n_layers = pipeline[0].total_layers;
     let mut covered_to = 0usize;
     for shard in &pipeline {
+        if covered_to >= n_layers {
+            break;
+        }
         if shard.start_layer != covered_to {
             return Err(api_error(StatusCode::SERVICE_UNAVAILABLE, format!(
                 "Pipeline gap: expected layer {} next, got shard [{}, {}) (node {}, addr {})",
@@ -5078,10 +5083,14 @@ async fn inference_run_consensus(
     if pipeline_ranges.is_empty() {
         return Err(api_error(StatusCode::SERVICE_UNAVAILABLE, "No shards announced."));
     }
-    // Verify contiguous coverage.
+    // Verify contiguous coverage. Stop early once coverage is complete —
+    // stale extra shards beyond n_layers must not cause a false gap error.
     let n_layers = pipeline_ranges[0].1[0].total_layers;
     let mut covered = 0usize;
     for ((s, e), _) in &pipeline_ranges {
+        if covered >= n_layers {
+            break;
+        }
         if *s != covered {
             return Err(api_error(StatusCode::SERVICE_UNAVAILABLE, format!(
                 "Pipeline gap: expected layer {} next, got [{}, {})", covered, s, e

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -314,7 +314,14 @@ pub async fn run_inference(
     max_tokens: Option<u32>,
 ) -> CmdResult<InferenceResult> {
     let port = state.node.lock().await.rpc_port;
-    rpc_client::run_inference(&state.http, port, &prompt, max_tokens.unwrap_or(32)).await
+    // Local inference can take 3-30s depending on token count and hardware.
+    // The shared state.http has a 3s timeout (fine for health polls) which
+    // is too short here — build a dedicated client with a generous limit.
+    let long_client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
+        .build()
+        .map_err(map_err)?;
+    rpc_client::run_inference(&long_client, port, &prompt, max_tokens.unwrap_or(32)).await
 }
 
 /// Milestone A (#35): observer / no-model nodes route inference through a
@@ -685,10 +692,12 @@ pub async fn ensure_binary(app: AppHandle) -> CmdResult<BinaryStatus> {
                 });
             }
             Some(v) => {
+                let relation = if semver_gt(&v, EXPECTED_NODE_VERSION) { "newer" } else { "older" };
                 tracing::info!(
-                    "arc-node {} at {} is older than desktop's expected {} - upgrading",
+                    "arc-node {} at {} is {} than desktop's expected {} - replacing with matched version",
                     v,
                     target.display(),
+                    relation,
                     EXPECTED_NODE_VERSION
                 );
             }
@@ -774,6 +783,22 @@ pub async fn ensure_binary(app: AppHandle) -> CmdResult<BinaryStatus> {
 
 /// Run `arc-node --version` and return the version token (e.g. "0.5.7").
 /// Returns None if the binary fails to launch (corrupt, wrong arch, missing
+/// Returns true if semver string `a` is strictly greater than `b`.
+/// Compares major.minor.patch numerically. Falls back to false on parse error.
+fn semver_gt(a: &str, b: &str) -> bool {
+    let parse = |s: &str| -> Option<(u64, u64, u64)> {
+        let mut parts = s.trim().splitn(3, '.');
+        let maj = parts.next()?.parse().ok()?;
+        let min = parts.next()?.parse().ok()?;
+        let pat = parts.next().and_then(|p| p.split('-').next()).and_then(|p| p.parse().ok()).unwrap_or(0);
+        Some((maj, min, pat))
+    };
+    match (parse(a), parse(b)) {
+        (Some(av), Some(bv)) => av > bv,
+        _ => false,
+    }
+}
+
 /// shared lib) or prints something we can't parse - in either case the caller
 /// should redownload to recover.
 fn read_arc_node_version(binary: &std::path::Path) -> Option<String> {

--- a/desktop/src-tauri/src/rpc_client.rs
+++ b/desktop/src-tauri/src/rpc_client.rs
@@ -18,6 +18,7 @@ use crate::types::{
     InferenceResult, NetworkStats, NodeStatus,
 };
 use serde_json::Value;
+use tracing::{debug, info, warn};
 
 const REWARD_PER_ATTESTATION: f64 = 2.5; // ARC; matches testnet flat rate
 
@@ -482,16 +483,24 @@ pub async fn run_inference(
     } else {
         format!("[INST] {} [/INST]", prompt)
     };
+    info!("[inference/run] → POST {}/inference/run  prompt={:?}  max_tokens={}", base, &wrapped[..wrapped.len().min(80)], max_tokens);
     let resp = http
         .post(format!("{}/inference/run", base))
         .json(&serde_json::json!({ "input": wrapped, "max_tokens": max_tokens }))
         .send()
         .await
-        .map_err(|e| e.to_string())?;
-    if !resp.status().is_success() {
-        return Err(format!("HTTP {}", resp.status()));
+        .map_err(|e| {
+            warn!("[inference/run] ✗ request failed: {}", e);
+            e.to_string()
+        })?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        warn!("[inference/run] ✗ HTTP {} — body: {}", status, body);
+        return Err(format!("HTTP {}: {}", status, body));
     }
     let v: Value = resp.json().await.map_err(|e| e.to_string())?;
+    debug!("[inference/run] ✓ response: {}", serde_json::to_string(&v).unwrap_or_default());
     let inf = v.get("inference").cloned().unwrap_or(Value::Null);
     let att = v.get("attestation").cloned().unwrap_or(Value::Null);
     Ok(InferenceResult {
@@ -565,6 +574,8 @@ pub async fn run_inference_consensus(
     } else {
         format!("[INST] {} [/INST]", prompt)
     };
+    info!("[inference/consensus] → POST {}/inference/run_consensus  k={}  max_tokens={}  prompt={:?}",
+        coord_base, k, max_tokens, &wrapped[..wrapped.len().min(80)]);
     let resp = http
         .post(format!("{}/inference/run_consensus", coord_base.trim_end_matches('/')))
         .json(&serde_json::json!({
@@ -574,11 +585,19 @@ pub async fn run_inference_consensus(
         }))
         .send()
         .await
-        .map_err(|e| format!("{}: {}", coord_base, e))?;
-    if !resp.status().is_success() {
-        return Err(format!("HTTP {} from {}", resp.status(), coord_base));
+        .map_err(|e| {
+            warn!("[inference/consensus] ✗ coordinator {} unreachable: {}", coord_base, e);
+            format!("{}: {}", coord_base, e)
+        })?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        warn!("[inference/consensus] ✗ HTTP {} from {} — body: {}", status, coord_base, body);
+        return Err(format!("HTTP {} from {}: {}", status, coord_base, body));
     }
+    info!("[inference/consensus] ✓ got response from {}", coord_base);
     let v: Value = resp.json().await.map_err(|e| e.to_string())?;
+    debug!("[inference/consensus] full response: {}", serde_json::to_string(&v).unwrap_or_default());
 
     let c = v.get("consensus").cloned().unwrap_or(Value::Null);
     let consensus = InferenceConsensus {

--- a/desktop/src/screens/Dashboard.tsx
+++ b/desktop/src/screens/Dashboard.tsx
@@ -4,6 +4,7 @@ import {
   CircleStop,
   ClipboardCheck,
   FileSignature,
+  Loader2,
   Play,
   RotateCw,
   Sparkles,
@@ -13,7 +14,7 @@ import {
   WifiOff,
   Zap,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Card, CardHeader } from "../components/Card";
 import { CrashBanner } from "../components/CrashBanner";
 import { EmptyState } from "../components/EmptyState";
@@ -122,6 +123,28 @@ export function Dashboard() {
     !!status?.lastError && status.lastError.includes("exited unexpectedly");
   const [addressCopied, setAddressCopied] = useState(false);
 
+  const [syncElapsed, setSyncElapsed] = useState(0);
+  const syncTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    const isSyncing = !!(status?.running && status?.health === "syncing");
+    if (isSyncing && !syncTimerRef.current) {
+      setSyncElapsed(0);
+      syncTimerRef.current = setInterval(() => setSyncElapsed((s) => s + 1), 1000);
+    } else if (!isSyncing && syncTimerRef.current) {
+      clearInterval(syncTimerRef.current);
+      syncTimerRef.current = null;
+      setSyncElapsed(0);
+    }
+  }, [status?.running, status?.health]);
+
+  useEffect(
+    () => () => {
+      if (syncTimerRef.current) clearInterval(syncTimerRef.current);
+    },
+    [],
+  );
+
   return (
     <div className="main-inner" data-testid="dashboard">
       <div className="page-header">
@@ -181,6 +204,42 @@ export function Dashboard() {
 
       {isCrashed && status?.lastError && (
         <CrashBanner message={status.lastError} />
+      )}
+
+      {status?.running && status?.health === "syncing" && (
+        <div
+          className="syncing-banner"
+          role="status"
+          data-testid="syncing-banner"
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--space-2)",
+              marginBottom: "var(--space-1)",
+            }}
+          >
+            <Loader2 size={13} className="spin" />
+            <strong>Connecting to network</strong>
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "var(--text-xs)",
+                opacity: 0.7,
+              }}
+            >
+              {syncElapsed}s
+            </span>
+          </div>
+          {syncElapsed < 10
+            ? "Handshaking with seed nodes…"
+            : syncElapsed < 25
+              ? "Waiting for QUIC peers to respond…"
+              : syncElapsed < 45
+                ? "Still connecting — trying all 6 data centers…"
+                : "Taking longer than usual. If this persists, try resetting peer state below."}
+        </div>
       )}
 
       {status?.health === "lite" && status?.coordinatorUrl && (

--- a/desktop/src/screens/Onboarding.tsx
+++ b/desktop/src/screens/Onboarding.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   ArrowRight,
   Check,
+  CheckCircle2,
   Copy,
   Cpu,
   HardDrive,
@@ -56,6 +57,11 @@ export function Onboarding() {
   const [modelProgress, setModelProgress] =
     useState<ModelDownloadProgress | null>(null);
   const [launchError, setLaunchError] = useState<string | null>(null);
+
+  // Connecting stage: elapsed time + which seed was reached
+  const [connectElapsed, setConnectElapsed] = useState(0);
+  const [connectedVia, setConnectedVia] = useState<string | null>(null);
+  const connectTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const setOnboarded = useAppStore((s) => s.setOnboarded);
   const setStoreIdentity = useAppStore((s) => s.setIdentity);
@@ -166,8 +172,21 @@ export function Onboarding() {
       setLaunchStage("starting");
       await api.startNode(config);
       setLaunchStage("connecting");
-      const joined = await waitForPeer({ timeoutMs: 90_000 });
-      if (joined) {
+      setConnectElapsed(0);
+      setConnectedVia(null);
+      connectTimerRef.current = setInterval(
+        () => setConnectElapsed((s) => s + 1),
+        1000,
+      );
+      const joinResult = await waitForPeer({ timeoutMs: 90_000 });
+      if (connectTimerRef.current) {
+        clearInterval(connectTimerRef.current);
+        connectTimerRef.current = null;
+      }
+      if (joinResult) {
+        setConnectedVia(joinResult.via ?? null);
+      }
+      if (joinResult) {
         setLaunchStage("claiming");
         try {
           await api.faucetClaim();
@@ -177,6 +196,10 @@ export function Onboarding() {
       }
       setOnboarded(true);
     } catch (err) {
+      if (connectTimerRef.current) {
+        clearInterval(connectTimerRef.current);
+        connectTimerRef.current = null;
+      }
       setLaunchError(
         err instanceof Error
           ? err.message
@@ -663,10 +686,7 @@ export function Onboarding() {
                         boxShadow: "var(--shadow-glow-strong)",
                       }}
                     >
-                      <Loader2
-                        size={26}
-                        style={{ animation: "spin 1s linear infinite" }}
-                      />
+                      <Loader2 size={26} className="spin" />
                     </div>
                   ) : (
                     <LogoMark size={64} radius={18} variant="gradient" />
@@ -714,9 +734,12 @@ export function Onboarding() {
                   {launching &&
                     launchStage === "starting" &&
                     "Launching your local node."}
-                  {launching &&
-                    launchStage === "connecting" &&
-                    "Waiting for peers - usually takes a few seconds."}
+                  {launching && launchStage === "connecting" && (
+                    <ConnectingStatus
+                      elapsed={connectElapsed}
+                      connectedVia={connectedVia}
+                    />
+                  )}
                   {launching &&
                     launchStage === "claiming" &&
                     "Asking the testnet faucet for your starter balance."}
@@ -796,10 +819,103 @@ export function Onboarding() {
         </AnimatePresence>
       </div>
 
-      <style>{`
-        @keyframes spin { to { transform: rotate(360deg); } }
-      `}</style>
     </div>
+  );
+}
+
+const SEEDS = [
+  { label: "NYC", ip: "149.28.32.76" },
+  { label: "LAX", ip: "140.82.16.112" },
+  { label: "AMS", ip: "136.244.109.1" },
+  { label: "LHR", ip: "104.238.171.11" },
+  { label: "NRT", ip: "202.182.107.41" },
+  { label: "SGP", ip: "149.28.153.31" },
+];
+
+function connectingPhaseMessage(elapsed: number): string {
+  if (elapsed < 10) return "Handshaking with seed nodes…";
+  if (elapsed < 25) return "Waiting for QUIC peers to respond…";
+  if (elapsed < 45) return "Still connecting — trying all 6 data centers…";
+  return "Taking longer than usual. Falling back to coordinator mode…";
+}
+
+function ConnectingStatus({
+  elapsed,
+  connectedVia,
+}: {
+  elapsed: number;
+  connectedVia: string | null;
+}) {
+  const activeSeedIdx = Math.floor(elapsed / 3) % SEEDS.length;
+
+  if (connectedVia) {
+    const label =
+      SEEDS.find((s) => connectedVia.includes(s.ip))?.label ?? connectedVia;
+    return (
+      <span style={{ color: "var(--success)" }}>
+        Connected via {label} coordinator ✓
+      </span>
+    );
+  }
+
+  return (
+    <span>
+      <span style={{ display: "block", marginBottom: "var(--space-3)" }}>
+        {connectingPhaseMessage(elapsed)}
+        <span
+          style={{
+            marginLeft: "var(--space-2)",
+            fontFamily: "var(--font-mono)",
+            color: "var(--text-muted)",
+          }}
+        >
+          {elapsed}s
+        </span>
+      </span>
+
+      {/* Seed node status row */}
+      <span
+        style={{
+          display: "flex",
+          gap: "var(--space-2)",
+          justifyContent: "center",
+          flexWrap: "wrap",
+        }}
+      >
+        {SEEDS.map((seed, i) => {
+          const isActive = i === activeSeedIdx && elapsed > 0;
+          const isPast = elapsed > (i + 1) * 3;
+          return (
+            <span
+              key={seed.label}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+                padding: "2px 8px",
+                borderRadius: 999,
+                fontSize: "var(--text-xs)",
+                fontFamily: "var(--font-mono)",
+                border: `1px solid ${isActive ? "var(--indigo-400)" : "var(--border)"}`,
+                background: isActive
+                  ? "rgba(99,102,241,0.12)"
+                  : "var(--surface)",
+                color: isActive
+                  ? "var(--indigo-300)"
+                  : isPast
+                    ? "var(--text-muted)"
+                    : "var(--text-faint)",
+                transition: "all 0.3s ease",
+              }}
+            >
+              {isActive && <Loader2 size={9} className="spin" />}
+              {isPast && !isActive && <CheckCircle2 size={9} />}
+              {seed.label}
+            </span>
+          );
+        })}
+      </span>
+    </span>
   );
 }
 
@@ -809,17 +925,17 @@ async function waitForPeer({
   timeoutMs,
 }: {
   timeoutMs: number;
-}): Promise<boolean> {
+}): Promise<{ via?: string } | null> {
   const started = Date.now();
   while (Date.now() - started < timeoutMs) {
     try {
       const s = await api.nodeStatus();
-      if (s.running && s.peers >= 1) return true;
-      if (s.coordinatorUrl) return true;
+      if (s.running && s.peers >= 1) return { via: "p2p" };
+      if (s.coordinatorUrl) return { via: s.coordinatorUrl };
     } catch {
       /* retry */
     }
     await new Promise((r) => setTimeout(r, 2000));
   }
-  return false;
+  return null;
 }

--- a/desktop/src/styles/app.css
+++ b/desktop/src/styles/app.css
@@ -651,6 +651,19 @@
   color: var(--info);
   margin-right: var(--space-2);
 }
+.syncing-banner {
+  background: var(--warning-bg);
+  color: var(--warning);
+  border: 1px solid color-mix(in srgb, var(--warning) 35%, transparent);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-6);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+.syncing-banner strong {
+  color: var(--warning);
+}
 
 /* - Big number - */
 .big-number {
@@ -1251,3 +1264,6 @@
   font-size: var(--text-lg);
   font-weight: var(--weight-semibold);
 }
+
+@keyframes spin { to { transform: rotate(360deg); } }
+.spin { animation: spin 1s linear infinite; }


### PR DESCRIPTION
## Summary
Three production bugs found while running the desktop app against live testnet, plus UX improvements for the long P2P join phase.

## Changes
- **Inference timeout (the UI killer)** — `commands.rs::run_inference` used the shared `state.http` client (3s timeout, fine for `/health` polls). Local inference takes 4-5s+, so every UI request silently timed out. Built its own 120s client now, matching the pattern already used by `run_inference_via_coordinator`.
- **Pipeline gap false 503** — `rpc.rs` validation walked the full shard registry even after the pipeline was complete, tripping on stale entries for layers already covered (`expected layer 32 next, got [28, 30)`). Added early `break` when `covered >= n_layers` in both `run_inference_sharded` and `run_consensus`.
- **Version-check log was backwards** — `arc-node 0.7.1 ... older than expected 0.7.0` always said "older". Added `semver_gt()` and proper newer/older labeling.
- **Inference logging** — `rpc_client.rs` now logs every attempt (URL, prompt preview, HTTP status, body on failure) so the above bugs are diagnosable from the terminal.
- **Connecting UX** — Onboarding "Joining the network" stage now shows elapsed time + animated seed-node pills (NYC/LAX/AMS/LHR/NRT/SGP) + phase-based messages so users on residential ISPs (30-90s P2P join) know the app isn't frozen. Dashboard adds a yellow "Connecting to network" banner during `health === "syncing"`.

## Testing
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy` clean
- [ ] Verified locally: inference returns in ~4s (was timing out at 3s)
- [ ] Verified locally: connecting banner shows during P2P join
- [ ] Direct API test confirms attestation posts on-chain: tx `0xcca18a69...`

## Deploy note
The `rpc.rs` pipeline gap fix only takes effect on the seed coordinators after a new `arc-node` release is cut and the 6 seeds auto-update. Currently every coordinator returns 503 on `/inference/run_consensus` due to this bug — desktop's local-first fallback masks it for users with peers, but observer-mode users see the 503 directly.