### PR TITLE
v0.7.4: working Tauri auto-update + relaunch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 license = "BUSL-1.1"
 authors = ["FerrumVir"]

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ ARC makes inference **verifiable by a blockchain the same way transactions are v
 
 | Your computer | One-click download |
 |---|---|
-| 🍎 **Mac (Apple Silicon - M1/M2/M3/M4)** | **[Download for Apple Silicon Mac](https://github.com/FerrumVir/arc-chain/releases/download/v0.7.3/ARC.Node_0.7.3_aarch64.dmg)** |
-| 🍎 **Mac (Intel)** | **[Download for Intel Mac](https://github.com/FerrumVir/arc-chain/releases/download/v0.7.3/ARC.Node_0.7.3_x64.dmg)** |
-| 🪟 **Windows 10 / 11** | **[Download for Windows](https://github.com/FerrumVir/arc-chain/releases/download/v0.7.3/ARC.Node_0.7.3_x64-setup.exe)** |
-| 🐧 **Linux (Ubuntu / Debian)** | **[Download .deb](https://github.com/FerrumVir/arc-chain/releases/download/v0.7.3/ARC.Node_0.7.3_amd64.deb)** |
-| 🐧 **Linux (Fedora / RHEL)** | **[Download .rpm](https://github.com/FerrumVir/arc-chain/releases/download/v0.7.3/ARC.Node-0.7.3-1.x86_64.rpm)** |
-| 🐧 **Linux (any distro)** | **[Download .AppImage](https://github.com/FerrumVir/arc-chain/releases/download/v0.7.3/ARC.Node_0.7.3_amd64.AppImage)** |
+| 🍎 **Mac (Apple Silicon - M1/M2/M3/M4)** | **[Download for Apple Silicon Mac](https://github.com/FerrumVir/arc-chain/releases/download/v0.7.4/ARC.Node_0.7.4_aarch64.dmg)** |
+| 🍎 **Mac (Intel)** | **[Download for Intel Mac](https://github.com/FerrumVir/arc-chain/releases/download/v0.7.4/ARC.Node_0.7.4_x64.dmg)** |
+| 🪟 **Windows 10 / 11** | **[Download for Windows](https://github.com/FerrumVir/arc-chain/releases/download/v0.7.4/ARC.Node_0.7.4_x64-setup.exe)** |
+| 🐧 **Linux (Ubuntu / Debian)** | **[Download .deb](https://github.com/FerrumVir/arc-chain/releases/download/v0.7.4/ARC.Node_0.7.4_amd64.deb)** |
+| 🐧 **Linux (Fedora / RHEL)** | **[Download .rpm](https://github.com/FerrumVir/arc-chain/releases/download/v0.7.4/ARC.Node-0.7.4-1.x86_64.rpm)** |
+| 🐧 **Linux (any distro)** | **[Download .AppImage](https://github.com/FerrumVir/arc-chain/releases/download/v0.7.4/ARC.Node_0.7.4_amd64.AppImage)** |
 
 > **Not sure which Mac?** Apple menu → *About This Mac*. If chip says "Apple M1/M2/M3/M4" → Apple Silicon. If "Intel" → Intel.
 
@@ -59,9 +59,9 @@ ARC makes inference **verifiable by a blockchain the same way transactions are v
 
 - **Mac**: open the `.dmg` → drag ARC Node to Applications → first launch right-click → Open
 - **Windows**: run the `.exe` → "More info" → "Run anyway" → Next → Install → Finish
-- **Linux**: `sudo apt install ./ARC.Node_0.7.3_amd64.deb` (or `rpm -i`, or `chmod +x` the AppImage)
+- **Linux**: `sudo apt install ./ARC.Node_0.7.4_amd64.deb` (or `rpm -i`, or `chmod +x` the AppImage)
 
-The app onboards in 3 clicks (welcome → identity → join), runs in your tray, auto-starts on login, auto-updates when v0.7.3+ ships.
+The app onboards in 3 clicks (welcome → identity → join), runs in your tray, auto-starts on login, auto-updates when v0.7.4+ ships.
 
 **📖 Full walkthrough:** [Getting Started with ARC Node](docs/GETTING_STARTED.md) - install, identity, first inference, faucet, earnings, and FAQ.
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@tanstack/react-query": "^5.59.0",
         "@tauri-apps/api": "^2.1.1",
+        "@tauri-apps/plugin-process": "^2.0.0",
         "@tauri-apps/plugin-shell": "^2.0.1",
+        "@tauri-apps/plugin-updater": "^2.0.0",
         "clsx": "^2.1.1",
         "framer-motion": "^11.11.0",
         "lucide-react": "^0.460.0",
@@ -867,9 +869,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -884,9 +883,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -901,9 +897,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -918,9 +911,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -935,9 +925,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -952,9 +939,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -969,9 +953,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -986,9 +967,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1003,9 +981,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1020,9 +995,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1037,9 +1009,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1054,9 +1023,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1071,9 +1037,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1289,9 +1252,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1309,9 +1269,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1329,9 +1286,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1349,9 +1303,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1369,9 +1320,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1432,10 +1380,28 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
     "node_modules/@tauri-apps/plugin-shell": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
       "integrity": "sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -17,7 +17,9 @@
   "dependencies": {
     "@tanstack/react-query": "^5.59.0",
     "@tauri-apps/api": "^2.1.1",
+    "@tauri-apps/plugin-process": "^2.0.0",
     "@tauri-apps/plugin-shell": "^2.0.1",
+    "@tauri-apps/plugin-updater": "^2.0.0",
     "clsx": "^2.1.1",
     "framer-motion": "^11.11.0",
     "lucide-react": "^0.460.0",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arc-desktop"
-version = "0.7.3"
+version = "0.7.4"
 description = "ARC Node - desktop app"
 authors = ["FerrumVir"]
 edition = "2021"

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "dialog:default",
     "opener:default",
     "updater:default",
+    "process:default",
     "autostart:default",
     {
       "identifier": "shell:allow-open",

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -58,6 +58,11 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        // Needed so the frontend can call `relaunch()` from
+        // `@tauri-apps/plugin-process` after `update.downloadAndInstall()`
+        // finishes. Without this, the new installer runs but the app stays
+        // dead until the user manually relaunches.
+        .plugin(tauri_plugin_process::init())
         // Auto-launch on OS login. LaunchAgent = macOS launchd user-scoped
         // LoginItem, Linux XDG autostart, Windows Run key. `--minimized`
         // tells the app to start with the window hidden to the tray so

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ARC Node",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "identifier": "network.arc.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src/screens/Settings.tsx
+++ b/desktop/src/screens/Settings.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { AlertTriangle, Check, RefreshCw, Trash2 } from "lucide-react";
 import { useState } from "react";
+import { check as tauriCheckUpdate } from "@tauri-apps/plugin-updater";
+import { relaunch as tauriRelaunch } from "@tauri-apps/plugin-process";
 import { Card, CardHeader } from "../components/Card";
 import { StatusPill } from "../components/StatusPill";
 import { api } from "../lib/tauri";
@@ -22,6 +24,32 @@ export function Settings() {
     queryFn: api.checkForUpdate,
     enabled: false,
   });
+  const [installing, setInstalling] = useState(false);
+  const [installError, setInstallError] = useState<string | null>(null);
+
+  // Tauri auto-update: download the new bundle then relaunch the app.
+  // Without the relaunch() call the installer overwrites the .app/.exe but
+  // the existing process exits without reopening — user sees "auto-update
+  // ran but the window never came back". The Rust-side updater plugin is
+  // already registered in lib.rs; this is the missing JS-side trigger.
+  const installUpdate = async () => {
+    setInstalling(true);
+    setInstallError(null);
+    try {
+      const u = await tauriCheckUpdate();
+      if (!u) {
+        setInstallError("No update available.");
+        setInstalling(false);
+        return;
+      }
+      await u.downloadAndInstall();
+      await tauriRelaunch();
+      // relaunch() never returns — process is replaced.
+    } catch (e) {
+      setInstallError(e instanceof Error ? e.message : String(e));
+      setInstalling(false);
+    }
+  };
 
   const save = async () => {
     if (!config) return;
@@ -155,21 +183,45 @@ export function Settings() {
           }}
         >
           {update?.hasUpdate
-            ? `A new version is available. Your node will upgrade on next restart.`
+            ? `Version ${update.version} is available. Click below to download, install, and relaunch.`
             : "You're running the latest version."}
         </p>
-        <button
-          className="btn btn-secondary"
-          onClick={() => checkUpdate()}
-          disabled={isFetching}
-          data-testid="btn-check-update"
-        >
-          <RefreshCw
-            size={14}
-            style={isFetching ? { animation: "spin 1s linear infinite" } : {}}
-          />{" "}
-          Check for updates
-        </button>
+        {installError && (
+          <p
+            style={{
+              fontSize: "var(--text-sm)",
+              color: "var(--danger)",
+              marginBottom: "var(--space-3)",
+            }}
+            data-testid="update-error"
+          >
+            Update failed: {installError}
+          </p>
+        )}
+        <div style={{ display: "flex", gap: "var(--space-2)" }}>
+          <button
+            className="btn btn-secondary"
+            onClick={() => checkUpdate()}
+            disabled={isFetching || installing}
+            data-testid="btn-check-update"
+          >
+            <RefreshCw
+              size={14}
+              style={isFetching ? { animation: "spin 1s linear infinite" } : {}}
+            />{" "}
+            Check for updates
+          </button>
+          {update?.hasUpdate && (
+            <button
+              className="btn btn-primary"
+              onClick={installUpdate}
+              disabled={installing}
+              data-testid="btn-install-update"
+            >
+              {installing ? "Installing…" : `Install v${update.version} & relaunch`}
+            </button>
+          )}
+        </div>
       </Card>
 
       <Card>


### PR DESCRIPTION
## Summary

Two changes:

1. **Wire the Tauri auto-update plugin end-to-end** (cherry-picked from the v0.7.3 branch — this commit missed the merge window on #43). The updater plugin was already registered in \`lib.rs\` but never invoked from JS, so the existing "Check for updates" button just queried the GitHub API and showed a message. Users saw the arc-node CLI binary update (via \`ensure_binary()\`) but the desktop UI stayed on the old version — exactly the "auto-update ran but the window never came back" symptom.

2. **Bump workspace + desktop + tauri.conf from 0.7.3 → 0.7.4** so the release ships.

## What changed

- \`desktop/package.json\` — add \`@tauri-apps/plugin-updater\` + \`@tauri-apps/plugin-process\`
- \`desktop/src-tauri/Cargo.toml\` — add \`tauri-plugin-process = "2"\`
- \`desktop/src-tauri/src/lib.rs\` — register \`tauri_plugin_process\` so \`relaunch()\` works from JS
- \`desktop/src-tauri/capabilities/default.json\` — grant \`process:default\` permission
- \`desktop/src/screens/Settings.tsx\` — replace placeholder "Check" button with check + downloadAndInstall + relaunch, surfaced as "Install vX.Y.Z & relaunch" when an update is available; inline error surface

## Caveat — one-time manual install for existing v0.7.3 users

v0.7.3 shipped without the working updater, so existing v0.7.3 users won't auto-update to v0.7.4. They need to install v0.7.4 manually one last time (download from the README links after this merges + tags). From v0.7.4 onward, real auto-update works.

## Test plan

- [x] \`cargo check\` passes (desktop + workspace)
- [x] \`npm install\` resolves both new plugins
- [x] tsc --noEmit passes
- [ ] After merge + tag: confirm \`release-desktop.yml\` publishes \`v0.7.4\` assets + \`latest.json\`
- [ ] Install v0.7.4 manually on a Mac, then tag v0.7.5 (or any later version) and confirm in-app "Install & relaunch" actually reopens the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)