### PR TITLE
fix(tier1): propagate escrow storage + tier1_pending in StateDiff (multi-validator 'no such request')

### DIFF
--- a/crates/arc-node/src/consensus.rs
+++ b/crates/arc-node/src/consensus.rs
@@ -962,6 +962,7 @@ impl ConsensusManager {
                     // Verifier: apply received state diff + verify root.
                     if multi_validator {
                         let mut committed_txs: Vec<Transaction> = Vec::new();
+                        let mut unresolved_committed = 0usize;
                         for tx_hash in &dag_block.transactions {
                             if let Some((_, tx)) = pending_txs.remove(&tx_hash.0) {
                                 // Skip transactions already applied via direct RPC path
@@ -970,7 +971,36 @@ impl ConsensusManager {
                                     continue;
                                 }
                                 committed_txs.push(tx);
+                            } else if !state.receipts.contains_key(&tx_hash.0) {
+                                // The committed DAG block references a tx hash this
+                                // node never stored (not proposed locally, not
+                                // received via DagBlockWithTxs) and that was not
+                                // already applied out-of-band. Silently skipping it
+                                // means this node executes a *different* tx set than
+                                // the leader - for Tier 1 this is the on-chain
+                                // "no such request" symptom, and more broadly it is a
+                                // state-divergence hazard. Surface it loudly so the
+                                // gap is observable in production.
+                                unresolved_committed += 1;
+                                warn!(
+                                    round = dag_block.round,
+                                    block = %dag_block.hash,
+                                    tx = %hex::encode(&tx_hash.0[..8]),
+                                    "Committed tx unresolved in pending_txs - dropped \
+                                     (possible state divergence / 'no such request')"
+                                );
                             }
+                        }
+                        if unresolved_committed > 0 {
+                            warn!(
+                                round = dag_block.round,
+                                dropped = unresolved_committed,
+                                total = dag_block.transactions.len(),
+                                "Dropped {} of {} committed txs that were not locally \
+                                 available",
+                                unresolved_committed,
+                                dag_block.transactions.len()
+                            );
                         }
                         if !committed_txs.is_empty() {
                             // ── Pipeline stage overlap: pre-verify signatures ──

--- a/crates/arc-state/src/lib.rs
+++ b/crates/arc-state/src/lib.rs
@@ -6021,7 +6021,7 @@ impl StateDB {
     /// accounts that changed and the new state root.  Verifiers receive this
     /// diff and call `apply_state_diff()` to cheaply confirm correctness.
     pub fn export_state_diff(&self, dirty_keys: &[Address]) -> arc_types::StateDiff {
-        use arc_types::{AccountChange, StateDiff};
+        use arc_types::{AccountChange, StateDiff, StorageChange};
 
         let changes: Vec<AccountChange> = dirty_keys
             .iter()
@@ -6033,9 +6033,49 @@ impl StateDB {
             })
             .collect();
 
+        // Export storage entries for every changed address. State that lives
+        // outside the `Account` record (contract storage, Tier 1 inference
+        // escrow blobs / votes / requester) is invisible to a verifier unless
+        // it travels in the diff.
+        let storage_changes: Vec<StorageChange> = dirty_keys
+            .iter()
+            .filter_map(|addr| {
+                self.storage.get(&addr.0).and_then(|map| {
+                    let entries: Vec<(Hash256, Vec<u8>)> =
+                        map.iter().map(|e| (*e.key(), e.value().clone())).collect();
+                    if entries.is_empty() {
+                        None
+                    } else {
+                        Some(StorageChange { address: *addr, entries })
+                    }
+                })
+            })
+            .collect();
+
+        // Carry the Tier 1 pending-inference index entries whose escrow account
+        // is part of this diff, so verifiers can also serve / vote on the
+        // request. Scoped to this block's escrows to keep the diff small.
+        let changed: std::collections::HashSet<[u8; 32]> =
+            dirty_keys.iter().map(|a| a.0).collect();
+        let tier1_pending: Vec<(Hash256, u64)> = self
+            .tier1_pending
+            .iter()
+            .filter_map(|e| {
+                let request_id = *e.key();
+                let escrow = hash_bytes(
+                    &[b"arc-infreq".as_ref(), request_id.as_ref()].concat(),
+                );
+                if changed.contains(&escrow.0) {
+                    Some((Hash256(request_id), *e.value()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         let new_root = self.compute_state_root();
 
-        StateDiff { changes, new_root }
+        StateDiff { changes, new_root, storage_changes, tier1_pending }
     }
 
     /// Apply a state diff from a proposer and return the resulting state root.
@@ -6047,6 +6087,19 @@ impl StateDB {
         for change in &diff.changes {
             self.accounts.insert(change.address.0, change.account.clone());
             self.dirty_accounts.insert(change.address.0);
+        }
+        // Restore contract / escrow storage so state outside the `Account`
+        // record (e.g. Tier 1 inference escrow blobs, votes, requester) is
+        // reconstructed on the verifier exactly as on the proposer.
+        for sc in &diff.storage_changes {
+            let entry = self.storage.entry(sc.address.0).or_default();
+            for (key, value) in &sc.entries {
+                entry.insert(*key, value.clone());
+            }
+        }
+        // Restore the Tier 1 pending-inference index.
+        for (request_id, anchor_height) in &diff.tier1_pending {
+            self.tier1_pending.insert(request_id.0, *anchor_height);
         }
         self.compute_state_root()
     }
@@ -6897,6 +6950,67 @@ mod tests {
 
         // Verifier applies diff
         assert!(verifier_db.verify_state_diff(&diff));
+    }
+
+    /// Regression for the Tier 1 multi-validator "no such request" bug.
+    ///
+    /// In propose/verify mode a verifier reconstructs state from the
+    /// proposer's `StateDiff` *without re-executing the block*. An
+    /// `InferenceRequest` writes per-escrow storage (`tier1.input_blob`,
+    /// `tier1.votes`, `tier1.requester`) and a `tier1_pending` index entry.
+    /// If the diff only carries `Account` records, every verifier loses that
+    /// data and `tier1_request_snapshot` returns an empty / missing request,
+    /// surfacing as "no such request" on the RPC. The diff MUST round-trip
+    /// the escrow storage and the pending index.
+    #[test]
+    fn test_state_diff_round_trips_tier1_inference() {
+        let requester = addr(1);
+        let proposer = StateDB::with_genesis(&[(requester, 1_000_000)]);
+
+        let request_id = [7u8; 32];
+        let tx = build_tier1_request(requester, 0, request_id, 100, 1, 20);
+        proposer.execute_block(&[tx], addr(99)).unwrap();
+
+        // Proposer sees the full request (sanity).
+        let snap_p = proposer
+            .tier1_request_snapshot(&request_id)
+            .expect("proposer created the request");
+        assert!(!snap_p.input_blob.is_empty(), "proposer stored input_blob");
+        assert!(
+            proposer.tier1_pending.contains_key(&request_id),
+            "proposer indexed tier1_pending"
+        );
+
+        // Export the diff the way the consensus loop does, guaranteeing the
+        // escrow account itself is included.
+        let escrow_addr =
+            hash_bytes(&[b"arc-infreq".as_ref(), request_id.as_ref()].concat());
+        let mut affected = proposer.drain_dirty_addresses();
+        if !affected.iter().any(|a| a.0 == escrow_addr.0) {
+            affected.push(escrow_addr);
+        }
+        let diff = proposer.export_state_diff(&affected);
+
+        // Verifier applies the diff WITHOUT executing the tx.
+        let verifier = StateDB::with_genesis(&[(requester, 1_000_000)]);
+        verifier.apply_state_diff(&diff);
+
+        // The verifier must reconstruct the request exactly.
+        let snap_v = verifier
+            .tier1_request_snapshot(&request_id)
+            .expect("verifier must see the request after applying the diff");
+        assert_eq!(
+            snap_v.input_blob, snap_p.input_blob,
+            "verifier lost tier1 escrow storage (input_blob) via the StateDiff"
+        );
+        assert_eq!(
+            snap_v.committee_size, snap_p.committee_size,
+            "verifier lost committee_size"
+        );
+        assert!(
+            verifier.tier1_pending.contains_key(&request_id),
+            "verifier lost the tier1_pending index via the StateDiff"
+        );
     }
 
     #[test]

--- a/crates/arc-types/src/block.rs
+++ b/crates/arc-types/src/block.rs
@@ -91,6 +91,19 @@ pub struct StateDiff {
     pub changes: Vec<AccountChange>,
     /// The expected state root after applying all changes.
     pub new_root: Hash256,
+    /// Per-address contract/escrow storage entries that changed during the
+    /// block. Required so verifiers reconstruct state that lives *outside* the
+    /// `Account` record - e.g. Tier 1 inference escrows store the prompt blob,
+    /// the vote list and the requester address under storage keys. Without
+    /// these a verifier's `tier1_request_snapshot` comes back empty and the
+    /// request surfaces as "no such request".
+    #[serde(default)]
+    pub storage_changes: Vec<StorageChange>,
+    /// Tier 1 pending-inference index entries (`request_id -> anchor_height`)
+    /// created in this block. Mirrors `StateDB.tier1_pending` so verifier
+    /// nodes can also serve / vote on the request.
+    #[serde(default)]
+    pub tier1_pending: Vec<(Hash256, u64)>,
 }
 
 /// A single account change within a state diff.
@@ -100,6 +113,15 @@ pub struct AccountChange {
     pub address: Hash256,
     /// The new account state after the block.
     pub account: Account,
+}
+
+/// Storage key/value entries for one address within a state diff.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StorageChange {
+    /// The address (contract / escrow) whose storage changed.
+    pub address: Hash256,
+    /// The storage entries `(key, value)` written under that address.
+    pub entries: Vec<(Hash256, Vec<u8>)>,
 }
 
 // ─── Protocol Versioning & Upgrade Scheduling ────────────────────────────────


### PR DESCRIPTION
## Problem
On the live 5-seed testnet (all on v0.7.7), every on-chain inference submit returns 200 + `request_id` but the result endpoint returns `no such request` forever. The v0.7.6/0.7.7 BlockSTM patch fixed a real but *different* layer; the actual failure is in the **multi-validator propose/verify** path, which single-node setups never exercise (solo + proposer-mode both finalize fine).

## Root cause
In propose/verify mode, verifier nodes reconstruct state from the proposer's `StateDiff` **without re-executing the block**. `StateDiff` only carried `Account` records, so verifiers lost everything that lives outside the account:
- Tier-1 inference escrow **storage** (`tier1.input_blob` / `tier1.votes` / `tier1.requester`)
- the **`tier1_pending`** index

→ `tier1_request_snapshot` comes back empty on those nodes → `no such request`. A pure balance change (faucet) survives because it *is* fully captured by an `AccountChange` (and faucet also writes local state directly in the RPC handler, bypassing consensus — which made it a misleading "consensus is healthy" signal).

Secondary: committed DAG tx hashes that can't be resolved in `pending_txs` were dropped silently (state-divergence hazard).

## Fix
- **arc-types**: `StateDiff` gains `storage_changes: Vec<StorageChange>` + `tier1_pending: Vec<(Hash256,u64)>` (serde-default; additive).
- **arc-state**: `export_state_diff` emits per-address storage + scoped `tier1_pending`; `apply_state_diff` restores both.
- **arc-node/consensus**: `warn!` instead of silently dropping an unresolved committed tx (observability for the secondary bug).

## Verification
- New regression test `test_state_diff_round_trips_tier1_inference` **fails before** (verifier `input_blob` empty), **passes after**.
- Full `arc-state` lib suite: **189 passed, 0 failed**.
- End-to-end multi-validator NOT verified locally (separate known QUIC loopback bug blocks a 2-node cluster). Needs a coordinated rollout + seed smoke test.

## Deploy note (consensus serialization change)
`StateDiff` wire format changes. Roll out to **all seeds**. A mixed fleet degrades safely (a node that can't deserialize a peer's diff drops it and re-executes the block — correct state, just loses the diff optimization), but inference is only reliable once all committee/serving seeds run the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)