### PR TITLE
Harden ARC recovery and release preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,6 +437,49 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Native Windows signer handoff permission boundary
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          python_bin="$(command -v python.exe)"
+          case "$python_bin" in
+            /*) ;;
+            *)
+              echo "::error::Python did not resolve to an absolute Windows executable."
+              exit 1
+              ;;
+          esac
+          [ -f "$python_bin" ] && [ ! -L "$python_bin" ] && [ -x "$python_bin" ]
+          "$python_bin" -I tests/release/test_unsigned_desktop_windows_permissions.py -v
+
+          probe_pid=''
+          cleanup_probe() {
+            if [ -n "$probe_pid" ] && kill -0 "$probe_pid" 2>/dev/null; then
+              MSYS_NO_PATHCONV=1 taskkill.exe \
+                /PID "$probe_pid" /T /F >/dev/null 2>&1 || \
+                kill -KILL "$probe_pid" 2>/dev/null || true
+            fi
+          }
+          trap cleanup_probe EXIT HUP INT TERM
+          "$python_bin" -I -c 'import time; time.sleep(300)' &
+          probe_pid=$!
+          kill -0 "$probe_pid"
+          MSYS_NO_PATHCONV=1 taskkill.exe \
+            /PID "$probe_pid" /T /F >/dev/null
+          for _ in {1..40}; do
+            if ! kill -0 "$probe_pid" 2>/dev/null; then
+              break
+            fi
+            sleep 0.25
+          done
+          if kill -0 "$probe_pid" 2>/dev/null; then
+            echo '::error::Native taskkill did not terminate the Windows probe.' >&2
+            exit 1
+          fi
+          wait "$probe_pid" 2>/dev/null || true
+          probe_pid=''
+          trap - EXIT HUP INT TERM
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,8 +465,12 @@ jobs:
           "$python_bin" -I -c 'import time; time.sleep(300)' &
           probe_pid=$!
           kill -0 "$probe_pid"
+          # Git Bash can expose an MSYS PID for a native child. Exercise the
+          # exact production cleanup chain: prefer native taskkill, then use
+          # the MSYS-aware signal path and a bounded force fallback.
           MSYS_NO_PATHCONV=1 taskkill.exe \
-            /PID "$probe_pid" /T /F >/dev/null
+            /PID "$probe_pid" /T /F >/dev/null 2>&1 || \
+            kill "$probe_pid" 2>/dev/null || true
           for _ in {1..40}; do
             if ! kill -0 "$probe_pid" 2>/dev/null; then
               break
@@ -474,7 +478,16 @@ jobs:
             sleep 0.25
           done
           if kill -0 "$probe_pid" 2>/dev/null; then
-            echo '::error::Native taskkill did not terminate the Windows probe.' >&2
+            kill -KILL "$probe_pid" 2>/dev/null || true
+            for _ in {1..20}; do
+              if ! kill -0 "$probe_pid" 2>/dev/null; then
+                break
+              fi
+              sleep 0.25
+            done
+          fi
+          if kill -0 "$probe_pid" 2>/dev/null; then
+            echo '::error::Native Windows cleanup did not terminate the probe.' >&2
             exit 1
           fi
           wait "$probe_pid" 2>/dev/null || true

--- a/.github/workflows/recovery-release-handoff.yml
+++ b/.github/workflows/recovery-release-handoff.yml
@@ -23,7 +23,7 @@ jobs:
     environment: release
     outputs:
       artifact-id: ${{ steps.upload.outputs.artifact-id }}
-      artifact-digest: ${{ steps.upload.outputs.artifact-digest }}
+      artifact-digest: ${{ format('sha256:{0}', steps.upload.outputs.artifact-digest) }}
       handoff-commit-sha: ${{ steps.select.outputs.handoff_commit_sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -119,13 +119,13 @@ jobs:
         run: |
           set -Eeuo pipefail
           [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]
-          [[ "$ARTIFACT_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "$ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ]]
           artifact="$RUNNER_TEMP/recovery-handoff-artifact.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID" > "$artifact"
           jq -e \
             --argjson id "$ARTIFACT_ID" \
             --arg name "arc-recovery-release-handoff-$GITHUB_SHA" \
-            --arg digest "$ARTIFACT_DIGEST" \
+            --arg digest "sha256:$ARTIFACT_DIGEST" \
             --argjson run_id "$GITHUB_RUN_ID" \
             '.id == $id and .name == $name and .digest == $digest
              and .expired == false and .workflow_run.id == $run_id

--- a/.github/workflows/release-signing-preflight.yml
+++ b/.github/workflows/release-signing-preflight.yml
@@ -200,6 +200,10 @@ jobs:
           restored="$WORK_DIR/restored"
           archive="$WORK_DIR/signing-keys.tar"
           derived_manifest="$WORK_DIR/derived-manifest.pub"
+          expected_manifest="$WORK_DIR/expected-manifest.pub"
+          derived_manifest_canonical="$WORK_DIR/derived-manifest.canonical"
+          restored_manifest_canonical="$WORK_DIR/restored-manifest.canonical"
+          expected_manifest_canonical="$WORK_DIR/expected-manifest.canonical"
           cleanup_plaintext() {
             unset ARC_SIGNING_BACKUP_PASSPHRASE passphrase \
               ARC_EXPECTED_MANIFEST_PUBLIC_KEY
@@ -208,7 +212,11 @@ jobs:
               "$restored/release-manifest-ed25519" \
               "$restored/release-manifest-ed25519.pub" \
               "$restored/tauri-updater.key" \
-              "$archive" "$derived_manifest"; do
+              "$archive" "$derived_manifest" \
+              "$expected_manifest" \
+              "$derived_manifest_canonical" \
+              "$restored_manifest_canonical" \
+              "$expected_manifest_canonical"; do
               if [ -f "$secret_path" ] && [ ! -L "$secret_path" ]; then
                 /usr/bin/shred -u -- "$secret_path" || true
               fi
@@ -250,8 +258,36 @@ jobs:
 
           /usr/bin/ssh-keygen -y -f "$restored/release-manifest-ed25519" \
             > "$derived_manifest"
-          [ "$(/usr/bin/tr -d '\r\n' < "$derived_manifest")" = "$ARC_EXPECTED_MANIFEST_PUBLIC_KEY" ]
-          [ "$(/usr/bin/tr -d '\r\n' < "$restored/release-manifest-ed25519.pub")" = "$ARC_EXPECTED_MANIFEST_PUBLIC_KEY" ]
+          canonicalize_manifest_public_key() {
+            local input_path="$1"
+            local output_path="$2"
+            /usr/bin/awk '
+              BEGIN { valid = 0 }
+              NR != 1 { exit 1 }
+              {
+                if (NF != 2 && NF != 3) exit 1
+                if ($1 != "ssh-ed25519") exit 1
+                if ($2 !~ /^[A-Za-z0-9+\/]+={0,2}$/) exit 1
+                if (NF == 3 && $3 != "arc-release-manifest-v1") exit 1
+                print $1 " " $2
+                valid = 1
+              }
+              END { if (NR != 1 || valid != 1) exit 1 }
+            ' "$input_path" > "$output_path"
+          }
+          canonicalize_manifest_public_key \
+            "$derived_manifest" "$derived_manifest_canonical"
+          canonicalize_manifest_public_key \
+            "$restored/release-manifest-ed25519.pub" \
+            "$restored_manifest_canonical"
+          /usr/bin/printf '%s\n' "$ARC_EXPECTED_MANIFEST_PUBLIC_KEY" \
+            > "$expected_manifest"
+          canonicalize_manifest_public_key \
+            "$expected_manifest" "$expected_manifest_canonical"
+          /usr/bin/cmp -s \
+            "$derived_manifest_canonical" "$expected_manifest_canonical"
+          /usr/bin/cmp -s \
+            "$restored_manifest_canonical" "$expected_manifest_canonical"
 
           manifest_canary="$WORK_DIR/manifest-canary"
           updater_canary="$WORK_DIR/updater-canary"
@@ -507,9 +543,28 @@ jobs:
              and .packages[$native].integrity == $native_integrity' \
             desktop/package-lock.json >/dev/null
           npm ci --prefix desktop --ignore-scripts
-          node_bin="$(command -v node)"
+          case "$RUNNER_OS" in
+            Windows)
+              node_bin="$(command -v node.exe)"
+              ;;
+            Linux|macOS)
+              node_bin="$(command -v node)"
+              ;;
+            *)
+              echo "::error::Unsupported runner OS for the locked Node runtime: $RUNNER_OS"
+              exit 1
+              ;;
+          esac
+          case "$node_bin" in
+            /*) ;;
+            *)
+              echo "::error::The locked Node runtime did not resolve to an absolute executable."
+              exit 1
+              ;;
+          esac
           tauri_cli="$GITHUB_WORKSPACE/desktop/node_modules/@tauri-apps/cli/tauri.js"
-          [ -x "$node_bin" ] && [ -f "$tauri_cli" ] && [ ! -L "$tauri_cli" ]
+          [ -f "$node_bin" ] && [ ! -L "$node_bin" ] && [ -x "$node_bin" ] \
+            && [ -f "$tauri_cli" ] && [ ! -L "$tauri_cli" ]
           [ "$("$node_bin" --version)" = "v24.20.0" ]
           case "$RUNNER_OS" in
             macOS)
@@ -692,17 +747,51 @@ jobs:
           # Invoked indirectly by trap.
           # shellcheck disable=SC2317,SC2329
           cleanup() {
+            cleanup_rc=$?
+            trap - EXIT HUP INT TERM
             if [ -n "${node_pid:-}" ]; then
               if [ "$RUNNER_OS" = Windows ]; then
-                taskkill.exe /PID "$node_pid" /T /F >/dev/null 2>&1 || true
+                # Git Bash otherwise rewrites taskkill's /PID, /T, and /F
+                # switches as MSYS paths. If taskkill itself fails, bounded
+                # TERM/KILL fallbacks ensure cleanup can never block in wait.
+                if kill -0 "$node_pid" 2>/dev/null; then
+                  MSYS_NO_PATHCONV=1 taskkill.exe \
+                    /PID "$node_pid" /T /F >/dev/null 2>&1 || \
+                    kill "$node_pid" 2>/dev/null || true
+                fi
+                for _ in {1..40}; do
+                  if ! kill -0 "$node_pid" 2>/dev/null; then
+                    break
+                  fi
+                  sleep 0.25
+                done
+                if kill -0 "$node_pid" 2>/dev/null; then
+                  kill -KILL "$node_pid" 2>/dev/null || true
+                  for _ in {1..20}; do
+                    if ! kill -0 "$node_pid" 2>/dev/null; then
+                      break
+                    fi
+                    sleep 0.25
+                  done
+                fi
+                if kill -0 "$node_pid" 2>/dev/null; then
+                  echo '::error::The Windows headless smoke process could not be terminated.' >&2
+                  cleanup_rc=1
+                else
+                  wait "$node_pid" 2>/dev/null || true
+                fi
               else
                 kill "$node_pid" 2>/dev/null || true
+                wait "$node_pid" 2>/dev/null || true
               fi
-              wait "$node_pid" 2>/dev/null || true
             fi
-            rm -rf -- "$smoke_dir"
+            rm -rf -- "$smoke_dir" || cleanup_rc=1
+            exit "$cleanup_rc"
           }
-          trap cleanup EXIT HUP INT TERM
+          trap cleanup EXIT
+          trap 'exit 129' HUP
+          trap 'exit 130' INT
+          trap 'exit 143' TERM
           "$node" \
             --rpc 127.0.0.1:19944 \
             --p2p-port 19945 \
@@ -1002,7 +1091,7 @@ jobs:
       contents: read
     outputs:
       artifact_id: ${{ steps.upload.outputs.artifact-id }}
-      artifact_digest: ${{ steps.upload.outputs.artifact-digest }}
+      artifact_digest: ${{ format('sha256:{0}', steps.upload.outputs.artifact-digest) }}
       artifact_name: ${{ steps.seal.outputs.artifact_name }}
       manifest_sha: ${{ steps.seal.outputs.manifest_sha }}
     steps:
@@ -1247,7 +1336,60 @@ jobs:
           [[ "$EXPECTED_ARTIFACT_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
           expected_name="arc-desktop-signer-handoff-$EXPECTED_SHA-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$EXPECTED_MANIFEST_SHA"
           [ "$EXPECTED_ARTIFACT_NAME" = "$expected_name" ]
-          /usr/bin/python3 -I - "$GITHUB_REPOSITORY" "$EXPECTED_SHA" \
+
+          # The hosted Windows Python is not installed at /usr/bin/python3.
+          # Resolve it before any release secret is exposed, resolve POSIX
+          # symlinks through the isolated interpreter itself, and pin the
+          # executable bytes for the duration of this validation step.
+          case "$RUNNER_OS" in
+            Windows)
+              python_candidate="$(command -v python.exe)"
+              python_bin="$python_candidate"
+              ;;
+            Linux|macOS)
+              python_candidate="$(command -v python3)"
+              case "$python_candidate" in
+                /*) ;;
+                *)
+                  echo "::error::Python did not resolve to an absolute executable."
+                  exit 1
+                  ;;
+              esac
+              python_bin="$("$python_candidate" -I -c \
+                'import os, sys; print(os.path.realpath(sys.executable))')"
+              ;;
+            *)
+              echo "::error::Unsupported runner OS for the isolated Python runtime: $RUNNER_OS"
+              exit 1
+              ;;
+          esac
+          case "$python_bin" in
+            /*) ;;
+            *)
+              echo "::error::Python did not resolve to an absolute executable."
+              exit 1
+              ;;
+          esac
+          [ -f "$python_bin" ] && [ ! -L "$python_bin" ] && [ -x "$python_bin" ]
+          case "$RUNNER_OS" in
+            macOS)
+              python_sha256="$(/usr/bin/shasum -a 256 "$python_bin" | /usr/bin/awk '{print $1}')"
+              ;;
+            Linux|Windows)
+              python_sha256="$(/usr/bin/sha256sum "$python_bin" | /usr/bin/awk '{print $1}')"
+              ;;
+          esac
+          [[ "$python_sha256" =~ ^[0-9a-f]{64}$ ]]
+          case "$RUNNER_OS" in
+            macOS)
+              current_python_sha256="$(/usr/bin/shasum -a 256 "$python_bin" | /usr/bin/awk '{print $1}')"
+              ;;
+            Linux|Windows)
+              current_python_sha256="$(/usr/bin/sha256sum "$python_bin" | /usr/bin/awk '{print $1}')"
+              ;;
+          esac
+          [ "$current_python_sha256" = "$python_sha256" ]
+          "$python_bin" -I - "$GITHUB_REPOSITORY" "$EXPECTED_SHA" \
             "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" "$PLATFORM" "$TARGET" \
             "$EXPECTED_MANIFEST_SHA" signer-handoff <<'PY'
           import hashlib, json, os, pathlib, stat, sys
@@ -1367,9 +1509,28 @@ jobs:
         run: |
           set -Eeuo pipefail
           [ "$(jq -r '.version' desktop/node_modules/@tauri-apps/cli/package.json)" = '2.11.4' ]
-          node_bin="$(command -v node)"
+          case "$RUNNER_OS" in
+            Windows)
+              node_bin="$(command -v node.exe)"
+              ;;
+            Linux|macOS)
+              node_bin="$(command -v node)"
+              ;;
+            *)
+              echo "::error::Unsupported runner OS for the locked Node runtime: $RUNNER_OS"
+              exit 1
+              ;;
+          esac
+          case "$node_bin" in
+            /*) ;;
+            *)
+              echo "::error::The locked Node runtime did not resolve to an absolute executable."
+              exit 1
+              ;;
+          esac
           tauri_cli="$PWD/desktop/node_modules/@tauri-apps/cli/tauri.js"
-          [ -x "$node_bin" ] && [ -f "$tauri_cli" ] && [ ! -L "$tauri_cli" ]
+          [ -f "$node_bin" ] && [ ! -L "$node_bin" ] && [ -x "$node_bin" ] \
+            && [ -f "$tauri_cli" ] && [ ! -L "$tauri_cli" ]
           [ "$("$node_bin" --version)" = "v24.20.0" ]
           case "$RUNNER_OS" in
             macOS)
@@ -1487,7 +1648,7 @@ jobs:
           verifier_target="$RUNNER_TEMP/tauri-updater-verifier"
           CARGO_TARGET_DIR="$verifier_target" cargo build --quiet --locked \
             --manifest-path tests/release/tauri-updater-verifier/Cargo.toml
-          "$verifier_target/debug/tauri-updater-verifier" \
+          "$verifier_target/debug/tauri-updater-verifier${{ matrix.binary-suffix }}" \
             "$public_key" \
             "unsigned-materialized/$updater_file" \
             "unsigned-materialized/$updater_file.sig"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -731,7 +731,7 @@ jobs:
       contents: read
     outputs:
       artifact_id: ${{ steps.unsigned-upload.outputs.artifact-id }}
-      artifact_digest: ${{ steps.unsigned-upload.outputs.artifact-digest }}
+      artifact_digest: ${{ format('sha256:{0}', steps.unsigned-upload.outputs.artifact-digest) }}
       artifact_name: ${{ steps.unsigned-stage.outputs.artifact_name }}
       metadata_sha: ${{ steps.unsigned-stage.outputs.metadata_sha }}
       manifest_sha: ${{ steps.unsigned-stage.outputs.manifest_sha }}
@@ -864,7 +864,7 @@ jobs:
       contents: read
     outputs:
       artifact_id: ${{ steps.sealed-upload.outputs.artifact-id }}
-      artifact_digest: ${{ steps.sealed-upload.outputs.artifact-digest }}
+      artifact_digest: ${{ format('sha256:{0}', steps.sealed-upload.outputs.artifact-digest) }}
       artifact_name: ${{ steps.sealed-stage.outputs.artifact_name }}
       metadata_sha: ${{ steps.sealed-stage.outputs.metadata_sha }}
     steps:
@@ -1092,7 +1092,7 @@ jobs:
     outputs:
       release_id: ${{ steps.draft.outputs.release_id }}
       evidence_id: ${{ steps.evidence.outputs.artifact-id }}
-      evidence_digest: ${{ steps.evidence.outputs.artifact-digest }}
+      evidence_digest: ${{ format('sha256:{0}', steps.evidence.outputs.artifact-digest) }}
       evidence_name: ${{ steps.draft.outputs.evidence_name }}
       evidence_sha: ${{ steps.draft.outputs.evidence_sha }}
     steps:
@@ -1583,7 +1583,7 @@ jobs:
       contents: write
     outputs:
       evidence_id: ${{ steps.evidence.outputs.artifact-id }}
-      evidence_digest: ${{ steps.evidence.outputs.artifact-digest }}
+      evidence_digest: ${{ format('sha256:{0}', steps.evidence.outputs.artifact-digest) }}
       evidence_name: ${{ steps.finalize.outputs.evidence_name }}
       evidence_sha: ${{ steps.finalize.outputs.evidence_sha }}
     steps:

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -974,19 +974,48 @@ async fn cached_chain_choice(state: &AppState) -> Option<ChainHostChoice> {
         .map(|(c, _)| c.clone())
 }
 
+/// A conservative upper bound for the number of tokens produced by ARC's
+/// raw-input tokenizer.
+///
+/// `CachedIntegerModel::encode` prepends one three-byte SentencePiece marker,
+/// replaces every ASCII space with that same three-byte marker, and then emits
+/// at most one token per transformed UTF-8 byte. Keeping the bound here in
+/// bytes means the desktop does not need the model vocabulary merely to avoid
+/// cancelling a valid coordinator request too early.
+fn inference_prompt_token_upper_bound(prompt: &str) -> u64 {
+    const SENTENCEPIECE_MARKER_BYTES: u64 = 3;
+
+    prompt
+        .as_bytes()
+        .iter()
+        .fold(SENTENCEPIECE_MARKER_BYTES, |transformed_bytes, byte| {
+            transformed_bytes.saturating_add(if *byte == b' ' {
+                SENTENCEPIECE_MARKER_BYTES
+            } else {
+                1
+            })
+        })
+}
+
 /// Mirror the coordinator's protocol budget: worker inference, independent
 /// validator recomputation, and remote reward approvals can span three model
-/// passes. Add 60 seconds beyond the server's capped deadline so a valid
+/// passes. The server budgets the complete generation context -- one internal
+/// BOS position, the tokenized prompt, and requested output -- rather than
+/// output tokens alone. Add 60 seconds beyond its capped deadline so a valid
 /// settled response is never cancelled by the desktop first.
-fn inference_timeout(max_tokens: u32) -> std::time::Duration {
+fn inference_timeout(prompt: &str, max_tokens: u32) -> std::time::Duration {
     const MIN_SERVER_SECS: u64 = 45;
     const MAX_SERVER_SECS: u64 = 3_900;
     const CLAIM_WINDOW_SECS: u64 = 30;
     const CLIENT_HEADROOM_SECS: u64 = 60;
+    const INTERNAL_BOS_POSITIONS: u64 = 1;
     // One generation is budgeted at 3.3s/token. Dispatch can include the
     // worker pass, coordinator verification, and validator approval pass,
-    // each with 50% headroom: ceil(14.85s * tokens) + claim window.
-    let estimated_ms = (max_tokens as u64).saturating_mul(14_850);
+    // each with 50% headroom: ceil(14.85s * positions) + claim window.
+    let required_positions = INTERNAL_BOS_POSITIONS
+        .saturating_add(inference_prompt_token_upper_bound(prompt))
+        .saturating_add(u64::from(max_tokens));
+    let estimated_ms = required_positions.saturating_mul(14_850);
     let estimated_secs = estimated_ms.saturating_add(999) / 1_000;
     let server_secs = estimated_secs
         .saturating_add(CLAIM_WINDOW_SECS)
@@ -997,9 +1026,9 @@ fn inference_timeout(max_tokens: u32) -> std::time::Duration {
 /// How long a coordinator gets to answer `/health` before we skip it.
 const COORDINATOR_HEALTH_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(1500);
 
-fn inference_client(max_tokens: u32) -> Result<reqwest::Client, String> {
+fn inference_client(prompt: &str, max_tokens: u32) -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
-        .timeout(inference_timeout(max_tokens))
+        .timeout(inference_timeout(prompt, max_tokens))
         .build()
         .map_err(map_err)
 }
@@ -1156,7 +1185,7 @@ pub async fn run_inference(
     let port = state.node.lock().await.rpc_port;
     let host = paths::local_host(port);
     let max_tokens = max_tokens.unwrap_or(32);
-    let client = inference_client(max_tokens)?;
+    let client = inference_client(&prompt, max_tokens)?;
     let mut result = rpc_client::run_inference(
         &client,
         &host,
@@ -1191,7 +1220,7 @@ pub async fn run_inference_via_coordinator(
     chat_template: Option<bool>,
 ) -> CmdResult<InferenceResult> {
     let max_tokens = max_tokens.unwrap_or(32);
-    let client = inference_client(max_tokens)?;
+    let client = inference_client(&prompt, max_tokens)?;
     let k = k.unwrap_or(3);
     let chat_template = chat_template.unwrap_or(true);
 
@@ -1300,7 +1329,7 @@ pub async fn run_inference_via_coordinator_direct(
     chat_template: Option<bool>,
 ) -> CmdResult<InferenceResult> {
     let max_tokens = max_tokens.unwrap_or(32);
-    let client = inference_client(max_tokens)?;
+    let client = inference_client(&prompt, max_tokens)?;
     let chat_template = chat_template.unwrap_or(true);
 
     let candidates = coordinator_candidates(&state).await;
@@ -3270,9 +3299,47 @@ mod release_binary_tests {
 
     #[test]
     fn desktop_inference_deadline_outlives_the_server_protocol_budget() {
-        assert_eq!(inference_timeout(0).as_secs(), 105);
-        assert_eq!(inference_timeout(32).as_secs(), 566);
-        assert_eq!(inference_timeout(u32::MAX).as_secs(), 3_960);
+        fn admitted_coordinator_budget(required_positions: u64) -> Option<u64> {
+            let estimated = required_positions
+                .saturating_mul(14_850)
+                .div_ceil(1_000)
+                .saturating_add(30);
+            (estimated <= 3_900).then_some(estimated.max(45))
+        }
+
+        // The UTF-8 byte bound accounts for the tokenizer's leading marker
+        // and its expansion of an ASCII space into a three-byte marker.
+        let short_prompt = "ARC node";
+        assert_eq!(inference_prompt_token_upper_bound(short_prompt), 13);
+        assert_eq!(inference_prompt_token_upper_bound("🧪 "), 10);
+        let short_positions = 1 + 13 + 16;
+        let short_timeout = inference_timeout(short_prompt, 16).as_secs();
+        assert_eq!(short_timeout, 536);
+        assert_eq!(
+            short_timeout,
+            admitted_coordinator_budget(short_positions).unwrap() + 60
+        );
+        assert!(short_timeout < 10 * 60, "short prompts stay bounded");
+
+        // At one output token, a long prompt alone can consume almost the
+        // complete coordinator budget. The old output-only calculation gave
+        // this request 105 seconds and cancelled it thousands of seconds too
+        // early. The conservative prompt bound now covers that budget plus
+        // client headroom.
+        let long_prompt = "x".repeat(255);
+        let long_positions = 1 + inference_prompt_token_upper_bound(&long_prompt) + 1;
+        assert_eq!(long_positions, 260);
+        assert_eq!(inference_timeout(&long_prompt, 1).as_secs(), 3_951);
+        assert_eq!(
+            inference_timeout(&long_prompt, 1).as_secs(),
+            admitted_coordinator_budget(long_positions).unwrap() + 60
+        );
+
+        // One more raw byte crosses the coordinator's admitted deadline. The
+        // desktop saturates at the full 3,900s server cap plus 60s headroom,
+        // including for arithmetic-overflow-scale output requests.
+        assert_eq!(inference_timeout(&"x".repeat(256), 1).as_secs(), 3_960);
+        assert_eq!(inference_timeout("", u32::MAX).as_secs(), 3_960);
     }
 
     #[test]

--- a/docs/VALIDATOR-FLEET-ROLLOUT.md
+++ b/docs/VALIDATOR-FLEET-ROLLOUT.md
@@ -526,10 +526,16 @@ tag creation. GitHub's endpoint requires repository Administration read access,
 which is intentionally unavailable to the workflow `GITHUB_TOKEN`. The
 least-privilege publisher instead creates a hidden draft, uploads and compares
 every GitHub-computed asset digest to the local bytes, publishes the validated
-draft, and requires the resulting release to report `immutable: true`. If it
-does not, the workflow immediately deletes that exact release ID without
-deleting the protected tag, so the same unchanged tag can be rerun after the
-setting is repaired.
+draft, and requires the resulting release to report `immutable: true`.
+Before publication, a failed upload or independent verification may delete
+only the exact release ID after re-proving that it is still the expected hidden
+`draft: true`, `immutable: false` object for the protected tag and commit.
+Once the publication PATCH has been attempted, every failure path retains that
+release ID: the workflow polls the one object for bounded eventual consistency
+and, if immutable state is still not observed, stops for manual verification.
+Never delete that ambiguous or already-published release, and do not rerun the
+tag or release workflow; the tag and its release are create-only incident
+evidence.
 
 - protect `main` with a no-bypass PR/check/review ruleset. Protect **all** tag
   names with two `~ALL` tag rulesets: owner-only creation, plus no-bypass
@@ -1057,11 +1063,73 @@ argv/output hashes must verify before any new validator key is installed.
    optional air-gapped input, never a required handoff.) The generator derives
    fork membership from the sealed six-node classification and URLs from
    sealed validator origins, verifies every live provenance pin, then writes
-   create-only config bytes. Publish those exact
-   bytes in one reviewable Git commit; verify the Pages hash and all
-   provenance endpoints. Rollback by reverting only that config commit, which
-   restores maintenance without rolling back or renumbering the canonical
-   chain.
+   create-only config bytes. Preserve them and their checksum outside the
+   checkout; do not change `main` before the exact-main handoff, tag, and
+   immutable release in step 17.
+17. Create the compact public release handoff from the exact four-file private
+   handoff only with
+   `scripts/release/create-cutover-handoff-commit.py --full-handoff-dir ...
+   --verifier-binary ... --inspector-binary ... --genesis ...
+   --main-commit ... --tag v0.8.0 --push-remote origin`. The source directory
+   must contain only the finalized manifest and sidecar, the capture's
+   maintenance boundary, and the quorum-signed checkpoint, all read-only; it
+   stays under protected operator storage. The helper strips credentials from
+   its isolated derivation and compiled-verifier children; only its hardened
+   exact-remote Git publisher receives the bounded token through a temporary
+   askpass boundary. The hidden ref contains only the three derived public JSON
+   files and has the exact current protected-main commit as its sole parent. An
+   exact existing local or remote ref is resumable after a fresh re-derivation;
+   a different ref is never replaced. Snapshot the exact-SHA run set. Manually dispatch
+   `recovery-release-handoff.yml` on `main` only when none exists, then
+   API-select exactly one workflow/path/event/branch/SHA run and seal its run ID
+   and attempt before approval. Record the successful artifact's immutable
+   numeric ID and `sha256:` server digest.
+   Immediately re-prove immutable releases and unchanged `main`, require the
+   exact direct set `FerrumVir` plus `arisarcmarket`, reduce only
+   `arisarcmarket` to `pull`, and re-query the complete set to prove that the
+   sole non-owner is now `read` with no `write`, `maintain`, or `admin`. An
+   unexpected collaborator fails closed without mutation. Require
+   zero pending invitations with any of those roles. Re-query active ruleset
+   21690216 as the `~ALL` creation gate with only FerrumVir's owner bypass and
+   active ruleset 21667203 as the no-bypass `~ALL` update/deletion/
+   non-fast-forward gate; then prove remote tag/release absence and create the
+   protected tag once with an isolated authenticated Git push to the exact
+   credential-free HTTPS repository URL. Clear credential helpers, HTTP
+   headers, hooks, and non-HTTPS protocols; use the pinned `gh` credential
+   helper and the atomic create-only
+   `--force-with-lease=refs/tags/v0.8.0:` guard. Whether the push succeeds or
+   returns an ambiguous error, re-read the remote ref and accept only the exact
+   main SHA; proven absence is safe to retry and any mismatch stops. Its
+   automatic `release.yml`
+   tag-push run is expected to fail in the initial validation job because a
+   push event cannot supply those two handoff inputs. API-select that exact
+   failed tag-push run rather than entering an ID. Prove that exact error and
+   that no publisher job ran. After that expected failure is confirmed,
+   create or reuse exactly one manual `release.yml` run with `tag`,
+   `cutover_handoff_artifact_id`, and `cutover_handoff_artifact_digest`. Never
+   move or recreate the tag, and never retry publication by pushing it again.
+   Bind the manual run's ID/attempt, wait for terminal success, require every
+   named job including the independent immutable-release verifier, and prove
+   through the release API that v0.8.0 is live, immutable, non-draft,
+   non-prerelease, targets the exact source SHA, and contains the complete
+   unique 32-asset digest-bound contract. The exact production commands and
+   API checks are in the recovery README.
+18. Only after the immutable release and its independent read-only verification
+   succeed, publish the preserved recovered frontend bytes in one deterministic
+   reviewable commit and create-only branch. Prefer `arisarcmarket`'s exact-head
+   approval. If unavailable, seal the exact main-ruleset policy, temporarily
+   relax only approval count and last-push approval under an EXIT/signal restore
+   trap, squash merge, and prove the policy snapshot hash was restored. The new
+   main commit must have the release source as its sole parent and exactly the
+   reviewed tree/config bytes. API-select the exact successful Pages run and
+   jobs, bind its successful `github-pages` deployment, compare the CDN config,
+   commit marker, and deployed SHA256SUMS, and re-fetch every advertised archive
+   provenance object field-for-field. Finally run a fresh no-service Linux
+   installer plus already-up-to-date canary and the read-only six-node
+   inference/reward verifier; seal `POST-RELEASE-ACCEPTANCE.json` before
+   unmasking package updates. Rollback by reverting only that config commit,
+   which restores maintenance without moving v0.8.0 or rolling back or
+   renumbering the canonical chain.
 
 Each production validator accepts RPC only on its rollout-derived Unix-domain
 socket. The remote unit passes `--rpc-unix` and omits `--rpc`; the manifest's

--- a/scripts/recovery/README.md
+++ b/scripts/recovery/README.md
@@ -2317,12 +2317,1327 @@ frontend_config=/secure/operator/arc-network.recovered.json
   /usr/bin/sha256sum --check --strict arc-network.recovered.json.sha256)
 ```
 
-<!-- END EXECUTABLE PRODUCTION RECOVERY PROCEDURE -->
+## Create the compact release handoff and publish
+
+Do this only after the finalized manifest, maintenance boundary, quorum-signed
+checkpoint, six-validator restart proof, and recovered frontend proof above are
+complete. Remain in the same clean, detached, exact-`$protected_main_sha`
+checkout. The private handoff directory must contain exactly the four files
+shown below, on protected local operator storage, with no write bits. Neither
+the multi-gigabyte checkpoint nor the private finalized rollout manifest is
+committed or uploaded. The helper derives three bounded public JSON files,
+creates a commit whose sole parent is the exact protected-main commit, and
+publishes its content-addressed
+`refs/arc-recovery-handoffs/<protected-main-sha>` ref. The helper runs both
+derivation/verification programs under isolated `python -I` with a five-variable
+non-secret environment. Only its hardened Git publisher receives the bounded
+token through a create-only askpass file, and the credential-free `origin` URL
+must exactly identify this repository. A retry freshly re-derives the commit,
+accepts only the identical local or remote ref, and never moves a mismatch.
+After any push error it re-probes the remote: the exact ref is success, proven
+absence is safely retryable, and an unavailable or different result stops with
+the local ref preserved. Never put a token in the remote URL.
+
+```bash
+set -Eeuo pipefail
+test "$PWD" = "$operator_checkout"
+unset GH_TOKEN GITHUB_TOKEN
+test "$(arc_git -C "$operator_checkout" rev-parse HEAD)" = "$protected_main_sha"
+arc_git -C "$operator_checkout" diff-index --quiet HEAD --
+test -z "$(arc_git -C "$operator_checkout" status --porcelain=v1 --untracked-files=all)"
+test "$(arc_git -C "$operator_checkout" remote get-url --all origin)" = \
+  https://github.com/FerrumVir/arc-chain.git
+test "$(arc_git -C "$operator_checkout" remote get-url --push --all origin)" = \
+  https://github.com/FerrumVir/arc-chain.git
+
+full_handoff_dir="$(
+  /usr/bin/mktemp -d /secure/operator/release-handoff-v0.8.0.XXXXXXXX
+)"
+release_control_root="$(
+  /usr/bin/mktemp -d /secure/operator/release-control-v0.8.0.XXXXXXXX
+)"
+test "$(/usr/bin/stat --format='%a:%h' "$full_handoff_dir")" = 700:1
+test "$(/usr/bin/stat --format='%a:%h' "$release_control_root")" = 700:1
+write_once_or_compare() {
+  local destination="$1" candidate
+  case "$destination" in "$release_control_root"/*) ;; *) return 1 ;; esac
+  candidate="$(/usr/bin/mktemp "$release_control_root/.receipt.XXXXXXXX")"
+  /usr/bin/cat > "$candidate"
+  /usr/bin/chmod 0400 "$candidate"
+  if [ -e "$destination" ] || [ -L "$destination" ]; then
+    test -f "$destination" && test ! -L "$destination"
+    test "$(/usr/bin/stat --format='%a:%h' "$destination")" = 400:1
+    /usr/bin/cmp -s "$candidate" "$destination"
+  else
+    /usr/bin/ln -- "$candidate" "$destination"
+    /usr/bin/sync -f "$destination"
+    /usr/bin/sync -f "$release_control_root"
+  fi
+  /usr/bin/rm -f -- "$candidate"
+}
+/usr/bin/install -m 0400 "$final_manifest" \
+  "$full_handoff_dir/arc-recovery-final.lock.json"
+/usr/bin/install -m 0400 "$final_manifest_sidecar" \
+  "$full_handoff_dir/arc-recovery-final.lock.json.sha256"
+/usr/bin/install -m 0400 "$legacy_maintenance_boundary" \
+  "$full_handoff_dir/legacy-maintenance-boundary.json"
+/usr/bin/install -m 0400 "$recovery_checkpoint" \
+  "$full_handoff_dir/recovery.arcchkpt"
+
+GH_TOKEN="$(
+  "$ARC_RECOVERY_GH_PATH" auth token --hostname github.com \
+    --user "$ARC_RECOVERY_GITHUB_LOGIN"
+)"
+test -n "$GH_TOKEN"
+test "$(GH_TOKEN="$GH_TOKEN" "$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/branches/main --jq .commit.sha)" = "$protected_main_sha"
+handoff_receipt="$(
+  GH_TOKEN="$GH_TOKEN" "$ARC_RECOVERY_PYTHON_PATH" -I \
+    scripts/release/create-cutover-handoff-commit.py \
+    --repository-root "$operator_checkout" \
+    --full-handoff-dir "$full_handoff_dir" \
+    --verifier-binary "$arc_node_linux" \
+    --inspector-binary "$arc_node_linux" \
+    --genesis "$operator_genesis" \
+    --main-commit "$protected_main_sha" \
+    --tag v0.8.0 \
+    --repository FerrumVir/arc-chain \
+    --push-remote origin
+)"
+handoff_commit_sha="$(printf '%s' "$handoff_receipt" | /usr/bin/jq -er '.handoff_commit_sha')"
+handoff_ref="refs/arc-recovery-handoffs/$protected_main_sha"
+[[ "$handoff_commit_sha" =~ ^[0-9a-f]{40}$ ]]
+printf '%s' "$handoff_receipt" | /usr/bin/jq -e \
+  --arg commit "$handoff_commit_sha" --arg ref "$handoff_ref" \
+  '.handoff_commit_sha == $commit and .handoff_ref == $ref
+   and (.local_ref_state == "created" or .local_ref_state == "reused")
+   and .pushed_remote == "origin"
+   and (.remote_ref_state == "created" or .remote_ref_state == "reused")' >/dev/null
+test "$(arc_git -C "$operator_checkout" rev-list --parents -n 1 \
+  "$handoff_commit_sha")" = "$handoff_commit_sha $protected_main_sha"
+test -z "$(arc_git -C "$operator_checkout" status --porcelain=v1 --untracked-files=all)"
+
+handoff_workflow_id="$("$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/actions/workflows/recovery-release-handoff.yml --jq .id)"
+[[ "$handoff_workflow_id" =~ ^[1-9][0-9]*$ ]]
+handoff_run_candidates() {
+  "$ARC_RECOVERY_GH_PATH" api --paginate \
+    'repos/FerrumVir/arc-chain/actions/workflows/recovery-release-handoff.yml/runs?event=workflow_dispatch&branch=main&per_page=100' \
+    --jq '.workflow_runs[]' \
+  | /usr/bin/jq -cs --arg sha "$protected_main_sha" \
+      --argjson workflow_id "$handoff_workflow_id" '
+      [.[] | select(.workflow_id == $workflow_id and .head_sha == $sha
+        and .head_branch == "main"
+        and .path == ".github/workflows/recovery-release-handoff.yml"
+        and .event == "workflow_dispatch")]'
+}
+# This is the pinned-path form of: gh workflow run recovery-release-handoff.yml
+handoff_runs="$(handoff_run_candidates)"
+handoff_run_count="$(printf '%s' "$handoff_runs" | /usr/bin/jq -er length)"
+case "$handoff_run_count" in
+  0)
+    GH_TOKEN="$GH_TOKEN" "$ARC_RECOVERY_GH_PATH" workflow run recovery-release-handoff.yml \
+      --repo FerrumVir/arc-chain \
+      --ref main \
+      -f handoff_commit_sha="$handoff_commit_sha"
+    for _ in {1..30}; do
+      /usr/bin/sleep 2
+      handoff_runs="$(handoff_run_candidates)"
+      handoff_run_count="$(printf '%s' "$handoff_runs" | /usr/bin/jq -er length)"
+      [ "$handoff_run_count" -eq 0 ] || break
+    done
+    test "$handoff_run_count" -eq 1
+    ;;
+  1)
+    printf 'reusing the one exact existing compact-handoff run\n' >&2
+    ;;
+  *)
+    printf 'compact-handoff run selection is ambiguous; preserve and stop\n' >&2
+    exit 1
+    ;;
+esac
+handoff_run_id="$(printf '%s' "$handoff_runs" | /usr/bin/jq -er '.[0].id')"
+handoff_run_attempt="$(printf '%s' "$handoff_runs" | /usr/bin/jq -er '.[0].run_attempt')"
+[[ "$handoff_run_id" =~ ^[1-9][0-9]*$ ]]
+[[ "$handoff_run_attempt" =~ ^[1-9][0-9]*$ ]]
+/usr/bin/jq -cnS --argjson id "$handoff_run_id" \
+  --argjson attempt "$handoff_run_attempt" --arg sha "$protected_main_sha" \
+  --argjson workflow_id "$handoff_workflow_id" \
+  '{schema:"arc.release-handoff-run-selection.v1",repository:"FerrumVir/arc-chain",
+    workflow_id:$workflow_id,
+    workflow_path:".github/workflows/recovery-release-handoff.yml",
+    event:"workflow_dispatch",head_branch:"main",head_sha:$sha,
+    run_id:$id,run_attempt:$attempt}' \
+  | write_once_or_compare "$release_control_root/HANDOFF-RUN-SELECTION.json"
+printf 'Approve only handoff run %s attempt %s, then wait here.\n' \
+  "$handoff_run_id" "$handoff_run_attempt"
+"$ARC_RECOVERY_GH_PATH" run watch "$handoff_run_id" \
+  --repo FerrumVir/arc-chain --interval 10 --exit-status
+```
+
+Approve that one exact `release`-environment deployment, wait for the
+`recovery-release-handoff.yml` run selected above to succeed. Then independently
+resolve its one live artifact. The API object must
+name the exact main commit, successful producer run, numeric immutable ID, and
+GitHub server digest; values copied only from a log line are not release
+inputs.
+
+```bash
+"$ARC_RECOVERY_GH_PATH" api \
+  "repos/FerrumVir/arc-chain/actions/runs/$handoff_run_id" \
+  | /usr/bin/jq -e --arg sha "$protected_main_sha" --argjson id "$handoff_run_id" \
+      --argjson attempt "$handoff_run_attempt" --argjson workflow_id "$handoff_workflow_id" \
+      '.id == $id and .workflow_id == $workflow_id
+       and .head_repository.full_name == "FerrumVir/arc-chain"
+       and .head_sha == $sha and .head_branch == "main"
+       and .path == ".github/workflows/recovery-release-handoff.yml"
+       and .event == "workflow_dispatch" and .run_attempt == $attempt
+       and .status == "completed" and .conclusion == "success"' >/dev/null
+handoff_artifact_json="$(
+  "$ARC_RECOVERY_GH_PATH" api --paginate \
+    "repos/FerrumVir/arc-chain/actions/runs/$handoff_run_id/artifacts?per_page=100" \
+    --jq '.artifacts[]' \
+  | /usr/bin/jq -cs --arg name "arc-recovery-release-handoff-$protected_main_sha" \
+      --arg sha "$protected_main_sha" --argjson run_id "$handoff_run_id" \
+      '[.[] | select(.name == $name and .expired == false
+          and .workflow_run.id == $run_id and .workflow_run.head_sha == $sha
+          and (.digest | test("^sha256:[0-9a-f]{64}$"))
+          and (.size_in_bytes > 0 and .size_in_bytes <= 33554432))]
+       | if length == 1 then .[0]
+         else error("expected exactly one live compact handoff artifact") end'
+)"
+handoff_artifact_id="$(printf '%s' "$handoff_artifact_json" | /usr/bin/jq -er '.id')"
+handoff_artifact_digest="$(printf '%s' "$handoff_artifact_json" | /usr/bin/jq -er '.digest')"
+[[ "$handoff_artifact_id" =~ ^[1-9][0-9]*$ ]]
+[[ "$handoff_artifact_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+```
+
+Immediately before tag creation, re-prove the owner session and immutable-release
+setting, require the exact direct-collaborator set `FerrumVir` plus
+`arisarcmarket`, and use one bounded owner API call to reduce only
+`arisarcmarket` to `pull`. Then re-query the complete set to prove that the sole
+non-owner retains no `write`, `maintain`, or `admin`. An unexpected collaborator
+fails closed instead of being silently mutated. Also prove unchanged protected `main` and the
+remote absence of both the tag and its release. If any check fails, do not
+create the tag. Create the lightweight protected tag with one isolated,
+authenticated Git push to the exact credential-free HTTPS URL. The push clears
+ambient credential helpers and HTTP headers, disables hooks and all protocols
+except HTTPS, uses only the pinned `gh auth git-credential` helper, and carries
+an empty expected-value lease so it can create but never move the tag. Re-read
+the remote ref after every push result instead of treating the Git exit status
+as the final proof.
+
+```bash
+test "$("$ARC_RECOVERY_GH_PATH" api /user --jq .login)" = FerrumVir
+test "$("$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/immutable-releases --jq .enabled)" = true
+test "$("$ARC_RECOVERY_GH_PATH" api repos/FerrumVir/arc-chain/branches/main \
+  --jq .commit.sha)" = "$protected_main_sha"
+direct_collaborators_before="$(
+  "$ARC_RECOVERY_GH_PATH" api --paginate \
+    'repos/FerrumVir/arc-chain/collaborators?affiliation=direct&per_page=100' \
+    --jq '.[]' | /usr/bin/jq -cs 'sort_by(.login)'
+)"
+printf '%s' "$direct_collaborators_before" | /usr/bin/jq -e '
+  length == 2 and .[0].login == "FerrumVir" and .[0].permissions.admin == true
+  and .[1].login == "arisarcmarket"
+  and (.[1].role_name == "write" or .[1].role_name == "read")' >/dev/null
+"$ARC_RECOVERY_GH_PATH" api --method PUT \
+  repos/FerrumVir/arc-chain/collaborators/arisarcmarket \
+  -f permission=pull >/dev/null
+direct_collaborators_after="$(
+  "$ARC_RECOVERY_GH_PATH" api --paginate \
+    'repos/FerrumVir/arc-chain/collaborators?affiliation=direct&per_page=100' \
+    --jq '.[]' | /usr/bin/jq -cs 'sort_by(.login)'
+)"
+printf '%s' "$direct_collaborators_after" | /usr/bin/jq -e '
+  length == 2 and .[0].login == "FerrumVir" and .[0].permissions.admin == true
+  and .[1].login == "arisarcmarket" and .[1].role_name == "read"
+  and .[1].permissions.pull == true and .[1].permissions.push == false
+  and .[1].permissions.maintain == false and .[1].permissions.admin == false' >/dev/null
+pending_writer_invitations="$(
+  "$ARC_RECOVERY_GH_PATH" api --paginate \
+    'repos/FerrumVir/arc-chain/invitations?per_page=100' --jq '.[]' \
+  | /usr/bin/jq -cs \
+      '[.[] | select(.permissions == "write" or .permissions == "maintain"
+                     or .permissions == "admin")] | length'
+)"
+test "$pending_writer_invitations" = 0
+remote_tag_before="$("$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/git/matching-refs/tags/v0.8.0 --jq .)"
+remote_tag_state="$(printf '%s' "$remote_tag_before" | /usr/bin/jq -er \
+  --arg sha "$protected_main_sha" '
+    [.[] | select(.ref == "refs/tags/v0.8.0")] as $matches
+    | if ($matches | length) == 0 then "absent"
+    elif ($matches | length) == 1
+         and $matches[0].object.type == "commit"
+         and $matches[0].object.sha == $sha then "exact"
+    else "mismatch" end')"
+case "$remote_tag_state" in
+  absent|exact) ;;
+  mismatch)
+    printf 'v0.8.0 exists at a different remote identity; preserve and stop\n' >&2
+    exit 1
+    ;;
+  *) exit 1 ;;
+esac
+remote_release_count="$(
+  "$ARC_RECOVERY_GH_PATH" api --paginate \
+    'repos/FerrumVir/arc-chain/releases?per_page=100' --jq '.[]' \
+  | /usr/bin/jq -cs '[.[] | select(.tag_name == "v0.8.0")] | length'
+)"
+test "$remote_release_count" = 0
+creation_ruleset="$("$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/rulesets/21690216)"
+printf '%s' "$creation_ruleset" | /usr/bin/jq -e '
+  .id == 21690216 and .name == "Restrict all ARC tag creation"
+  and .target == "tag" and .enforcement == "active"
+  and .conditions == {"ref_name":{"exclude":[],"include":["~ALL"]}}
+  and .rules == [{"type":"creation"}]
+  and .bypass_actors == [{"actor_id":111036403,"actor_type":"User",
+                          "bypass_mode":"always"}]' >/dev/null
+mutation_ruleset="$("$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/rulesets/21667203)"
+printf '%s' "$mutation_ruleset" | /usr/bin/jq -e '
+  .id == 21667203 and .name == "Protect all ARC tags from mutation"
+  and .target == "tag" and .enforcement == "active"
+  and .conditions == {"ref_name":{"exclude":[],"include":["~ALL"]}}
+  and .rules == [{"type":"update"},{"type":"deletion"},
+                 {"type":"non_fast_forward"}]
+  and .bypass_actors == []' >/dev/null
+tag_ref_push_status=0
+if [ "$remote_tag_state" = absent ]; then
+  tag_push_attempt_root="$(
+    /usr/bin/mktemp -d "$release_control_root/tag-push.XXXXXXXX"
+  )"
+  test "$(/usr/bin/stat --format='%a:%h' "$tag_push_attempt_root")" = 700:1
+  tag_push_stdout="$tag_push_attempt_root/STDOUT.txt"
+  tag_push_stderr="$tag_push_attempt_root/STDERR.txt"
+  ( umask 077
+    set -o noclobber
+    /usr/bin/env -i \
+      HOME="$git_home" PATH=/usr/bin:/bin LANG=C LC_ALL=C TZ=UTC \
+      GH_TOKEN="$GH_TOKEN" GH_PROMPT_DISABLED=1 \
+      GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
+      GIT_TERMINAL_PROMPT=0 \
+      /usr/bin/git -C "$operator_checkout" \
+        -c core.hooksPath=/dev/null \
+        -c credential.helper= \
+        -c "credential.https://github.com.helper=!$ARC_RECOVERY_GH_PATH auth git-credential" \
+        -c http.extraHeader= \
+        -c http.https://github.com/.extraHeader= \
+        -c http.sslVerify=true \
+        -c protocol.allow=never \
+        -c protocol.https.allow=always \
+        push --porcelain --atomic --no-verify \
+        --force-with-lease=refs/tags/v0.8.0: \
+        -- https://github.com/FerrumVir/arc-chain.git \
+        "$protected_main_sha:refs/tags/v0.8.0" \
+        >"$tag_push_stdout" 2>"$tag_push_stderr"
+  ) || tag_ref_push_status=$?
+fi
+remote_tag_after="$("$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/git/matching-refs/tags/v0.8.0 --jq .)"
+remote_tag_after_state="$(printf '%s' "$remote_tag_after" | /usr/bin/jq -er \
+  --arg sha "$protected_main_sha" '
+    [.[] | select(.ref == "refs/tags/v0.8.0")] as $matches
+    | if ($matches | length) == 0 then "absent"
+    elif ($matches | length) == 1
+         and $matches[0].object.type == "commit"
+         and $matches[0].object.sha == $sha then "exact"
+    else "mismatch" end')"
+case "$remote_tag_after_state" in
+  exact)
+    if [ "$tag_ref_push_status" -ne 0 ]; then
+      printf 'tag push returned %s, but the mandatory post-query proved the exact tag\n' \
+        "$tag_ref_push_status" >&2
+    fi
+    ;;
+  absent)
+    printf 'tag push did not create a remote ref; absence is proven and a fresh retry is safe\n' >&2
+    exit 1
+    ;;
+  mismatch)
+    printf 'post-create v0.8.0 remote identity differs; preserve and stop\n' >&2
+    exit 1
+    ;;
+  *) exit 1 ;;
+esac
+```
+
+Tag creation automatically starts exactly one `push` form of `release.yml`;
+that run is expected to fail in its initial validation job because a tag-push event
+cannot carry the protected handoff artifact ID and digest. Select it by
+workflow ID, path, event, branch, and exact SHA rather than copying a run ID
+from the UI. An exact existing selection is resumable; zero or multiple runs
+after the bounded discovery poll stop without moving or re-pushing the tag.
+
+```bash
+release_workflow_id="$("$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/actions/workflows/release.yml --jq .id)"
+[[ "$release_workflow_id" =~ ^[1-9][0-9]*$ ]]
+tag_push_run_candidates() {
+  "$ARC_RECOVERY_GH_PATH" api --paginate \
+    'repos/FerrumVir/arc-chain/actions/workflows/release.yml/runs?event=push&branch=v0.8.0&per_page=100' \
+    --jq '.workflow_runs[]' \
+  | /usr/bin/jq -cs --arg sha "$protected_main_sha" \
+      --argjson workflow_id "$release_workflow_id" '
+      [.[] | select(.workflow_id == $workflow_id and .head_sha == $sha
+        and .head_branch == "v0.8.0"
+        and .path == ".github/workflows/release.yml" and .event == "push")]'
+}
+tag_push_runs='[]'
+for _ in {1..30}; do
+  tag_push_runs="$(tag_push_run_candidates)"
+  tag_push_run_count="$(printf '%s' "$tag_push_runs" | /usr/bin/jq -er length)"
+  [ "$tag_push_run_count" -eq 0 ] || break
+  /usr/bin/sleep 2
+done
+test "$tag_push_run_count" -eq 1
+tag_push_run_id="$(printf '%s' "$tag_push_runs" | /usr/bin/jq -er '.[0].id')"
+tag_push_run_attempt="$(printf '%s' "$tag_push_runs" | /usr/bin/jq -er '.[0].run_attempt')"
+[[ "$tag_push_run_id" =~ ^[1-9][0-9]*$ ]]
+[[ "$tag_push_run_attempt" =~ ^[1-9][0-9]*$ ]]
+/usr/bin/jq -cnS --argjson id "$tag_push_run_id" \
+  --argjson attempt "$tag_push_run_attempt" --arg sha "$protected_main_sha" \
+  --argjson workflow_id "$release_workflow_id" \
+  '{schema:"arc.release-tag-push-run-selection.v1",repository:"FerrumVir/arc-chain",
+    workflow_id:$workflow_id,workflow_path:".github/workflows/release.yml",
+    event:"push",head_branch:"v0.8.0",head_sha:$sha,
+    run_id:$id,run_attempt:$attempt}' \
+  | write_once_or_compare "$release_control_root/TAG-PUSH-RUN-SELECTION.json"
+"$ARC_RECOVERY_GH_PATH" run watch "$tag_push_run_id" \
+  --repo FerrumVir/arc-chain --interval 10
+"$ARC_RECOVERY_GH_PATH" api \
+  "repos/FerrumVir/arc-chain/actions/runs/$tag_push_run_id" \
+  | /usr/bin/jq -e --arg sha "$protected_main_sha" --argjson id "$tag_push_run_id" \
+      --argjson attempt "$tag_push_run_attempt" --argjson workflow_id "$release_workflow_id" \
+      '.id == $id and .run_attempt == $attempt and .workflow_id == $workflow_id
+       and .head_repository.full_name == "FerrumVir/arc-chain"
+       and .head_sha == $sha and .head_branch == "v0.8.0"
+       and .path == ".github/workflows/release.yml" and .event == "push"
+       and .status == "completed" and .conclusion == "failure"' >/dev/null
+"$ARC_RECOVERY_GH_PATH" api \
+  "repos/FerrumVir/arc-chain/actions/runs/$tag_push_run_id/jobs?filter=all&per_page=100" \
+  | /usr/bin/jq -e '
+      ([.jobs[] | select(.name == "Validate release tag and pin commit"
+        and .conclusion == "failure")] | length) == 1
+      and ([.jobs[] | select(
+        (.name == "Create and upload one isolated release draft"
+         or .name == "Publish only the independently verified draft")
+        and .conclusion != "skipped")] | length) == 0' >/dev/null
+tag_push_failure_log="$(
+  "$ARC_RECOVERY_GH_PATH" run view "$tag_push_run_id" \
+    --repo FerrumVir/arc-chain --log-failed
+)"
+printf '%s\n' "$tag_push_failure_log" | /usr/bin/grep -Fq \
+  'Release requires workflow_dispatch with a positive cutover_handoff_artifact_id.'
+```
+
+Only after that automatic run has stopped and passed the negative proof above,
+select or create exactly one manual run of the same workflow definition on
+`main`. This block is resumable: an already-dispatched exact-SHA run is reused,
+and an existing release prevents a second dispatch. More than one matching run,
+or a release without its matching run, is ambiguous and stops. The create-only
+selection receipt records the run ID and attempt before any environment
+approval. Approve deployments only when GitHub shows that exact run ID and
+attempt. Do not move, delete, recreate, or re-push the tag.
+
+```bash
+release_workflow_id="$("$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/actions/workflows/release.yml --jq .id)"
+[[ "$release_workflow_id" =~ ^[1-9][0-9]*$ ]]
+release_run_candidates() {
+  "$ARC_RECOVERY_GH_PATH" api --paginate \
+    'repos/FerrumVir/arc-chain/actions/workflows/release.yml/runs?event=workflow_dispatch&branch=main&per_page=100' \
+    --jq '.workflow_runs[]' \
+  | /usr/bin/jq -cs --arg sha "$protected_main_sha" \
+      --argjson workflow_id "$release_workflow_id" '
+      [.[] | select(.workflow_id == $workflow_id and .head_sha == $sha
+        and .head_branch == "main"
+        and .path == ".github/workflows/release.yml"
+        and .event == "workflow_dispatch")]'
+}
+manual_release_runs="$(release_run_candidates)"
+manual_release_run_count="$(printf '%s' "$manual_release_runs" | /usr/bin/jq -er length)"
+existing_release_count="$(
+  "$ARC_RECOVERY_GH_PATH" api --paginate \
+    'repos/FerrumVir/arc-chain/releases?per_page=100' --jq '.[]' \
+  | /usr/bin/jq -cs '[.[] | select(.tag_name == "v0.8.0")] | length'
+)"
+case "$manual_release_run_count:$existing_release_count" in
+  0:0)
+    "$ARC_RECOVERY_GH_PATH" workflow run release.yml \
+      --repo FerrumVir/arc-chain \
+      --ref main \
+      -f tag=v0.8.0 \
+      -f cutover_handoff_artifact_id="$handoff_artifact_id" \
+      -f cutover_handoff_artifact_digest="$handoff_artifact_digest"
+    for _ in {1..30}; do
+      /usr/bin/sleep 2
+      manual_release_runs="$(release_run_candidates)"
+      manual_release_run_count="$(printf '%s' "$manual_release_runs" | /usr/bin/jq -er length)"
+      [ "$manual_release_run_count" -eq 0 ] || break
+    done
+    test "$manual_release_run_count" -eq 1
+    ;;
+  1:0|1:1)
+    printf 'reusing the one exact existing manual release run\n' >&2
+    ;;
+  0:1)
+    printf 'v0.8.0 exists without its exact manual release run; preserve and stop\n' >&2
+    exit 1
+    ;;
+  *)
+    printf 'manual release run/release selection is ambiguous; preserve and stop\n' >&2
+    exit 1
+    ;;
+esac
+release_run_id="$(printf '%s' "$manual_release_runs" | /usr/bin/jq -er '.[0].id')"
+release_run_attempt="$(printf '%s' "$manual_release_runs" | /usr/bin/jq -er '.[0].run_attempt')"
+[[ "$release_run_id" =~ ^[1-9][0-9]*$ ]]
+[[ "$release_run_attempt" =~ ^[1-9][0-9]*$ ]]
+/usr/bin/jq -cnS --argjson id "$release_run_id" \
+  --argjson attempt "$release_run_attempt" --arg sha "$protected_main_sha" \
+  --argjson workflow_id "$release_workflow_id" \
+  '{schema:"arc.release-run-selection.v1",repository:"FerrumVir/arc-chain",
+    workflow_id:$workflow_id,workflow_path:".github/workflows/release.yml",
+    event:"workflow_dispatch",head_branch:"main",head_sha:$sha,
+    run_id:$id,run_attempt:$attempt}' \
+  | write_once_or_compare "$release_control_root/RELEASE-RUN-SELECTION.json"
+printf 'Approve only release run %s attempt %s, then wait here.\n' \
+  "$release_run_id" "$release_run_attempt"
+"$ARC_RECOVERY_GH_PATH" run watch "$release_run_id" \
+  --repo FerrumVir/arc-chain --interval 10 --exit-status
+```
+
+After the watch returns success, re-read the run rather than trusting terminal
+output. Require the exact workflow/path/event/branch/SHA/attempt, every required
+matrix and publication job, and the final read-only immutable-release verifier.
+Then query the live release by tag and prove its lifecycle, target, publisher,
+and complete 32-asset name/size/digest/uploader contract. These projections are
+stored create-only so a resumed audit must reproduce the same terminal facts.
+
+```bash
+release_run_final="$release_control_root/RELEASE-RUN-FINAL.json"
+release_jobs_final="$release_control_root/RELEASE-JOBS-FINAL.json"
+release_api_final="$release_control_root/RELEASE-API-FINAL.json"
+release_run_live="$("$ARC_RECOVERY_GH_PATH" api \
+  "repos/FerrumVir/arc-chain/actions/runs/$release_run_id")"
+printf '%s' "$release_run_live" | /usr/bin/jq -e \
+  --argjson id "$release_run_id" --argjson attempt "$release_run_attempt" \
+  --argjson workflow_id "$release_workflow_id" --arg sha "$protected_main_sha" '
+  .id == $id and .run_attempt == $attempt and .workflow_id == $workflow_id
+  and .head_repository.full_name == "FerrumVir/arc-chain"
+  and .head_sha == $sha and .head_branch == "main"
+  and .path == ".github/workflows/release.yml"
+  and .event == "workflow_dispatch"
+  and .status == "completed" and .conclusion == "success"' >/dev/null
+printf '%s' "$release_run_live" | /usr/bin/jq -cS \
+  '{id,run_attempt,workflow_id,path,event,head_branch,head_sha,status,conclusion}' \
+  | write_once_or_compare "$release_run_final"
+
+required_release_jobs='[
+  "Validate release tag and pin commit",
+  "Full quality gate on validated release commit",
+  "Cargo dependency policy (workspace)",
+  "Cargo dependency policy (desktop)",
+  "Cargo dependency policy (updater-verifier)",
+  "Golden vectors (linux-x86_64)",
+  "Golden vectors (linux-arm64)",
+  "Golden vectors (macos-arm64)",
+  "Golden vectors (macos-x86_64)",
+  "Golden vectors (windows-x86_64)",
+  "Verify exact pre-tag headless linux-x86_64",
+  "Verify exact pre-tag headless linux-arm64",
+  "Verify exact pre-tag headless macos-arm64",
+  "Verify exact pre-tag headless macos-x86_64",
+  "Verify exact pre-tag headless windows-x86_64",
+  "Ubuntu server smoke (linux-x86_64)",
+  "Ubuntu server smoke (linux-arm64)",
+  "Verify exact pre-tag desktop macos-arm64",
+  "Verify exact pre-tag desktop macos-x86_64",
+  "Verify exact pre-tag desktop windows-x86_64",
+  "Verify exact pre-tag desktop linux-x86_64",
+  "Assemble the exact unsigned release manifest",
+  "Sign only the verified release manifest",
+  "Create and upload one isolated release draft",
+  "Verify GitHub draft bytes without publication authority",
+  "Publish only the independently verified draft",
+  "Verify the immutable GitHub release without publication authority"
+]'
+release_jobs_live="$("$ARC_RECOVERY_GH_PATH" api --paginate \
+  "repos/FerrumVir/arc-chain/actions/runs/$release_run_id/jobs?filter=all&per_page=100" \
+  --jq '.jobs[]' | /usr/bin/jq -cs 'sort_by(.name)')"
+printf '%s' "$release_jobs_live" | /usr/bin/jq -e \
+  --argjson required "$required_release_jobs" '
+  ([.[] | select(.status == "completed" and .conclusion == "success") | .name]
+    | sort) == ($required | sort)
+  and ([.[] | select(.name == "Delete a draft rejected by the unprivileged verifier"
+    and .status == "completed" and .conclusion == "skipped")] | length) == 1
+  and length == (($required | length) + 1)' >/dev/null
+printf '%s' "$release_jobs_live" | /usr/bin/jq -cS \
+  '[.[] | {id,name,status,conclusion}] | sort_by(.name)' \
+  | write_once_or_compare "$release_jobs_final"
+
+expected_release_assets='[
+  "arc-node-linux-x86_64","arc-cli-linux-x86_64",
+  "arc-node-linux-arm64","arc-cli-linux-arm64",
+  "arc-node-macos-arm64","arc-cli-macos-arm64",
+  "arc-node-macos-x86_64","arc-cli-macos-x86_64",
+  "arc-node-windows-x86_64.exe","arc-cli-windows-x86_64.exe",
+  "arc-desktop-macos-arm64.app.tar.gz","arc-desktop-macos-arm64.app.tar.gz.sig",
+  "arc-desktop-macos-arm64.dmg","arc-desktop-macos-x86_64.app.tar.gz",
+  "arc-desktop-macos-x86_64.app.tar.gz.sig","arc-desktop-macos-x86_64.dmg",
+  "arc-desktop-windows-x86_64-setup.exe","arc-desktop-windows-x86_64-setup.exe.sig",
+  "arc-desktop-windows-x86_64.msi","arc-desktop-linux-x86_64.AppImage",
+  "arc-desktop-linux-x86_64.AppImage.sig","arc-desktop-linux-x86_64.deb",
+  "arc-desktop-linux-x86_64.rpm","install.sh","testnet-seeds.txt","genesis.toml",
+  "arc-legacy-maintenance-boundary.json","arc-recovery-checkpoint-descriptor.json",
+  "arc-cutover-policy.json","latest.json","SHA256SUMS","SHA256SUMS.sig"
+]'
+release_api_live="$("$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/releases/tags/v0.8.0)"
+printf '%s' "$release_api_live" | /usr/bin/jq -e \
+  --arg sha "$protected_main_sha" --argjson expected "$expected_release_assets" '
+  .tag_name == "v0.8.0" and .target_commitish == $sha
+  and .draft == false and .prerelease == false and .immutable == true
+  and .author.login == "github-actions[bot]"
+  and ([.assets[].name] | sort) == ($expected | sort)
+  and ([.assets[].name] | unique | length) == 32
+  and ([.assets[].size] | add) <= 12884901888
+  and all(.assets[];
+    .state == "uploaded" and (.digest | test("^sha256:[0-9a-f]{64}$"))
+    and .uploader.login == "github-actions[bot]" and .size > 0
+    and .size <= (if .name == "arc-recovery-checkpoint-descriptor.json" then 1048576
+                  elif (.name | endswith(".sig") or endswith(".json")) then 4194304
+                  else 2147483648 end))' >/dev/null
+release_id="$(printf '%s' "$release_api_live" | /usr/bin/jq -er .id)"
+[[ "$release_id" =~ ^[1-9][0-9]*$ ]]
+printf '%s' "$release_api_live" | /usr/bin/jq -cS \
+  '{id,tag_name,target_commitish,draft,prerelease,immutable,author:.author.login,
+    assets:(.assets | map({id,name,size,digest,state,uploader:.uploader.login})
+      | sort_by(.name))}' \
+  | write_once_or_compare "$release_api_final"
+unset GH_TOKEN
+```
+
+A rejected draft
+may be deleted before publication only after re-proving its exact release ID,
+tag, target commit, `draft: true`, and `immutable: false` state. Once the
+publication PATCH has been attempted, the workflow deliberately retains the
+release on every error. If `immutable: true` is not observed within the bounded
+poll, stop and manually verify that exact release ID and the repository audit
+trail. Never delete the ambiguous or published object and never rerun the tag
+or release workflow.
 
 Keep the runtime package-mutation masks in place through the immutable tag,
 six-validator restart proof, public frontend hash proof, and installer/update
-canaries. Only after all of those gates are green, restore the operator VM's
-normal security-update schedule and prove the three enabled units are active:
+canaries. Do not unmask anything at this point; the executable post-release
+gates below come first.
+
+An air-gapped review may instead supply both `--archive-manifest` and
+`--archive-complete`; they must be canonical mode-read-only files matching the
+same finalized roots. Supplying only one fails closed. The default has no
+manual local-file handoff and still never mounts or serves Drive.
+
+### Publish the recovered frontend through one reviewed PR
+
+The output and sidecar are create-only mode `0444`. Derive a deterministic
+single-parent commit that changes only `shared/frontend/arc-network.json`,
+publish its dedicated branch with a create-only lease, and reuse only an exact
+existing branch on resume. Never push directly to `main`. The pull request must
+retain the exact head and pass every required check. Prefer an exact-head
+approval from `arisarcmarket`. If that reviewer is unavailable, the owner may
+temporarily change only the main ruleset's approval count from one to zero and
+last-push approval from true to false. That exception is allowed only from the
+sealed exact policy snapshot, is recorded, and is guarded by an EXIT/signal
+restoration trap; it never disables checks, thread resolution, linear history,
+or any tag rule. A leftover exact exception is restored before a retry, while
+any third policy state stops without mutation. Merge by squash, as required by
+the live linear-history rule. The resulting `main` commit must have the release
+source as its sole parent and exactly the reviewed frontend tree and bytes.
+Finally re-prove the protected tag and the canonical ruleset snapshot hash.
+
+```bash
+test "$(arc_sha256 "$frontend_config")" = \
+  "$(/usr/bin/awk '{print $1}' "$frontend_config.sha256")"
+test "$("$ARC_RECOVERY_GH_PATH" api repos/FerrumVir/arc-chain/branches/main \
+  --jq .commit.sha)" = "$protected_main_sha"
+test "$("$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/git/ref/tags/v0.8.0 --jq .object.sha)" = \
+  "$protected_main_sha"
+
+repository_ruleset_snapshot() {
+  local ruleset_ids id
+  ruleset_ids="$("$ARC_RECOVERY_GH_PATH" api --paginate \
+    'repos/FerrumVir/arc-chain/rulesets?includes_parents=true&per_page=100' \
+    --jq '.[].id' | /usr/bin/sort -n)"
+  while IFS= read -r id; do
+    [[ "$id" =~ ^[1-9][0-9]*$ ]]
+    "$ARC_RECOVERY_GH_PATH" api "repos/FerrumVir/arc-chain/rulesets/$id" \
+      | /usr/bin/jq -cS \
+          '{id,name,target,source,source_type,enforcement,bypass_actors,conditions,rules}'
+  done <<< "$ruleset_ids" | /usr/bin/jq -csS 'sort_by(.id)'
+}
+rulesets_before_frontend="$(repository_ruleset_snapshot)"
+test "$(printf '%s' "$rulesets_before_frontend" | /usr/bin/jq -er length)" -gt 0
+
+frontend_branch='arc-recovery/frontend-v0.8.0'
+frontend_index="$(/usr/bin/mktemp "$release_control_root/frontend-index.XXXXXXXX")"
+/usr/bin/rm -f -- "$frontend_index"
+arc_index_git() {
+  /usr/bin/env -i HOME="$git_home" PATH=/usr/bin:/bin LANG=C LC_ALL=C \
+    GIT_CONFIG_NOSYSTEM=1 GIT_INDEX_FILE="$frontend_index" \
+    /usr/bin/git -C "$operator_checkout" "$@"
+}
+arc_index_git read-tree "$protected_main_sha^{tree}"
+frontend_blob_sha="$(arc_git -C "$operator_checkout" hash-object -w -- "$frontend_config")"
+[[ "$frontend_blob_sha" =~ ^[0-9a-f]{40}$ ]]
+arc_index_git update-index --add --cacheinfo 100644 "$frontend_blob_sha" \
+  shared/frontend/arc-network.json
+frontend_tree_sha="$(arc_index_git write-tree)"
+frontend_parent_date="$(arc_git -C "$operator_checkout" show -s --format=%cI \
+  "$protected_main_sha")"
+frontend_commit_sha="$(
+  /usr/bin/printf '%s\n' 'Publish verified ARC v0.8 recovery frontend' \
+  | /usr/bin/env -i HOME="$git_home" PATH=/usr/bin:/bin LANG=C LC_ALL=C TZ=UTC \
+      GIT_CONFIG_NOSYSTEM=1 GIT_AUTHOR_NAME=FerrumVir \
+      GIT_AUTHOR_EMAIL=111036403+FerrumVir@users.noreply.github.com \
+      GIT_AUTHOR_DATE="$frontend_parent_date" GIT_COMMITTER_NAME=FerrumVir \
+      GIT_COMMITTER_EMAIL=111036403+FerrumVir@users.noreply.github.com \
+      GIT_COMMITTER_DATE="$frontend_parent_date" \
+      /usr/bin/git -C "$operator_checkout" -c commit.gpgSign=false \
+        commit-tree "$frontend_tree_sha" -p "$protected_main_sha"
+)"
+/usr/bin/rm -f -- "$frontend_index"
+[[ "$frontend_commit_sha" =~ ^[0-9a-f]{40}$ ]]
+test "$(arc_git -C "$operator_checkout" rev-list --parents -n 1 \
+  "$frontend_commit_sha")" = "$frontend_commit_sha $protected_main_sha"
+test "$(arc_git -C "$operator_checkout" diff-tree --no-commit-id --name-only -r \
+  "$frontend_commit_sha")" = shared/frontend/arc-network.json
+arc_git -C "$operator_checkout" show \
+  "$frontend_commit_sha:shared/frontend/arc-network.json" \
+  | /usr/bin/cmp -s - "$frontend_config"
+
+frontend_remote_refs="$("$ARC_RECOVERY_GH_PATH" api \
+  'repos/FerrumVir/arc-chain/git/matching-refs/heads/arc-recovery/frontend/v0.8.0' \
+  --jq .)"
+frontend_remote_state="$(printf '%s' "$frontend_remote_refs" | /usr/bin/jq -er \
+  --arg sha "$frontend_commit_sha" --arg ref "refs/heads/$frontend_branch" '
+  [.[] | select(.ref == $ref)] as $matches
+  | if ($matches | length) == 0 then "absent"
+    elif ($matches | length) == 1 and $matches[0].object.type == "commit"
+         and $matches[0].object.sha == $sha then "exact"
+    else "mismatch" end')"
+case "$frontend_remote_state" in
+  absent)
+    frontend_git_token="$("$ARC_RECOVERY_GH_PATH" auth token \
+      --hostname github.com --user "$ARC_RECOVERY_GITHUB_LOGIN")"
+    test -n "$frontend_git_token"
+    frontend_push_attempt_root="$(
+      /usr/bin/mktemp -d "$release_control_root/frontend-push.XXXXXXXX"
+    )"
+    test "$(/usr/bin/stat --format='%a:%h' "$frontend_push_attempt_root")" = 700:1
+    frontend_push_status=0
+    ( umask 077
+      set -o noclobber
+      /usr/bin/env -i HOME="$git_home" PATH=/usr/bin:/bin LANG=C LC_ALL=C TZ=UTC \
+        GH_TOKEN="$frontend_git_token" GH_PROMPT_DISABLED=1 \
+        GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_TERMINAL_PROMPT=0 \
+        /usr/bin/git -C "$operator_checkout" -c core.hooksPath=/dev/null \
+          -c credential.helper= \
+          -c "credential.https://github.com.helper=!$ARC_RECOVERY_GH_PATH auth git-credential" \
+          -c http.extraHeader= -c http.https://github.com/.extraHeader= \
+          -c http.sslVerify=true \
+          -c protocol.allow=never -c protocol.https.allow=always \
+          push --porcelain --atomic --no-verify \
+          --force-with-lease="refs/heads/$frontend_branch:" \
+          -- https://github.com/FerrumVir/arc-chain.git \
+          "$frontend_commit_sha:refs/heads/$frontend_branch" \
+          >"$frontend_push_attempt_root/STDOUT.txt" \
+          2>"$frontend_push_attempt_root/STDERR.txt"
+    ) || frontend_push_status=$?
+    unset frontend_git_token
+    ;;
+  exact) frontend_push_status=0 ;;
+  *) printf 'frontend branch exists at another identity; preserve and stop\n' >&2; exit 1 ;;
+esac
+frontend_remote_after="$("$ARC_RECOVERY_GH_PATH" api \
+  'repos/FerrumVir/arc-chain/git/matching-refs/heads/arc-recovery/frontend/v0.8.0' \
+  --jq .)"
+printf '%s' "$frontend_remote_after" | /usr/bin/jq -e \
+  --arg sha "$frontend_commit_sha" --arg ref "refs/heads/$frontend_branch" '
+  [.[] | select(.ref == $ref and .object.type == "commit" and .object.sha == $sha)]
+  | length == 1' >/dev/null
+if [ "$frontend_push_status" -ne 0 ]; then
+  printf 'branch push returned %s, but the post-query proved the exact branch\n' \
+    "$frontend_push_status" >&2
+fi
+
+frontend_pr_title='Publish verified ARC v0.8 recovery frontend'
+frontend_pr_body='Publishes only the create-only, rollout-derived recovered frontend configuration after immutable v0.8.0 verification.'
+frontend_prs="$("$ARC_RECOVERY_GH_PATH" api --method GET \
+  repos/FerrumVir/arc-chain/pulls -f state=all \
+  -f head="FerrumVir:$frontend_branch" -f base=main \
+  | /usr/bin/jq -c --arg sha "$frontend_commit_sha" \
+      '[.[] | select(.head.sha == $sha and .head.ref == "arc-recovery/frontend-v0.8.0"
+        and .base.ref == "main")]')"
+frontend_pr_count="$(printf '%s' "$frontend_prs" | /usr/bin/jq -er length)"
+case "$frontend_pr_count" in
+  0)
+    test "$("$ARC_RECOVERY_GH_PATH" api repos/FerrumVir/arc-chain/branches/main \
+      --jq .commit.sha)" = "$protected_main_sha"
+    "$ARC_RECOVERY_GH_PATH" api --method POST repos/FerrumVir/arc-chain/pulls \
+      -f title="$frontend_pr_title" -f head="$frontend_branch" -f base=main \
+      -f body="$frontend_pr_body" -F draft=false >/dev/null
+    ;;
+  1) ;;
+  *) printf 'frontend pull-request selection is ambiguous; preserve and stop\n' >&2; exit 1 ;;
+esac
+frontend_prs="$("$ARC_RECOVERY_GH_PATH" api --method GET \
+  repos/FerrumVir/arc-chain/pulls -f state=all \
+  -f head="FerrumVir:$frontend_branch" -f base=main \
+  | /usr/bin/jq -c --arg sha "$frontend_commit_sha" \
+      '[.[] | select(.head.sha == $sha and .head.ref == "arc-recovery/frontend-v0.8.0"
+        and .base.ref == "main")]')"
+test "$(printf '%s' "$frontend_prs" | /usr/bin/jq -er length)" -eq 1
+frontend_pr_number="$(printf '%s' "$frontend_prs" | /usr/bin/jq -er '.[0].number')"
+[[ "$frontend_pr_number" =~ ^[1-9][0-9]*$ ]]
+frontend_main_ruleset_id=21689753
+frontend_main_ruleset_policy() {
+  "$ARC_RECOVERY_GH_PATH" api \
+    "repos/FerrumVir/arc-chain/rulesets/$frontend_main_ruleset_id" \
+    | /usr/bin/jq -cS \
+        '{id,name,target,source,source_type,enforcement,bypass_actors,conditions,rules}'
+}
+frontend_main_ruleset_put() {
+  printf '%s' "$1" | /usr/bin/jq -cS \
+    '{name,target,enforcement,bypass_actors,conditions,rules}' \
+    | "$ARC_RECOVERY_GH_PATH" api --method PUT \
+        "repos/FerrumVir/arc-chain/rulesets/$frontend_main_ruleset_id" \
+        --input - >/dev/null
+}
+frontend_ruleset_baseline_receipt="$release_control_root/FRONTEND-MAIN-RULESET-BASELINE.json"
+if [ ! -e "$frontend_ruleset_baseline_receipt" ]; then
+  frontend_main_ruleset_policy | write_once_or_compare \
+    "$frontend_ruleset_baseline_receipt"
+fi
+test -f "$frontend_ruleset_baseline_receipt" \
+  && test ! -L "$frontend_ruleset_baseline_receipt"
+test "$(/usr/bin/stat --format='%a:%h' "$frontend_ruleset_baseline_receipt")" = 400:1
+frontend_ruleset_baseline="$(/usr/bin/jq -cS . "$frontend_ruleset_baseline_receipt")"
+printf '%s' "$frontend_ruleset_baseline" | /usr/bin/jq -e \
+  --argjson id "$frontend_main_ruleset_id" '
+  .id == $id and .name == "Protect ARC main release path"
+  and .target == "branch" and .source == "FerrumVir/arc-chain"
+  and .source_type == "Repository" and .enforcement == "active"
+  and .bypass_actors == []
+  and .conditions == {"ref_name":{"exclude":[],"include":["refs/heads/main"]}}
+  and ([.rules[] | select(.type == "required_linear_history")] | length) == 1
+  and ([.rules[] | select(.type == "pull_request"
+    and .parameters.required_approving_review_count == 1
+    and .parameters.require_last_push_approval == true
+    and .parameters.dismiss_stale_reviews_on_push == true
+    and .parameters.require_extra_approval_for_unattributed_changes == true
+    and .parameters.required_review_thread_resolution == true
+    and (.parameters.allowed_merge_methods | sort) == ["rebase","squash"])]
+    | length) == 1
+  and ([.rules[] | select(.type == "required_status_checks"
+    and .parameters.strict_required_status_checks_policy == true
+    and (.parameters.required_status_checks | length) > 0)] | length) == 1' >/dev/null
+frontend_ruleset_exception="$(printf '%s' "$frontend_ruleset_baseline" \
+  | /usr/bin/jq -cS '
+      .rules |= map(if .type == "pull_request" then
+        .parameters.required_approving_review_count = 0
+        | .parameters.require_last_push_approval = false
+      else . end)')"
+frontend_ruleset_current="$(frontend_main_ruleset_policy)"
+case "$frontend_ruleset_current" in
+  "$frontend_ruleset_baseline") ;;
+  "$frontend_ruleset_exception")
+    printf 'restoring an exact interrupted frontend ruleset exception before retry\n' >&2
+    frontend_main_ruleset_put "$frontend_ruleset_baseline"
+    test "$(frontend_main_ruleset_policy)" = "$frontend_ruleset_baseline"
+    ;;
+  *)
+    printf 'main ruleset differs from both sealed baseline and exact exception; preserve and stop\n' >&2
+    exit 1
+    ;;
+esac
+test "$(printf '%s' "$rulesets_before_frontend" | /usr/bin/jq -cS \
+  --argjson id "$frontend_main_ruleset_id" '.[] | select(.id == $id)')" = \
+  "$frontend_ruleset_baseline"
+frontend_ruleset_baseline_sha="$(arc_sha256 "$frontend_ruleset_baseline_receipt")"
+[[ "$frontend_ruleset_baseline_sha" =~ ^[0-9a-f]{64}$ ]]
+frontend_ruleset_exception_active=false
+restore_frontend_main_ruleset() {
+  local current
+  current="$(frontend_main_ruleset_policy)" || return 1
+  case "$current" in
+    "$frontend_ruleset_baseline") ;;
+    "$frontend_ruleset_exception")
+      frontend_main_ruleset_put "$frontend_ruleset_baseline" || return 1
+      test "$(frontend_main_ruleset_policy)" = "$frontend_ruleset_baseline" || return 1
+      ;;
+    *)
+      printf 'main ruleset changed concurrently; refusing to overwrite it during restore\n' >&2
+      return 1
+      ;;
+  esac
+  frontend_ruleset_exception_active=false
+}
+frontend_restore_on_exit() {
+  local status=$?
+  trap - EXIT HUP INT TERM
+  if [ "$frontend_ruleset_exception_active" = true ]; then
+    restore_frontend_main_ruleset || status=1
+  fi
+  exit "$status"
+}
+trap frontend_restore_on_exit EXIT
+trap 'exit 130' HUP INT TERM
+
+frontend_pr_state="$(printf '%s' "$frontend_prs" | /usr/bin/jq -er '.[0].state')"
+frontend_review_authorization="$release_control_root/FRONTEND-REVIEW-AUTHORIZATION.json"
+case "$frontend_pr_state" in
+  open)
+    "$ARC_RECOVERY_GH_PATH" pr checks "$frontend_pr_number" \
+      --repo FerrumVir/arc-chain --required --watch --interval 10
+    frontend_pr_view="$("$ARC_RECOVERY_GH_PATH" pr view "$frontend_pr_number" \
+      --repo FerrumVir/arc-chain --json state,headRefOid,baseRefOid,reviewDecision)"
+    printf '%s' "$frontend_pr_view" | /usr/bin/jq -e \
+      --arg head "$frontend_commit_sha" --arg base "$protected_main_sha" '
+      .state == "OPEN" and .headRefOid == $head and .baseRefOid == $base
+      and .reviewDecision != "CHANGES_REQUESTED"' >/dev/null
+    frontend_aris_approval_count="$(
+      "$ARC_RECOVERY_GH_PATH" api --paginate \
+        "repos/FerrumVir/arc-chain/pulls/$frontend_pr_number/reviews?per_page=100" \
+        --jq '.[]' \
+      | /usr/bin/jq -cs --arg head "$frontend_commit_sha" '
+          [.[] | select(.user.login == "arisarcmarket" and .state == "APPROVED"
+            and .commit_id == $head)] | length'
+    )"
+    if [ ! -e "$frontend_review_authorization" ]; then
+      if [ "$(printf '%s' "$frontend_pr_view" | /usr/bin/jq -r .reviewDecision)" = APPROVED ] \
+          && [ "$frontend_aris_approval_count" -ge 1 ]; then
+        frontend_review_mode=arisarcmarket-approval
+      else
+        frontend_review_mode=temporary-ruleset-exception
+      fi
+      /usr/bin/jq -cnS --argjson pr "$frontend_pr_number" \
+        --arg head "$frontend_commit_sha" --arg base "$protected_main_sha" \
+        --arg mode "$frontend_review_mode" \
+        --arg baseline_sha "$frontend_ruleset_baseline_sha" \
+        '{schema:"arc.frontend-review-authorization.v1",pull_request:$pr,
+          head_commit:$head,base_commit:$base,mode:$mode,
+          reviewer:(if $mode == "arisarcmarket-approval" then "arisarcmarket" else null end),
+          main_ruleset_id:21689753,main_ruleset_baseline_sha256:$baseline_sha}' \
+        | write_once_or_compare "$frontend_review_authorization"
+    fi
+    frontend_review_mode="$(/usr/bin/jq -er \
+      --argjson pr "$frontend_pr_number" --arg head "$frontend_commit_sha" \
+      --arg base "$protected_main_sha" --arg baseline_sha "$frontend_ruleset_baseline_sha" '
+      select(.schema == "arc.frontend-review-authorization.v1"
+        and .pull_request == $pr and .head_commit == $head and .base_commit == $base
+        and .main_ruleset_id == 21689753
+        and .main_ruleset_baseline_sha256 == $baseline_sha
+        and (.mode == "arisarcmarket-approval"
+          or .mode == "temporary-ruleset-exception")) | .mode' \
+      "$frontend_review_authorization")"
+    case "$frontend_review_mode" in
+      arisarcmarket-approval)
+        test "$(printf '%s' "$frontend_pr_view" | /usr/bin/jq -r .reviewDecision)" = APPROVED
+        test "$frontend_aris_approval_count" -ge 1
+        ;;
+      temporary-ruleset-exception)
+        frontend_ruleset_exception_active=true
+        frontend_main_ruleset_put "$frontend_ruleset_exception"
+        test "$(frontend_main_ruleset_policy)" = "$frontend_ruleset_exception"
+        ;;
+      *) exit 1 ;;
+    esac
+    test "$("$ARC_RECOVERY_GH_PATH" api repos/FerrumVir/arc-chain/branches/main \
+      --jq .commit.sha)" = "$protected_main_sha"
+    "$ARC_RECOVERY_GH_PATH" api --method PUT \
+      "repos/FerrumVir/arc-chain/pulls/$frontend_pr_number/merge" \
+      -f commit_title="$frontend_pr_title" -f merge_method=squash \
+      -f sha="$frontend_commit_sha" \
+      | /usr/bin/jq -e '.merged == true and (.sha | test("^[0-9a-f]{40}$"))' >/dev/null
+    restore_frontend_main_ruleset
+    ;;
+  closed)
+    printf '%s' "$frontend_prs" | /usr/bin/jq -e '.[0].merged_at != null' >/dev/null
+    test -f "$frontend_review_authorization" && test ! -L "$frontend_review_authorization"
+    frontend_review_mode="$(/usr/bin/jq -er \
+      --argjson pr "$frontend_pr_number" --arg head "$frontend_commit_sha" \
+      --arg base "$protected_main_sha" --arg baseline_sha "$frontend_ruleset_baseline_sha" '
+      select(.schema == "arc.frontend-review-authorization.v1"
+        and .pull_request == $pr and .head_commit == $head and .base_commit == $base
+        and .main_ruleset_id == 21689753
+        and .main_ruleset_baseline_sha256 == $baseline_sha
+        and (.mode == "arisarcmarket-approval"
+          or .mode == "temporary-ruleset-exception")) | .mode' \
+      "$frontend_review_authorization")"
+    ;;
+  *) exit 1 ;;
+esac
+restore_frontend_main_ruleset
+trap - EXIT HUP INT TERM
+frontend_pr_live="$("$ARC_RECOVERY_GH_PATH" api \
+  "repos/FerrumVir/arc-chain/pulls/$frontend_pr_number")"
+printf '%s' "$frontend_pr_live" | /usr/bin/jq -e --arg head "$frontend_commit_sha" '
+  .state == "closed" and .merged == true and .head.sha == $head
+  and .base.ref == "main" and (.merge_commit_sha | test("^[0-9a-f]{40}$"))' >/dev/null
+frontend_main_sha="$(printf '%s' "$frontend_pr_live" | /usr/bin/jq -er .merge_commit_sha)"
+arc_git -C "$operator_checkout" fetch --no-tags origin "$frontend_main_sha"
+test "$(arc_git -C "$operator_checkout" rev-list --parents -n 1 \
+  "$frontend_main_sha")" = "$frontend_main_sha $protected_main_sha"
+test "$(arc_git -C "$operator_checkout" rev-parse "$frontend_main_sha^{tree}")" = \
+  "$frontend_tree_sha"
+test "$(arc_git -C "$operator_checkout" diff --name-only \
+  "$protected_main_sha" "$frontend_main_sha")" = shared/frontend/arc-network.json
+arc_git -C "$operator_checkout" show \
+  "$frontend_main_sha:shared/frontend/arc-network.json" \
+  | /usr/bin/cmp -s - "$frontend_config"
+test "$("$ARC_RECOVERY_GH_PATH" api repos/FerrumVir/arc-chain/branches/main \
+  --jq .commit.sha)" = "$frontend_main_sha"
+test "$("$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/git/ref/tags/v0.8.0 --jq .object.sha)" = \
+  "$protected_main_sha"
+rulesets_after_frontend="$(repository_ruleset_snapshot)"
+test "$rulesets_after_frontend" = "$rulesets_before_frontend"
+test "$(frontend_main_ruleset_policy)" = "$frontend_ruleset_baseline"
+frontend_ruleset_exception_used=false
+if [ "$frontend_review_mode" = temporary-ruleset-exception ]; then
+  frontend_ruleset_exception_used=true
+fi
+/usr/bin/jq -cnS --arg branch "$frontend_branch" --arg commit "$frontend_commit_sha" \
+  --argjson pr "$frontend_pr_number" --arg merge "$frontend_main_sha" \
+  --arg source "$protected_main_sha" --arg config_sha "$(arc_sha256 "$frontend_config")" \
+  --arg review_mode "$frontend_review_mode" \
+  --argjson ruleset_exception_used "$frontend_ruleset_exception_used" \
+  --arg ruleset_baseline_sha "$frontend_ruleset_baseline_sha" \
+  '{schema:"arc.frontend-merge-receipt.v1",branch:$branch,source_commit:$source,
+    frontend_commit:$commit,pull_request:$pr,merge_commit:$merge,
+    merge_method:"squash",review_authorization:$review_mode,
+    temporary_ruleset_exception_used:$ruleset_exception_used,
+    main_ruleset_baseline_sha256:$ruleset_baseline_sha,
+    config_sha256:$config_sha,changed_paths:["shared/frontend/arc-network.json"]}' \
+  | write_once_or_compare "$release_control_root/FRONTEND-MERGE.json"
+```
+
+Rollback, if a later Pages or live gate fails, is a new reviewed PR that reverts
+only this config change and then repeats the same Pages run and deployed-byte
+proof. It restores maintenance without moving `v0.8.0`, rolling back or
+renumbering canonical blocks, or deleting any archive. A fork view is always
+explicitly selected and provenance-verified; it is never canonical or a reward
+source.
+
+### Prove the exact Pages deployment and every advertised archive provenance
+
+The merge uniquely triggers `deploy-explorer.yml`. Select its `push` run by
+workflow/path/event/main/SHA, never by the most recent run. Reuse one exact run
+on resume, wait for terminal success, require both named jobs, then bind one
+successful `github-pages` deployment to that merge. The CDN check polls only
+for convergence and accepts only the exact merged config bytes and
+`deployed-commit.txt`; it also verifies those bytes against the deployed site
+manifest. Every advertised legacy-fork provenance URL is fetched again and
+compared field-for-field with its immutable config commitments.
+
+```bash
+post_release_attempt_root="$(
+  /usr/bin/mktemp -d "$release_control_root/post-release.XXXXXXXX"
+)"
+test "$(/usr/bin/stat --format='%a:%h' "$post_release_attempt_root")" = 700:1
+pages_workflow_id="$("$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/actions/workflows/deploy-explorer.yml --jq .id)"
+[[ "$pages_workflow_id" =~ ^[1-9][0-9]*$ ]]
+pages_run_candidates() {
+  "$ARC_RECOVERY_GH_PATH" api --paginate \
+    'repos/FerrumVir/arc-chain/actions/workflows/deploy-explorer.yml/runs?event=push&branch=main&per_page=100' \
+    --jq '.workflow_runs[]' \
+  | /usr/bin/jq -cs --arg sha "$frontend_main_sha" \
+      --argjson workflow_id "$pages_workflow_id" '
+      [.[] | select(.workflow_id == $workflow_id and .head_sha == $sha
+        and .head_branch == "main"
+        and .path == ".github/workflows/deploy-explorer.yml"
+        and .event == "push")]'
+}
+pages_runs='[]'
+for _ in {1..30}; do
+  pages_runs="$(pages_run_candidates)"
+  pages_run_count="$(printf '%s' "$pages_runs" | /usr/bin/jq -er length)"
+  [ "$pages_run_count" -eq 0 ] || break
+  /usr/bin/sleep 2
+done
+test "$pages_run_count" -eq 1
+pages_run_id="$(printf '%s' "$pages_runs" | /usr/bin/jq -er '.[0].id')"
+pages_run_attempt="$(printf '%s' "$pages_runs" | /usr/bin/jq -er '.[0].run_attempt')"
+[[ "$pages_run_id" =~ ^[1-9][0-9]*$ ]]
+[[ "$pages_run_attempt" =~ ^[1-9][0-9]*$ ]]
+/usr/bin/jq -cnS --argjson id "$pages_run_id" --argjson attempt "$pages_run_attempt" \
+  --arg sha "$frontend_main_sha" --argjson workflow_id "$pages_workflow_id" \
+  '{schema:"arc.pages-run-selection.v1",repository:"FerrumVir/arc-chain",
+    workflow_id:$workflow_id,workflow_path:".github/workflows/deploy-explorer.yml",
+    event:"push",head_branch:"main",head_sha:$sha,run_id:$id,run_attempt:$attempt}' \
+  | write_once_or_compare "$release_control_root/PAGES-RUN-SELECTION.json"
+"$ARC_RECOVERY_GH_PATH" run watch "$pages_run_id" \
+  --repo FerrumVir/arc-chain --interval 10 --exit-status
+pages_run_live="$("$ARC_RECOVERY_GH_PATH" api \
+  "repos/FerrumVir/arc-chain/actions/runs/$pages_run_id")"
+printf '%s' "$pages_run_live" | /usr/bin/jq -e \
+  --argjson id "$pages_run_id" --argjson attempt "$pages_run_attempt" \
+  --argjson workflow_id "$pages_workflow_id" --arg sha "$frontend_main_sha" '
+  .id == $id and .run_attempt == $attempt and .workflow_id == $workflow_id
+  and .head_repository.full_name == "FerrumVir/arc-chain"
+  and .head_sha == $sha and .head_branch == "main"
+  and .path == ".github/workflows/deploy-explorer.yml" and .event == "push"
+  and .status == "completed" and .conclusion == "success"' >/dev/null
+pages_jobs_live="$("$ARC_RECOVERY_GH_PATH" api --paginate \
+  "repos/FerrumVir/arc-chain/actions/runs/$pages_run_id/jobs?filter=all&per_page=100" \
+  --jq '.jobs[]' | /usr/bin/jq -cs 'sort_by(.name)')"
+printf '%s' "$pages_jobs_live" | /usr/bin/jq -e '
+  length == 2
+  and ([.[] | select(.name == "Verify and assemble public console"
+    and .status == "completed" and .conclusion == "success")] | length) == 1
+  and ([.[] | select(.name == "Publish GitHub Pages"
+    and .status == "completed" and .conclusion == "success")] | length) == 1' >/dev/null
+printf '%s' "$pages_run_live" > "$post_release_attempt_root/pages-run.json"
+printf '%s' "$pages_jobs_live" > "$post_release_attempt_root/pages-jobs.json"
+
+pages_api_live="$("$ARC_RECOVERY_GH_PATH" api repos/FerrumVir/arc-chain/pages)"
+printf '%s' "$pages_api_live" | /usr/bin/jq -e '
+  .build_type == "workflow"
+  and (.html_url | test("^https://[A-Za-z0-9.-]+(?:/[A-Za-z0-9._~/-]*)?/$"))' >/dev/null
+pages_url="$(printf '%s' "$pages_api_live" | /usr/bin/jq -er '.html_url | rtrimstr("/")')"
+pages_deployments="$("$ARC_RECOVERY_GH_PATH" api --method GET \
+  repos/FerrumVir/arc-chain/deployments -f sha="$frontend_main_sha" \
+  -f environment=github-pages -f per_page=100 \
+  | /usr/bin/jq -c --arg sha "$frontend_main_sha" '
+      [.[] | select(.sha == $sha and .ref == "main"
+        and .environment == "github-pages" and .task == "deploy")]')"
+test "$(printf '%s' "$pages_deployments" | /usr/bin/jq -er length)" -eq 1
+pages_deployment_id="$(printf '%s' "$pages_deployments" | /usr/bin/jq -er '.[0].id')"
+[[ "$pages_deployment_id" =~ ^[1-9][0-9]*$ ]]
+pages_deployment_statuses="$("$ARC_RECOVERY_GH_PATH" api \
+  "repos/FerrumVir/arc-chain/deployments/$pages_deployment_id/statuses?per_page=100")"
+printf '%s' "$pages_deployment_statuses" | /usr/bin/jq -e \
+  --arg url "$pages_url" '
+  [.[] | select(.state == "success" and .environment == "github-pages"
+    and ((.environment_url | rtrimstr("/")) == $url))] | length == 1' >/dev/null
+printf '%s' "$pages_api_live" > "$post_release_attempt_root/pages-api.json"
+printf '%s' "$pages_deployments" > "$post_release_attempt_root/pages-deployments.json"
+printf '%s' "$pages_deployment_statuses" > "$post_release_attempt_root/pages-statuses.json"
+
+deployed_config="$post_release_attempt_root/arc-network.json"
+deployed_commit="$post_release_attempt_root/deployed-commit.txt"
+deployed_sums="$post_release_attempt_root/SHA256SUMS"
+pages_bytes_match=false
+for _ in {1..12}; do
+  /usr/bin/curl --fail --silent --show-error --location \
+    --proto '=https' --proto-redir '=https' --tlsv1.2 --max-time 30 \
+    --max-filesize 4194304 \
+    "$pages_url/shared/frontend/arc-network.json?commit=$frontend_main_sha" \
+    -o "$deployed_config.tmp"
+  /usr/bin/curl --fail --silent --show-error --location \
+    --proto '=https' --proto-redir '=https' --tlsv1.2 --max-time 30 \
+    --max-filesize 1024 \
+    "$pages_url/deployed-commit.txt?commit=$frontend_main_sha" \
+    -o "$deployed_commit.tmp"
+  if /usr/bin/cmp -s "$deployed_config.tmp" "$frontend_config" \
+     && test "$(/usr/bin/tr -d '\r\n' < "$deployed_commit.tmp")" = "$frontend_main_sha"; then
+    /usr/bin/mv -- "$deployed_config.tmp" "$deployed_config"
+    /usr/bin/mv -- "$deployed_commit.tmp" "$deployed_commit"
+    pages_bytes_match=true
+    break
+  fi
+  /usr/bin/rm -f -- "$deployed_config.tmp" "$deployed_commit.tmp"
+  /usr/bin/sleep 5
+done
+test "$pages_bytes_match" = true
+/usr/bin/curl --fail --silent --show-error --location \
+  --proto '=https' --proto-redir '=https' --tlsv1.2 --max-time 30 \
+  --max-filesize 1048576 "$pages_url/SHA256SUMS?commit=$frontend_main_sha" \
+  -o "$deployed_sums"
+test "$(/usr/bin/awk '$2 == "./shared/frontend/arc-network.json" {print $1}' \
+  "$deployed_sums")" = "$(arc_sha256 "$frontend_config")"
+test "$(/usr/bin/awk '$2 == "./deployed-commit.txt" {print $1}' \
+  "$deployed_sums")" = "$(arc_sha256 "$deployed_commit")"
+/usr/bin/chmod 0400 "$deployed_config" "$deployed_commit" "$deployed_sums" \
+  "$post_release_attempt_root"/*.json
+
+legacy_provenance_count=0
+while IFS= read -r archive_source; do
+  legacy_provenance_count=$((legacy_provenance_count + 1))
+  archive_node="$(printf '%s' "$archive_source" | /usr/bin/jq -er '.archive.node')"
+  [[ "$archive_node" =~ ^[a-z0-9][a-z0-9-]{0,62}$ ]]
+  archive_url="$(printf '%s' "$archive_source" | /usr/bin/jq -er \
+    '(.baseUrl | rtrimstr("/")) + .archive.provenancePath')"
+  archive_response="$post_release_attempt_root/provenance-$archive_node.json"
+  /usr/bin/curl --fail --silent --show-error --location \
+    --proto '=https' --proto-redir '=https' --tlsv1.2 --max-time 30 \
+    --max-filesize 1048576 "$archive_url" -o "$archive_response"
+  printf '%s' "$archive_source" | /usr/bin/jq -e \
+    --slurpfile actual "$archive_response" '
+    .archive as $a | $actual[0] == {
+      schema:"arc.legacy-archive.query.v1",read_only:true,
+      classification:$a.classification,capture_id:$a.captureId,node:$a.node,
+      rollout_manifest_sha256:$a.rolloutManifestSha256,
+      archive_manifest_sha256:$a.archiveManifestSha256,
+      complete_sha256:$a.completeSha256,bundle_sha256:$a.bundleSha256,
+      inventory_sha256:$a.inventorySha256,
+      binding_index_sha256:$a.bindingIndexSha256,binding_sha256:$a.bindingSha256,
+      checkpoint_sha256:$a.checkpointSha256,
+      checkpoint_manifest_hash:$a.checkpointManifestHash,
+      checkpoint_payload_hash:$a.checkpointPayloadHash,
+      canonical_checkpoint_height:$a.canonicalCheckpointHeight,
+      source_height:$a.sourceHeight,source_block_hash:$a.sourceBlockHash,
+      source_state_root:$a.sourceStateRoot}' >/dev/null
+  /usr/bin/chmod 0400 "$archive_response"
+done < <(/usr/bin/jq -c '.sources[] | select(.kind == "legacy-fork")' "$deployed_config")
+test "$legacy_provenance_count" = \
+  "$(/usr/bin/jq '[.sources[] | select(.kind == "legacy-fork")] | length' \
+    "$deployed_config")"
+```
+
+### Run published installer/update and live inference/reward acceptance gates
+
+Use a fresh, no-service install root on the reviewed Linux x86_64 operator.
+The bootstrap is downloaded from the exact immutable release and matched to
+the API digest already sealed above. A partial canary root without its final
+receipt is preserved and stops; a completed exact root is read-only verified
+and reused. The update-only pass must resolve the public channel back to
+v0.8.0 and report equality without replacement. Finally, rerun the rollout's
+read-only live verifier against the immutable two-canary reward evidence. This
+does not issue a third reward: it re-proves all-six convergence, inference
+attestations, the two mined `0x25` receipts, exact 5 ARC delta, and honest
+projection state from the existing evidence.
+
+```bash
+installer_canary_root="$release_control_root/installer-canary-linux-x86_64"
+installer_canary_receipt="$installer_canary_root/ACCEPTED.json"
+release_api_canary="$("$ARC_RECOVERY_GH_PATH" api \
+  repos/FerrumVir/arc-chain/releases/tags/v0.8.0)"
+printf '%s' "$release_api_canary" | /usr/bin/jq -e \
+  --argjson release_id "$release_id" --arg sha "$protected_main_sha" '
+  .id == $release_id and .tag_name == "v0.8.0" and .target_commitish == $sha
+  and .draft == false and .prerelease == false and .immutable == true' >/dev/null
+installer_expected_digest="$(printf '%s' "$release_api_canary" | /usr/bin/jq -er \
+  '.assets[] | select(.name == "install.sh") | .digest | sub("^sha256:"; "")')"
+node_expected_digest="$(printf '%s' "$release_api_canary" | /usr/bin/jq -er \
+  '.assets[] | select(.name == "arc-node-linux-x86_64") | .digest | sub("^sha256:"; "")')"
+cli_expected_digest="$(printf '%s' "$release_api_canary" | /usr/bin/jq -er \
+  '.assets[] | select(.name == "arc-cli-linux-x86_64") | .digest | sub("^sha256:"; "")')"
+[[ "$installer_expected_digest" =~ ^[0-9a-f]{64}$ ]]
+[[ "$node_expected_digest" =~ ^[0-9a-f]{64}$ ]]
+[[ "$cli_expected_digest" =~ ^[0-9a-f]{64}$ ]]
+if [ -e "$installer_canary_root" ] && [ ! -f "$installer_canary_receipt" ]; then
+  printf 'partial installer canary exists without acceptance receipt; preserve and stop\n' >&2
+  exit 1
+fi
+if [ ! -e "$installer_canary_root" ]; then
+  /usr/bin/mkdir -m 0700 "$installer_canary_root"
+  /usr/bin/curl --fail --silent --show-error --location \
+    --proto '=https' --proto-redir '=https' --tlsv1.2 --max-time 60 \
+    --max-filesize 4194304 \
+    https://github.com/FerrumVir/arc-chain/releases/download/v0.8.0/install.sh \
+    -o "$installer_canary_root/install.sh"
+  test "$(arc_sha256 "$installer_canary_root/install.sh")" = \
+    "$installer_expected_digest"
+  /usr/bin/chmod 0500 "$installer_canary_root/install.sh"
+  /usr/bin/bash "$installer_canary_root/install.sh" --version 0.8.0 \
+    --install-dir "$installer_canary_root/install" \
+    --data-dir "$installer_canary_root/data" \
+    --no-service --no-auto-update \
+    >"$installer_canary_root/install.stdout" \
+    2>"$installer_canary_root/install.stderr"
+  "$installer_canary_root/install/bin/arc-node" --version \
+    | /usr/bin/grep -F ' 0.8.0'
+  "$installer_canary_root/install/bin/arc-cli" --version \
+    | /usr/bin/grep -F ' 0.8.0'
+  /usr/bin/bash "$installer_canary_root/install.sh" --update-only \
+    --install-dir "$installer_canary_root/install" --no-service --no-auto-update \
+    >"$installer_canary_root/update.stdout" \
+    2>"$installer_canary_root/update.stderr"
+  /usr/bin/grep -Fq 'Already up to date at v0.8.0' \
+    "$installer_canary_root/update.stdout"
+  test "$(arc_sha256 "$installer_canary_root/install/bin/arc-node")" = \
+    "$node_expected_digest"
+  test "$(arc_sha256 "$installer_canary_root/install/bin/arc-cli")" = \
+    "$cli_expected_digest"
+  /usr/bin/jq -cnS --argjson release_run_id "$release_run_id" \
+    --argjson release_run_attempt "$release_run_attempt" --argjson release_id "$release_id" \
+    --arg node_sha "$node_expected_digest" --arg cli_sha "$cli_expected_digest" \
+    --arg update_sha "$(arc_sha256 "$installer_canary_root/update.stdout")" \
+    '{schema:"arc.post-release-installer-canary.v1",version:"0.8.0",
+      platform:"linux-x86_64",release_run_id:$release_run_id,
+      release_run_attempt:$release_run_attempt,release_id:$release_id,
+      node_sha256:$node_sha,cli_sha256:$cli_sha,update_stdout_sha256:$update_sha,
+      service_started:false,update_result:"already-up-to-date"}' \
+    | write_once_or_compare "$installer_canary_receipt"
+fi
+test "$(/usr/bin/stat --format='%a:%h' "$installer_canary_root")" = 700:1
+test "$(/usr/bin/stat --format='%a:%h' "$installer_canary_receipt")" = 400:1
+test ! -L "$installer_canary_receipt"
+test "$(arc_sha256 "$installer_canary_root/install.sh")" = "$installer_expected_digest"
+test "$(arc_sha256 "$installer_canary_root/install/bin/arc-node")" = \
+  "$node_expected_digest"
+test "$(arc_sha256 "$installer_canary_root/install/bin/arc-cli")" = \
+  "$cli_expected_digest"
+/usr/bin/jq -e --argjson release_run_id "$release_run_id" \
+  --argjson release_run_attempt "$release_run_attempt" --argjson release_id "$release_id" \
+  --arg node_sha "$node_expected_digest" --arg cli_sha "$cli_expected_digest" \
+  --arg update_sha "$(arc_sha256 "$installer_canary_root/update.stdout")" '
+  . == {schema:"arc.post-release-installer-canary.v1",version:"0.8.0",
+    platform:"linux-x86_64",release_run_id:$release_run_id,
+    release_run_attempt:$release_run_attempt,release_id:$release_id,
+    node_sha256:$node_sha,cli_sha256:$cli_sha,update_stdout_sha256:$update_sha,
+    service_started:false,update_result:"already-up-to-date"}' \
+  "$installer_canary_receipt" >/dev/null
+/usr/bin/grep -Fq 'Already up to date at v0.8.0' \
+  "$installer_canary_root/update.stdout"
+"$installer_canary_root/install/bin/arc-node" --version | /usr/bin/grep -F ' 0.8.0'
+"$installer_canary_root/install/bin/arc-cli" --version | /usr/bin/grep -F ' 0.8.0'
+
+live_acceptance="$post_release_attempt_root/live-rollout-verify.txt"
+"$ARC_RECOVERY_PYTHON_PATH" -I scripts/recovery/recovery_rollout.py verify \
+  --manifest "$final_manifest" --reward-evidence "$reward_evidence" \
+  >"$live_acceptance"
+test -s "$live_acceptance"
+/usr/bin/chmod 0400 "$live_acceptance"
+(cd /secure/operator && \
+  /usr/bin/sha256sum --check --strict recovery-v3.reward-evidence.json.sha256)
+
+acceptance_receipt="$post_release_attempt_root/POST-RELEASE-ACCEPTANCE.json"
+/usr/bin/jq -cnS --arg source_sha "$protected_main_sha" \
+  --argjson release_run_id "$release_run_id" \
+  --argjson release_run_attempt "$release_run_attempt" --argjson release_id "$release_id" \
+  --arg frontend_commit "$frontend_commit_sha" --argjson frontend_pr "$frontend_pr_number" \
+  --arg frontend_main "$frontend_main_sha" --argjson pages_run_id "$pages_run_id" \
+  --argjson pages_run_attempt "$pages_run_attempt" \
+  --argjson pages_deployment_id "$pages_deployment_id" \
+  --arg config_sha "$(arc_sha256 "$deployed_config")" \
+  --arg installer_receipt_sha "$(arc_sha256 "$installer_canary_receipt")" \
+  --arg reward_evidence_sha "$(arc_sha256 "$reward_evidence")" \
+  --arg live_verify_sha "$(arc_sha256 "$live_acceptance")" '
+  {schema:"arc.post-release-acceptance.v1",repository:"FerrumVir/arc-chain",
+   release_source_sha:$source_sha,release_run_id:$release_run_id,
+   release_run_attempt:$release_run_attempt,release_id:$release_id,
+   frontend_commit:$frontend_commit,frontend_pull_request:$frontend_pr,
+   frontend_main_sha:$frontend_main,pages_run_id:$pages_run_id,
+   pages_run_attempt:$pages_run_attempt,pages_deployment_id:$pages_deployment_id,
+   deployed_config_sha256:$config_sha,installer_receipt_sha256:$installer_receipt_sha,
+   reward_evidence_sha256:$reward_evidence_sha,live_verify_sha256:$live_verify_sha,
+   release_immutable:true,pages_jobs_succeeded:true,provenance_verified:true,
+   installer_update_verified:true,inference_reward_evidence_verified:true}' \
+  > "$acceptance_receipt"
+/usr/bin/chmod 0400 "$acceptance_receipt"
+/usr/bin/sync -f "$acceptance_receipt"
+/usr/bin/sync -f "$post_release_attempt_root"
+```
+
+Only now may the operator restore the normal package-update schedule:
 
 ```bash
 /usr/bin/systemctl unmask --runtime "${operator_package_units[@]}"
@@ -2335,24 +3650,12 @@ for unit in apt-daily.timer apt-daily-upgrade.timer unattended-upgrades.service;
 done
 ```
 
+<!-- END EXECUTABLE PRODUCTION RECOVERY PROCEDURE -->
+
 If the enclave reboots before that point, the runtime masks disappear by
 design. Do not recreate them and continue from remembered values: rerun every
 preceding read-only package-version, file-hash, artifact, and remote-state
 proof first.
-
-An air-gapped review may instead supply both `--archive-manifest` and
-`--archive-complete`; they must be canonical mode-read-only files matching the
-same finalized roots. Supplying only one fails closed. The default has no
-manual local-file handoff and still never mounts or serves Drive.
-
-The output and sidecar are create-only mode `0444`. Publish the exact bytes in
-a dedicated Git commit replacing `shared/frontend/arc-network.json` only after
-the dashboard and explorer contract tests pass. Verify the deployed Pages file
-hash equals the generated hash and re-fetch every advertised provenance URL.
-Rollback is `git revert <that-config-commit>` followed by the same Pages deploy
-and hash check; this restores the tracked maintenance config without changing
-canonical blocks or deleting any archive. A fork view is always explicitly
-selected and provenance-verified; it is never canonical or a reward source.
 
 ## Reward gates
 

--- a/scripts/recovery/archive-fleet-to-drive.sh
+++ b/scripts/recovery/archive-fleet-to-drive.sh
@@ -1378,7 +1378,10 @@ for prepare_unit in prepare_units:
     unit_states[prepare_unit] = {
         "active_state": prepare_prop("ActiveState"),
         "sub_state": prepare_prop("SubState"),
-        "main_pid": int(prepare_prop("MainPID")),
+        # MainPID is not a property of timer units, so systemd returns an
+        # empty value for arc-node-update.timer.  Normalize that service-only
+        # property to the same quiescent zero represented by inactive services.
+        "main_pid": int(prepare_prop("MainPID") or "0"),
         "job": prepare_prop("Job") or "0",
         "enablement": enabled_result.stdout.strip(),
     }

--- a/scripts/recovery/test_archive_node_quarantine_runtime.py
+++ b/scripts/recovery/test_archive_node_quarantine_runtime.py
@@ -308,7 +308,9 @@ class EmbeddedProgramTests(unittest.TestCase):
         precommit = self.outer[self.outer.index('if mode in {"precommit-status", "stopped-precommit"}:'):
                                self.outer.index("def validate_stopped_transition(")]
         for marker in (
-            'if recovery_started <= deadline:',
+            'accepted_elapsed = acceptance.get("accepted_monotonic_ns")',
+            'current_elapsed - accepted_elapsed <= lease_ns',
+            'fail("precommit stopped status is not after monotonic lease expiry")',
             '"Job", "MainPID", "Requires", "After", "DropInPaths"',
             'properties["ActiveState"] not in {"inactive", "failed"}',
             'properties["Job"] not in {"", "0"}',
@@ -321,16 +323,18 @@ class EmbeddedProgramTests(unittest.TestCase):
 
     def test_helper_deadline_and_writer_checks_immediately_precede_nft(self) -> None:
         initial = self.helper.index("# initial:")
-        deadline_check = self.helper.index(
-            "authorization expired immediately before", initial
-        )
+        lease_check = self.helper.index("enforce_monotonic_lease()", initial)
         nft = self.helper.index(
             'subprocess.run([str(nft),"-f",str(STATE/"rendered-policy.nft")],check=True)',
-            deadline_check,
+            lease_check,
         )
         prefix = self.helper[initial:nft]
         self.assertIn("verify_writer(contract)", prefix)
-        self.assertIn("authorization expired immediately before", prefix)
+        self.assertIn("enforce_monotonic_lease()", prefix)
+        self.assertLess(
+            prefix.rindex("verify_writer(contract)"),
+            prefix.rindex("enforce_monotonic_lease()"),
+        )
         self.assertIn("nft-deadline-gate.json", self.helper)
 
     def test_ensure_requires_durable_commit(self) -> None:

--- a/scripts/release/create-cutover-handoff-commit.py
+++ b/scripts/release/create-cutover-handoff-commit.py
@@ -11,8 +11,9 @@ import re
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
-from typing import NoReturn, Sequence
+from typing import Iterator, NoReturn, Sequence
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -25,26 +26,57 @@ PUBLIC_FILES = (
     "arc-recovery-checkpoint-descriptor.json",
 )
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
-REMOTE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+OBJECT_RE = re.compile(r"^[0-9a-f]{40,64}$")
+REMOTE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 ZERO_COMMIT = "0" * 40
+HANDOFF_AUTHOR_NAME = "ARC Recovery Handoff"
+HANDOFF_AUTHOR_EMAIL = "recovery-handoff@arc.compute"
+HANDOFF_SCHEMA = "arc-recovery-checkpoint-descriptor/v1"
+SENSITIVE_ENVIRONMENT_NAMES = (
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+)
 
 
 class HandoffCommitError(RuntimeError):
     pass
 
 
+class GitCommandError(HandoffCommitError):
+    pass
+
+
+class RemoteProbeError(HandoffCommitError):
+    pass
+
+
+@dataclass(frozen=True)
+class CommitContract:
+    commit: str
+    tree: str
+    parent: str
+    commit_payload: str
+    tree_entries: tuple[str, ...]
+
+
 def fail(message: str) -> NoReturn:
     raise HandoffCommitError(message)
 
 
-def run_git(
-    repository: Path,
-    arguments: Sequence[str],
-    *,
+def safe_diagnostic(value: str) -> str:
+    redacted = value
+    for name in SENSITIVE_ENVIRONMENT_NAMES:
+        secret = os.environ.get(name)
+        if secret:
+            redacted = redacted.replace(secret, "<redacted>")
+    redacted = re.sub(r"(https?://)[^/@\s]+@", r"\1<redacted>@", redacted)
+    return redacted.strip()[:2000]
+
+
+def git_environment(
     environment: dict[str, str] | None = None,
-    input_text: str | None = None,
-) -> str:
-    env = {
+) -> dict[str, str]:
+    result = {
         "HOME": os.environ.get("HOME", "/var/empty"),
         "PATH": "/usr/bin:/bin:/usr/local/bin",
         "LANG": "C",
@@ -54,24 +86,135 @@ def run_git(
         "GIT_TERMINAL_PROMPT": "0",
     }
     if environment:
-        env.update(environment)
+        result.update(environment)
+    return result
+
+
+def write_create_only_executable(path: Path, payload: bytes) -> None:
+    descriptor = os.open(
+        path,
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_NOFOLLOW", 0),
+        0o700,
+    )
     try:
-        completed = subprocess.run(
-            ["git", "-C", os.fspath(repository), *arguments],
+        offset = 0
+        while offset < len(payload):
+            written = os.write(descriptor, payload[offset:])
+            if written <= 0:
+                fail("credential helper write made no progress")
+            offset += written
+        os.fchmod(descriptor, 0o700)
+    finally:
+        os.close(descriptor)
+
+
+@contextlib.contextmanager
+def remote_push_environment(push_url: str) -> Iterator[dict[str, str]]:
+    if not push_url.startswith("https://"):
+        fail("authenticated handoff publication requires the exact HTTPS remote")
+    config = (
+        ("credential.helper", ""),
+        ("http.extraHeader", ""),
+        ("http.https://github.com/.extraHeader", ""),
+        ("http.sslVerify", "true"),
+        ("protocol.allow", "never"),
+        ("protocol.https.allow", "always"),
+    )
+    environment = {
+        "GIT_CONFIG_COUNT": str(len(config)),
+        **{f"GIT_CONFIG_KEY_{index}": key for index, (key, _value) in enumerate(config)},
+        **{
+            f"GIT_CONFIG_VALUE_{index}": value
+            for index, (_key, value) in enumerate(config)
+        },
+    }
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token is None or re.fullmatch(r"[A-Za-z0-9_]{20,1024}", token) is None:
+        fail("an HTTPS push requires one bounded GH_TOKEN or GITHUB_TOKEN")
+    with tempfile.TemporaryDirectory(prefix="arc-cutover-askpass-") as temporary:
+        directory = Path(temporary)
+        directory.chmod(0o700)
+        askpass = directory / "askpass"
+        write_create_only_executable(
+            askpass,
+            b"#!/bin/sh\n"
+            b"case \"$1\" in\n"
+            b"  Username*) /usr/bin/printf '%s\\n' x-access-token ;;\n"
+            b"  Password*) /usr/bin/printf '%s\\n' \"$ARC_HANDOFF_PUSH_TOKEN\" ;;\n"
+            b"  *) exit 1 ;;\n"
+            b"esac\n",
+        )
+        environment.update(
+            {
+                "ARC_HANDOFF_PUSH_TOKEN": token,
+                "GIT_ASKPASS": os.fspath(askpass),
+                "GIT_ASKPASS_REQUIRE": "force",
+            }
+        )
+        yield environment
+
+
+def invoke_git(
+    repository: Path,
+    arguments: Sequence[str],
+    *,
+    environment: dict[str, str] | None = None,
+    input_text: str | None = None,
+    timeout: int = 120,
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        "git",
+        "-C",
+        os.fspath(repository),
+        "-c",
+        "core.hooksPath=/dev/null",
+        *arguments,
+    ]
+    try:
+        return subprocess.run(
+            command,
             input=input_text,
             text=True,
             stdin=None if input_text is not None else subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=env,
-            timeout=120,
+            env=git_environment(environment),
+            timeout=timeout,
             check=False,
         )
-    except (OSError, subprocess.TimeoutExpired) as error:
-        fail(f"git {' '.join(arguments[:2])} failed: {error}")
+    except OSError as error:
+        raise GitCommandError(
+            f"git {arguments[0] if arguments else 'command'} could not start: {error}"
+        ) from error
+    except subprocess.TimeoutExpired as error:
+        raise GitCommandError(
+            f"git {arguments[0] if arguments else 'command'} timed out"
+        ) from error
+
+
+def run_git(
+    repository: Path,
+    arguments: Sequence[str],
+    *,
+    environment: dict[str, str] | None = None,
+    input_text: str | None = None,
+    timeout: int = 120,
+) -> str:
+    completed = invoke_git(
+        repository,
+        arguments,
+        environment=environment,
+        input_text=input_text,
+        timeout=timeout,
+    )
     if completed.returncode != 0:
-        diagnostic = completed.stderr.strip()[:2000]
-        fail(f"git {' '.join(arguments[:2])} rejected the handoff: {diagnostic}")
+        diagnostic = safe_diagnostic(completed.stderr or completed.stdout)
+        raise GitCommandError(
+            f"git {' '.join(arguments[:2])} rejected the handoff: {diagnostic}"
+        )
     return completed.stdout.strip()
 
 
@@ -81,7 +224,7 @@ def create_commit(
     main_commit: str,
     ref_name: str,
     timestamp: str,
-) -> tuple[str, str]:
+) -> tuple[CommitContract, str]:
     expected_ref = f"refs/arc-recovery-handoffs/{main_commit}"
     if ref_name != expected_ref:
         fail(f"handoff ref must be exactly {expected_ref}")
@@ -90,28 +233,12 @@ def create_commit(
         fail("main commit does not resolve exactly")
     if run_git(repository, ["rev-parse", "--is-bare-repository"]) not in {"true", "false"}:
         fail("repository shape is unsupported")
-    existing = subprocess.run(
-        ["git", "-C", os.fspath(repository), "show-ref", "--verify", "--quiet", ref_name],
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        env={
-            "HOME": os.environ.get("HOME", "/var/empty"),
-            "PATH": "/usr/bin:/bin:/usr/local/bin",
-            "GIT_CONFIG_NOSYSTEM": "1",
-            "GIT_CONFIG_GLOBAL": "/dev/null",
-        },
-        check=False,
-    )
-    if existing.returncode == 0:
-        fail("create-only handoff ref already exists")
-    if existing.returncode not in {1}:
-        fail("cannot prove the handoff ref is absent")
 
     with tempfile.TemporaryDirectory(prefix="arc-cutover-index-") as temporary:
         index = Path(temporary) / "index"
         index_env = {"GIT_INDEX_FILE": os.fspath(index)}
         run_git(repository, ["read-tree", "--empty"], environment=index_env)
+        tree_entries: list[str] = []
         for filename in PUBLIC_FILES:
             path = assets_dir / filename
             if not path.is_file() or path.is_symlink() or path.stat().st_size <= 0:
@@ -120,26 +247,27 @@ def create_commit(
                 repository,
                 ["hash-object", "-w", "--no-filters", os.fspath(path)],
             )
-            if not re.fullmatch(r"[0-9a-f]{40,64}", blob):
+            if OBJECT_RE.fullmatch(blob) is None:
                 fail(f"git returned an invalid blob ID for {filename}")
             run_git(
                 repository,
                 ["update-index", "--add", "--cacheinfo", f"100644,{blob},{filename}"],
                 environment=index_env,
             )
+            tree_entries.append(f"100644 blob {blob}\t{filename}")
         tree = run_git(repository, ["write-tree"], environment=index_env)
         identity_env = {
-            "GIT_AUTHOR_NAME": "ARC Recovery Handoff",
-            "GIT_AUTHOR_EMAIL": "recovery-handoff@arc.compute",
-            "GIT_COMMITTER_NAME": "ARC Recovery Handoff",
-            "GIT_COMMITTER_EMAIL": "recovery-handoff@arc.compute",
+            "GIT_AUTHOR_NAME": HANDOFF_AUTHOR_NAME,
+            "GIT_AUTHOR_EMAIL": HANDOFF_AUTHOR_EMAIL,
+            "GIT_COMMITTER_NAME": HANDOFF_AUTHOR_NAME,
+            "GIT_COMMITTER_EMAIL": HANDOFF_AUTHOR_EMAIL,
             "GIT_AUTHOR_DATE": timestamp,
             "GIT_COMMITTER_DATE": timestamp,
         }
         message = (
             "ARC compact recovery handoff\n\n"
             f"release-main: {main_commit}\n"
-            "schema: arc-recovery-checkpoint-descriptor/v1\n"
+            f"schema: {HANDOFF_SCHEMA}\n"
         )
         commit = run_git(
             repository,
@@ -149,17 +277,116 @@ def create_commit(
         )
     if COMMIT_RE.fullmatch(commit) is None:
         fail("git returned an invalid handoff commit ID")
+    contract = CommitContract(
+        commit=commit,
+        tree=tree,
+        parent=main_commit,
+        commit_payload=run_git(repository, ["cat-file", "commit", commit]),
+        tree_entries=tuple(tree_entries),
+    )
+    validate_commit_contract(repository, commit, contract)
+    local_ref_state = ensure_local_ref(repository, ref_name, contract)
+    return contract, local_ref_state
+
+
+def validate_commit_contract(
+    repository: Path,
+    commit: str,
+    expected: CommitContract,
+) -> None:
+    if commit != expected.commit or COMMIT_RE.fullmatch(commit) is None:
+        fail("existing local handoff ref differs from the freshly derived commit")
+    resolved = run_git(repository, ["rev-parse", f"{commit}^{{commit}}"])
+    if resolved != commit:
+        fail("handoff commit does not resolve exactly as a commit")
     parent_line = run_git(repository, ["rev-list", "--parents", "-n", "1", commit])
-    if parent_line != f"{commit} {main_commit}":
-        fail("derived handoff commit does not have the sole exact-main parent")
-    listing = run_git(repository, ["ls-tree", "-r", "--name-only", commit]).splitlines()
-    if listing != list(PUBLIC_FILES):
-        fail("derived handoff commit tree differs from the exact three assets")
-    run_git(repository, ["update-ref", ref_name, commit, ZERO_COMMIT])
-    return commit, tree
+    if parent_line != f"{commit} {expected.parent}":
+        fail("handoff commit does not have the sole exact-main parent")
+    actual_tree = run_git(repository, ["show", "-s", "--format=%T", commit])
+    if actual_tree != expected.tree:
+        fail("handoff commit tree differs from the freshly derived tree")
+    listing = tuple(
+        run_git(repository, ["ls-tree", "-r", "--full-tree", commit]).splitlines()
+    )
+    if listing != expected.tree_entries:
+        fail("handoff commit assets or modes differ from the exact three-file contract")
+    payload = run_git(repository, ["cat-file", "commit", commit])
+    if payload != expected.commit_payload:
+        fail("handoff commit identity, timestamp, or message metadata differs")
 
 
-def run_checked(arguments: Sequence[str], label: str) -> None:
+def local_ref_target(repository: Path, ref_name: str) -> str | None:
+    symbolic = invoke_git(repository, ["symbolic-ref", "--quiet", ref_name])
+    if symbolic.returncode == 0:
+        fail("local handoff ref is symbolic; refusing indirect replacement")
+    if symbolic.returncode != 1:
+        diagnostic = safe_diagnostic(symbolic.stderr or symbolic.stdout)
+        fail(f"cannot prove the local handoff ref is direct: {diagnostic}")
+    completed = invoke_git(
+        repository,
+        ["show-ref", "--verify", "--quiet", ref_name],
+    )
+    if completed.returncode == 1:
+        return None
+    if completed.returncode != 0:
+        diagnostic = safe_diagnostic(completed.stderr or completed.stdout)
+        fail(f"cannot prove the local handoff ref state: {diagnostic}")
+    values = run_git(repository, ["rev-parse", "--verify", ref_name]).splitlines()
+    if len(values) != 1 or COMMIT_RE.fullmatch(values[0]) is None:
+        fail("local handoff ref resolved ambiguously or to an invalid object ID")
+    return values[0]
+
+
+def ensure_local_ref(
+    repository: Path,
+    ref_name: str,
+    expected: CommitContract,
+) -> str:
+    existing = local_ref_target(repository, ref_name)
+    if existing is not None:
+        validate_commit_contract(repository, existing, expected)
+        return "reused"
+    try:
+        run_git(
+            repository,
+            ["update-ref", "--no-deref", ref_name, expected.commit, ZERO_COMMIT],
+        )
+    except GitCommandError as update_error:
+        raced = local_ref_target(repository, ref_name)
+        if raced == expected.commit:
+            validate_commit_contract(repository, raced, expected)
+            return "reused"
+        if raced is None:
+            fail(
+                "create-only local handoff ref update failed while the ref remained absent; "
+                f"safe to retry: {safe_diagnostic(str(update_error))}"
+            )
+        fail("local handoff ref changed to a different commit; refusing replacement")
+    created = local_ref_target(repository, ref_name)
+    if created != expected.commit:
+        fail("created local handoff ref does not resolve to the freshly derived commit")
+    validate_commit_contract(repository, created, expected)
+    return "created"
+
+
+def isolated_tool_environment(safe_home: Path) -> dict[str, str]:
+    if not safe_home.is_dir() or safe_home.is_symlink():
+        fail("isolated handoff-tool home is unavailable")
+    return {
+        "HOME": os.fspath(safe_home),
+        "PATH": "/usr/bin:/bin",
+        "LANG": "C",
+        "LC_ALL": "C",
+        "TZ": "UTC",
+    }
+
+
+def run_checked(
+    arguments: Sequence[str],
+    label: str,
+    *,
+    environment: dict[str, str],
+) -> None:
     try:
         completed = subprocess.run(
             list(arguments),
@@ -167,14 +394,167 @@ def run_checked(arguments: Sequence[str], label: str) -> None:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            env=environment,
             timeout=600,
             check=False,
         )
     except (OSError, subprocess.TimeoutExpired) as error:
         fail(f"{label} failed: {error}")
     if completed.returncode != 0:
-        diagnostic = (completed.stderr or completed.stdout).strip()[:4000]
+        diagnostic = safe_diagnostic(completed.stderr or completed.stdout)
         fail(f"{label} rejected the recovery handoff: {diagnostic}")
+
+
+def run_isolated_python(
+    script: Path,
+    arguments: Sequence[str],
+    label: str,
+    *,
+    safe_home: Path,
+) -> None:
+    run_checked(
+        [sys.executable, "-I", os.fspath(script), *arguments],
+        label,
+        environment=isolated_tool_environment(safe_home),
+    )
+
+
+def allowed_remote_urls(repository_name: str) -> frozenset[str]:
+    return frozenset({f"https://github.com/{repository_name}.git"})
+
+
+def verify_remote_identity(
+    repository: Path,
+    remote_name: str,
+    repository_name: str,
+) -> tuple[str, str]:
+    if REMOTE_RE.fullmatch(remote_name) is None:
+        fail("push remote name is unsafe")
+    allowed = allowed_remote_urls(repository_name)
+    fetch_urls = run_git(
+        repository, ["remote", "get-url", "--all", remote_name]
+    ).splitlines()
+    push_urls = run_git(
+        repository, ["remote", "get-url", "--push", "--all", remote_name]
+    ).splitlines()
+    if len(fetch_urls) != 1 or len(push_urls) != 1:
+        fail("push remote must have one unambiguous fetch URL and one push URL")
+    if fetch_urls[0] not in allowed or push_urls[0] not in allowed:
+        fail(
+            "push remote does not identify the exact credential-free "
+            f"github.com/{repository_name}.git repository"
+        )
+    return fetch_urls[0], push_urls[0]
+
+
+def probe_remote_ref(
+    repository: Path,
+    remote_name: str,
+    repository_name: str,
+    ref_name: str,
+    *,
+    expected_identity: tuple[str, str] | None = None,
+) -> tuple[str | None, tuple[str, str]]:
+    try:
+        identity = verify_remote_identity(repository, remote_name, repository_name)
+        if expected_identity is not None and identity != expected_identity:
+            raise RemoteProbeError("push remote identity changed during publication")
+        output = run_git(
+            repository,
+            ["ls-remote", "--refs", remote_name, ref_name],
+            timeout=120,
+        )
+    except GitCommandError as error:
+        raise RemoteProbeError(
+            "remote handoff ref probe is unavailable; absence was not proven: "
+            f"{safe_diagnostic(str(error))}"
+        ) from error
+    if not output:
+        return None, identity
+    rows = output.splitlines()
+    if len(rows) != 1:
+        raise RemoteProbeError("remote handoff ref probe returned multiple records")
+    fields = rows[0].split("\t")
+    if (
+        len(fields) != 2
+        or COMMIT_RE.fullmatch(fields[0]) is None
+        or fields[1] != ref_name
+    ):
+        raise RemoteProbeError("remote handoff ref probe returned a malformed record")
+    return fields[0], identity
+
+
+def publish_remote_ref(
+    repository: Path,
+    remote_name: str,
+    repository_name: str,
+    ref_name: str,
+    commit: str,
+) -> str:
+    existing, identity = probe_remote_ref(
+        repository,
+        remote_name,
+        repository_name,
+        ref_name,
+    )
+    if existing is not None:
+        if existing == commit:
+            return "reused"
+        fail(
+            "remote handoff ref already identifies a different commit; "
+            "refusing to move or replace it"
+        )
+
+    push_error: GitCommandError | None = None
+    try:
+        with remote_push_environment(identity[1]) as push_environment:
+            run_git(
+                repository,
+                [
+                    "push",
+                    "--atomic",
+                    "--receive-pack=git-receive-pack",
+                    f"--force-with-lease={ref_name}:",
+                    remote_name,
+                    f"{commit}:{ref_name}",
+                ],
+                environment=push_environment,
+                timeout=120,
+            )
+    except GitCommandError as error:
+        push_error = error
+
+    try:
+        observed, _identity = probe_remote_ref(
+            repository,
+            remote_name,
+            repository_name,
+            ref_name,
+            expected_identity=identity,
+        )
+    except RemoteProbeError as probe_error:
+        detail = " after a push error" if push_error is not None else " after push success"
+        fail(
+            "remote handoff publication outcome could not be proven"
+            f"{detail}; the exact local ref is intact and the operation is safe to retry: "
+            f"{safe_diagnostic(str(probe_error))}"
+        )
+    if observed == commit:
+        return "created"
+    if observed is None:
+        detail = (
+            safe_diagnostic(str(push_error))
+            if push_error is not None
+            else "push returned success but the ref remained absent"
+        )
+        fail(
+            "remote handoff ref remains absent; the exact local ref is intact and "
+            f"the operation is safe to retry: {detail}"
+        )
+    fail(
+        "remote handoff ref changed to a different commit during publication; "
+        "treat this as an incident and do not replace it"
+    )
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -206,11 +586,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             temporary = stack.enter_context(
                 tempfile.TemporaryDirectory(prefix="arc-cutover-assets-")
             )
+            isolated_home_name = stack.enter_context(
+                tempfile.TemporaryDirectory(prefix="arc-cutover-home-")
+            )
             assets = Path(temporary)
-            run_checked(
+            isolated_home = Path(isolated_home_name)
+            isolated_home.chmod(0o700)
+            run_isolated_python(
+                ASSEMBLER,
                 [
-                    sys.executable,
-                    os.fspath(ASSEMBLER),
                     "--handoff-dir",
                     os.fspath(args.full_handoff_dir),
                     "--output-dir",
@@ -229,11 +613,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                     args.main_commit,
                 ],
                 "full ARCCHKPT derivation",
+                safe_home=isolated_home,
             )
-            run_checked(
+            run_isolated_python(
+                DERIVED_VALIDATOR,
                 [
-                    sys.executable,
-                    os.fspath(DERIVED_VALIDATOR),
                     "--input-dir",
                     os.fspath(assets),
                     "--verifier-binary",
@@ -250,36 +634,34 @@ def main(argv: Sequence[str] | None = None) -> int:
                     args.main_commit,
                 ],
                 "compact certificate validation",
+                safe_home=isolated_home,
             )
             policy = json.loads((assets / "arc-cutover-policy.json").read_bytes())
             timestamp = policy["all_controlled_stopped_at"]
-            commit, tree = create_commit(
+            if not isinstance(timestamp, str) or not timestamp or len(timestamp) > 64:
+                fail("cutover policy contains an invalid commit timestamp")
+            contract, local_ref_state = create_commit(
                 repository, assets, args.main_commit, ref_name, timestamp
             )
 
+        remote_ref_state: str | None = None
         if args.push_remote is not None:
-            if REMOTE_RE.fullmatch(args.push_remote) is None:
-                fail("push remote name is unsafe")
-            existing = run_git(repository, ["ls-remote", "--refs", args.push_remote, ref_name])
-            if existing:
-                fail("create-only remote handoff ref already exists")
-            run_git(
+            remote_ref_state = publish_remote_ref(
                 repository,
-                [
-                    "push",
-                    "--atomic",
-                    f"--force-with-lease={ref_name}:",
-                    args.push_remote,
-                    f"{commit}:{ref_name}",
-                ],
+                args.push_remote,
+                args.repository,
+                ref_name,
+                contract.commit,
             )
         print(
             json.dumps(
                 {
-                    "handoff_commit_sha": commit,
+                    "handoff_commit_sha": contract.commit,
                     "handoff_ref": ref_name,
-                    "handoff_tree_sha": tree,
+                    "handoff_tree_sha": contract.tree,
+                    "local_ref_state": local_ref_state,
                     "pushed_remote": args.push_remote,
+                    "remote_ref_state": remote_ref_state,
                 },
                 sort_keys=True,
                 separators=(",", ":"),

--- a/scripts/release/release-manifest-handoff.py
+++ b/scripts/release/release-manifest-handoff.py
@@ -47,6 +47,9 @@ BASE_FILES = HEADLESS + DESKTOP + (
     "install.sh",
     "testnet-seeds.txt",
     "genesis.toml",
+    "arc-legacy-maintenance-boundary.json",
+    "arc-recovery-checkpoint-descriptor.json",
+    "arc-cutover-policy.json",
     "latest.json",
     "SHA256SUMS",
 )

--- a/scripts/release/unsigned-desktop-handoff.py
+++ b/scripts/release/unsigned-desktop-handoff.py
@@ -130,6 +130,123 @@ def require_regular(path: Path, *, label: str, maximum: int) -> os.stat_result:
     return metadata
 
 
+def signer_input_permissions_are_read_only(
+    metadata: os.stat_result, *, windows: bool
+) -> bool:
+    """Return whether a signer input has the host's strict read-only state.
+
+    POSIX preserves the materializer's exact ``0400`` mode. Native Windows
+    deliberately maps ``chmod(..., 0400)`` to the read-only file attribute and
+    reports the resulting permission bits as ``0444``. Prove both Windows
+    representations and reject reparse points instead of weakening the POSIX
+    contract to a cross-platform numeric mode comparison.
+    """
+
+    mode = stat.S_IMODE(metadata.st_mode)
+    if not windows:
+        return mode == 0o400
+
+    readonly_flag = getattr(stat, "FILE_ATTRIBUTE_READONLY", None)
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", None)
+    file_attributes = getattr(metadata, "st_file_attributes", None)
+    if (
+        not isinstance(readonly_flag, int)
+        or not isinstance(reparse_flag, int)
+        or not isinstance(file_attributes, int)
+    ):
+        return False
+    return (
+        file_attributes & readonly_flag != 0
+        and file_attributes & reparse_flag == 0
+        and mode & (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH) == 0
+    )
+
+
+def same_regular_file_identity(left: os.stat_result, right: os.stat_result) -> bool:
+    """Compare an open descriptor and pathname without trusting mode text."""
+
+    return (
+        stat.S_ISREG(left.st_mode)
+        and stat.S_ISREG(right.st_mode)
+        and left.st_dev == right.st_dev
+        and left.st_ino == right.st_ino
+        and left.st_nlink == 1
+        and right.st_nlink == 1
+    )
+
+
+def windows_permissions_match_mode(metadata: os.stat_result, mode: int) -> bool:
+    """Prove the Windows read-only attribute implied by a portable mode."""
+
+    readonly_flag = getattr(stat, "FILE_ATTRIBUTE_READONLY", None)
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", None)
+    file_attributes = getattr(metadata, "st_file_attributes", None)
+    if (
+        not isinstance(readonly_flag, int)
+        or not isinstance(reparse_flag, int)
+        or not isinstance(file_attributes, int)
+        or file_attributes & reparse_flag != 0
+    ):
+        return False
+    expects_writable = mode & stat.S_IWUSR != 0
+    is_readonly = file_attributes & readonly_flag != 0
+    has_write_mode = metadata.st_mode & (
+        stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH
+    ) != 0
+    return (
+        (expects_writable and not is_readonly and has_write_mode)
+        or (not expects_writable and is_readonly and not has_write_mode)
+    )
+
+
+def set_open_file_mode(path: Path, descriptor: int, mode: int) -> None:
+    """Set a mode while proving that path still names the open regular file.
+
+    Python gained ``os.fchmod`` on Windows only in 3.13, while the hosted
+    Windows runner currently exposes Python 3.12. On that runtime, use the
+    pathname API only while retaining the descriptor, and bind the pathname to
+    the descriptor both before and after the mutation. A replacement, link, or
+    reparse-point race therefore fails closed rather than being accepted as
+    the staged handoff object.
+    """
+
+    before_descriptor = os.fstat(descriptor)
+    before_path = path.lstat()
+    if path.is_symlink() or not same_regular_file_identity(
+        before_descriptor, before_path
+    ):
+        fail(f"open file identity differs before chmod for {path.name}")
+
+    descriptor_chmod = getattr(os, "fchmod", None)
+    if callable(descriptor_chmod):
+        descriptor_chmod(descriptor, mode)
+    elif os.name == "nt":
+        os.chmod(path, mode)
+    else:
+        fail(f"descriptor chmod is unavailable for {path.name}")
+
+    after_descriptor = os.fstat(descriptor)
+    after_path = path.lstat()
+    if (
+        path.is_symlink()
+        or not same_regular_file_identity(before_descriptor, after_descriptor)
+        or not same_regular_file_identity(after_descriptor, after_path)
+    ):
+        fail(f"open file identity changed during chmod for {path.name}")
+    if os.name == "nt":
+        if not windows_permissions_match_mode(after_descriptor, mode) or not \
+           windows_permissions_match_mode(after_path, mode):
+            fail(f"Windows file permissions differ after chmod for {path.name}")
+    elif stat.S_IMODE(after_descriptor.st_mode) != mode or \
+         stat.S_IMODE(after_path.st_mode) != mode:
+        fail(f"POSIX file permissions differ after chmod for {path.name}")
+
+
+def require_signer_input_read_only(metadata: os.stat_result) -> None:
+    if not signer_input_permissions_are_read_only(metadata, windows=os.name == "nt"):
+        fail("a signer input regained permissions before verification")
+
+
 def payload_files(platform: str, root: Path) -> list[tuple[str, Path, int]]:
     if not root.is_dir() or root.is_symlink():
         fail("unsigned payload must be a non-symlink directory")
@@ -193,7 +310,7 @@ def write_exclusive(path: Path, payload: bytes, mode: int) -> None:
             if written <= 0:
                 fail(f"write made no progress for {path.name}")
             offset += written
-        os.fchmod(descriptor, mode)
+        set_open_file_mode(path, descriptor, mode)
         os.fsync(descriptor)
     finally:
         os.close(descriptor)
@@ -525,7 +642,7 @@ def copy_stream(source: BinaryIO, target: Path, mode: int) -> None:
             shutil.copyfileobj(source, output)
             output.flush()
             os.fsync(output.fileno())
-        os.fchmod(descriptor, mode)
+        set_open_file_mode(target, descriptor, mode)
     finally:
         os.close(descriptor)
 
@@ -732,8 +849,7 @@ def verify_signed(args: argparse.Namespace) -> None:
         metadata = require_regular(
             path, label="signed-workspace input", maximum=MAX_PAYLOAD_FILE_BYTES
         )
-        if metadata.st_mode & 0o777 != 0o400:
-            fail("a signer input regained permissions before verification")
+        require_signer_input_read_only(metadata)
         expected_hash = hashes[name]
         if re.fullmatch(r"[0-9a-f]{64}", str(expected_hash)) is None:
             fail("handoff receipt has an invalid payload hash")

--- a/tests/release/cutover_handoff_commit_test.sh
+++ b/tests/release/cutover_handoff_commit_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+exec python3 "$TEST_DIR/test_cutover_handoff_commit.py"

--- a/tests/release/documentation_contract_test.sh
+++ b/tests/release/documentation_contract_test.sh
@@ -20,6 +20,7 @@ DRIVE_PREFREEZE_TEST="$REPO_ROOT/tests/release/drive_prefreeze_gate_test.sh"
 CANARY_RUNBOOK="$REPO_ROOT/docs/MACOS-PRETAG-COMMUNITY-CANARY.md"
 CANARY_HELPER="$REPO_ROOT/scripts/release/macos-community-canary.py"
 VAULT_HELPER="$REPO_ROOT/scripts/release/restore-validator-vault.py"
+CUTOVER_HANDOFF_HELPER="$REPO_ROOT/scripts/release/create-cutover-handoff-commit.py"
 PRODUCTION_RECOVERY_AUDIT="$REPO_ROOT/docs/PRODUCTION-RECOVERY-AUDIT-2026-08-26.md"
 GETTING_STARTED="$REPO_ROOT/docs/GETTING_STARTED.md"
 STATUS_DOC="$REPO_ROOT/docs/STATUS.md"
@@ -804,7 +805,7 @@ recovery_archive_commands_are_exact_and_resumable() {
 }
 
 operator_recovery_commands_are_linux_pinned_and_ordered() {
-    local file literal pair count line previous audit_block
+    local file literal pair count line previous audit_block handoff_help handoff_section
 
     (
         local procedure_file rollout_file
@@ -1297,6 +1298,222 @@ PY
             'recovery README omits a create-only input or Linux archive/download invariant' \
             || return 1
     done
+
+    handoff_help="$(python3 "$CUTOVER_HANDOFF_HELPER" --help)" || return 1
+    for literal in \
+        --repository-root --full-handoff-dir --verifier-binary \
+        --inspector-binary --genesis --main-commit --tag --repository --push-remote
+    do
+        printf '%s\n' "$handoff_help" | grep -Fq -- "$literal" || {
+            printf 'cutover handoff helper omits documented option: %s\n' "$literal"
+            return 1
+        }
+        require_literal "$RECOVERY_README" "$literal" \
+            'recovery README omits compact handoff helper option' || return 1
+    done
+    for literal in \
+        'arc-recovery-final.lock.json.sha256' \
+        'legacy-maintenance-boundary.json' \
+        'recovery.arcchkpt' \
+        'refs/arc-recovery-handoffs/$protected_main_sha' \
+        'scripts/release/create-cutover-handoff-commit.py' \
+        'workflow run recovery-release-handoff.yml' \
+        'arc-recovery-release-handoff-$protected_main_sha' \
+        'handoff_run_id=' \
+        'handoff_artifact_id="$(printf' \
+        'handoff_artifact_digest="$(printf' \
+        'unset GH_TOKEN' \
+        'GH_TOKEN="$GH_TOKEN" "$ARC_RECOVERY_PYTHON_PATH" -I' \
+        '--push-remote origin' \
+        '.local_ref_state == "created" or .local_ref_state == "reused"' \
+        '.remote_ref_state == "created" or .remote_ref_state == "reused"' \
+        'collaborators?affiliation=direct&per_page=100' \
+        'direct_collaborators_before=' \
+        'repos/FerrumVir/arc-chain/collaborators/arisarcmarket' \
+        '-f permission=pull' \
+        'direct_collaborators_after=' \
+        '.[1].login == "arisarcmarket" and .[1].role_name == "read"' \
+        'repos/FerrumVir/arc-chain/invitations?per_page=100' \
+        'pending_writer_invitations' \
+        'remote_release_count=' \
+        '[.[] | select(.tag_name == "v0.8.0")] | length' \
+        'repos/FerrumVir/arc-chain/immutable-releases --jq .enabled' \
+        'repos/FerrumVir/arc-chain/rulesets/21690216' \
+        'Restrict all ARC tag creation' \
+        'repos/FerrumVir/arc-chain/rulesets/21667203' \
+        'Protect all ARC tags from mutation' \
+        'tag_ref_push_status=0' \
+        '[.[] | select(.ref == "refs/tags/v0.8.0")] as $matches' \
+        'GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null' \
+        'GH_TOKEN="$GH_TOKEN" GH_PROMPT_DISABLED=1' \
+        '-c core.hooksPath=/dev/null' \
+        '-c credential.helper=' \
+        'credential.https://github.com.helper=!$ARC_RECOVERY_GH_PATH auth git-credential' \
+        '-c http.extraHeader=' \
+        '-c http.https://github.com/.extraHeader=' \
+        '-c protocol.allow=never' \
+        '-c protocol.https.allow=always' \
+        'push --porcelain --atomic --no-verify' \
+        '--force-with-lease=refs/tags/v0.8.0:' \
+        '$protected_main_sha:refs/tags/v0.8.0' \
+        'remote_tag_after_state=' \
+        'absence is proven and a fresh retry is safe' \
+        'mandatory post-query proved the exact tag' \
+        'tag_push_run_id=' \
+        'actions/runs/$tag_push_run_id/jobs?filter=all&per_page=100' \
+        'Release requires workflow_dispatch with a positive cutover_handoff_artifact_id.' \
+        'workflow run release.yml' \
+        '-f tag=v0.8.0' \
+        '-f cutover_handoff_artifact_id="$handoff_artifact_id"' \
+        '-f cutover_handoff_artifact_digest="$handoff_artifact_digest"' \
+        'a tag-push event' \
+        'cannot carry the protected handoff artifact ID' \
+        'Do not move, delete, recreate, or re-push the tag' \
+        'never rerun the tag' \
+        'or release workflow'
+    do
+        require_literal "$RECOVERY_README" "$literal" \
+            'recovery README omits compact handoff or manual release contract' \
+            || return 1
+    done
+    for literal in \
+        'HANDOFF-RUN-SELECTION.json' \
+        'TAG-PUSH-RUN-SELECTION.json' \
+        'RELEASE-RUN-SELECTION.json' \
+        'Verify the immutable GitHub release without publication authority' \
+        'expected_release_assets=' \
+        '.immutable == true' \
+        '| length) == 32' \
+        'RELEASE-API-FINAL.json' \
+        'frontend-push.XXXXXXXX' \
+        '-c http.sslVerify=true' \
+        'FRONTEND-MAIN-RULESET-BASELINE.json' \
+        '.parameters.required_approving_review_count = 0' \
+        '.parameters.require_last_push_approval = false' \
+        'trap frontend_restore_on_exit EXIT' \
+        '-f commit_title="$frontend_pr_title" -f merge_method=squash' \
+        '"$frontend_main_sha $protected_main_sha"' \
+        'PAGES-RUN-SELECTION.json' \
+        'Verify and assemble public console' \
+        'Publish GitHub Pages' \
+        'repos/FerrumVir/arc-chain/deployments' \
+        './shared/frontend/arc-network.json' \
+        'arc.post-release-installer-canary.v1' \
+        'Already up to date at v0.8.0' \
+        'scripts/recovery/recovery_rollout.py verify' \
+        'POST-RELEASE-ACCEPTANCE.json'
+    do
+        require_literal "$RECOVERY_README" "$literal" \
+            'recovery README omits an executable release or post-release receipt gate' \
+            || return 1
+    done
+    for forbidden in \
+        "handoff_run_id='<" \
+        "handoff_run_attempt='<" \
+        "tag_push_run_id='<" \
+        "release_run_id='<"
+    do
+        if grep -Fq -- "$forbidden" "$RECOVERY_README"; then
+            printf 'recovery README retains unsafe manual run placeholder: %s\n' "$forbidden"
+            return 1
+        fi
+    done
+    if grep -Fq -- '.status == "built" and .build_type == "workflow"' \
+        "$RECOVERY_README"; then
+        printf 'recovery README treats nullable Pages status as a deployment proof\n'
+        return 1
+    fi
+    for literal in \
+        'scripts/release/create-cutover-handoff-commit.py --full-handoff-dir' \
+        'Manually dispatch' \
+        '`recovery-release-handoff.yml`' \
+        '`cutover_handoff_artifact_id`' \
+        '`cutover_handoff_artifact_digest`' \
+        'exact direct set `FerrumVir` plus `arisarcmarket`' \
+        '`arisarcmarket` to `pull`' \
+        'zero pending invitations' \
+        '21690216' \
+        '21667203' \
+        'isolated authenticated Git push' \
+        '`--force-with-lease=refs/tags/v0.8.0:`' \
+        'proven absence is safe to retry' \
+        'automatic `release.yml`' \
+        'tag-push run is expected to fail' \
+        'expected to fail in the initial validation job' \
+        'Prove that exact error' \
+        'move or recreate the tag'
+    do
+        require_literal "$ROLLOUT" "$literal" \
+            'validator rollout omits compact handoff or manual release contract' \
+            || return 1
+    done
+    for literal in \
+        'API-select exactly one workflow/path/event/branch/SHA run' \
+        'independent immutable-release verifier' \
+        'unique 32-asset digest-bound contract' \
+        'temporarily' \
+        'approval count and last-push approval' \
+        'squash merge' \
+        'successful `github-pages` deployment' \
+        '`POST-RELEASE-ACCEPTANCE.json`'
+    do
+        require_literal "$ROLLOUT" "$literal" \
+            'validator rollout omits an executable release or post-release receipt gate' \
+            || return 1
+    done
+    if grep -Fq -- 'immediately deletes that exact release ID without' \
+        "$RECOVERY_README" "$ROLLOUT"; then
+        printf 'operator docs still claim an attempted publication is deleted\n'
+        return 1
+    fi
+    handoff_section="$(awk '
+        /^## Create the compact release handoff and publish$/ { capture=1 }
+        capture { print }
+        capture && /^Keep the runtime package-mutation masks/ { exit }
+    ' "$RECOVERY_README")"
+    if printf '%s\n' "$handoff_section" | grep -Fq 'export GH_TOKEN'; then
+        printf 'compact handoff runbook exports GitHub authority to repository code\n'
+        return 1
+    fi
+    previous=0
+    for literal in \
+        'unset GH_TOKEN' \
+        'GH_TOKEN="$(' \
+        'handoff_receipt="$(' \
+        'workflow run recovery-release-handoff.yml' \
+        'handoff_artifact_id="$(printf' \
+        'repos/FerrumVir/arc-chain/collaborators/arisarcmarket' \
+        'pending_writer_invitations=' \
+        'creation_ruleset=' \
+        'mutation_ruleset=' \
+        'tag_ref_push_status=0' \
+        'tag_push_run_id=' \
+        'workflow run release.yml'
+    do
+        line="$(printf '%s\n' "$handoff_section" | grep -nF -- "$literal" \
+            | head -n 1 | cut -d: -f1)"
+        if [ -z "$line" ] || [ "$line" -le "$previous" ]; then
+            printf 'compact handoff/release command is absent or out of order: %s\n' \
+                "$literal"
+            return 1
+        fi
+        previous="$line"
+    done
+
+    post_release_acceptance_line="$(grep -nF -- 'POST-RELEASE-ACCEPTANCE.json' \
+        "$RECOVERY_README" | tail -n 1 | cut -d: -f1)"
+    post_release_unmask_line="$(grep -nF -- '/usr/bin/systemctl unmask --runtime' \
+        "$RECOVERY_README" | tail -n 1 | cut -d: -f1)"
+    procedure_end_line="$(grep -nF -- \
+        '<!-- END EXECUTABLE PRODUCTION RECOVERY PROCEDURE -->' \
+        "$RECOVERY_README" | cut -d: -f1)"
+    if [ -z "$post_release_acceptance_line" ] || [ -z "$post_release_unmask_line" ] \
+        || [ -z "$procedure_end_line" ] \
+        || [ "$post_release_acceptance_line" -ge "$post_release_unmask_line" ] \
+        || [ "$post_release_unmask_line" -ge "$procedure_end_line" ]; then
+        printf 'executable procedure ends before post-release acceptance and unmask gates\n'
+        return 1
+    fi
 
     if grep -Eq '751619276800|750 GiB|700 GiB' \
         "$RECOVERY_README" "$DRIVE_PREFREEZE_GATE"; then

--- a/tests/release/recovery_archive_contract_test.sh
+++ b/tests/release/recovery_archive_contract_test.sh
@@ -55,6 +55,24 @@ for bad in ("-drive:path","arc-drive:../escape","arc-drive:path/../escape","arc-
 PY
 }
 
+timer_units_with_empty_mainpid_normalize_to_zero() {
+    python3 - "$ORCHESTRATOR" <<'PY' || return 1
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+audit = text[text.index("audit_writers()") : text.index("seal_freeze_plan()")]
+expected = '"main_pid": int(prepare_prop("MainPID") or "0"),'
+assert expected in audit
+assert '"main_pid": int(prepare_prop("MainPID")),' not in audit
+
+# Ubuntu systemd emits an empty MainPID for timer units.  Keep the exact
+# production normalization executable in this regression, not just documented.
+prepare_prop = lambda _name: ""
+assert int(prepare_prop("MainPID") or "0") == 0
+PY
+}
+
 sealed_stake_quorum_never_claims_global_halt() {
     for required in 'source_total_stake") != 40_000_000' controlled_writer_stake \
       controlled_quorum_unavailable_after_all_stops global_legacy_halt_claimed \
@@ -2536,10 +2554,27 @@ assert 'arc.recovery.shared-input-source.v1' in t
 PY
 )
 
-archive_scripts_are_lintable() { bash -n "$NODE_HELPER" "$ORCHESTRATOR" && PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile "$ROLLOUT" "$FREEZE_MODULE" "$FREEZE_MODULE_TEST" && PYTHONDONTWRITEBYTECODE=1 python3 -m unittest "$REPO_ROOT/scripts/recovery/test_recovery_rollout.py" >/dev/null && PYTHONDONTWRITEBYTECODE=1 python3 "$FREEZE_MODULE_TEST" >/dev/null && python3 -m json.tool "$SCHEMA" >/dev/null && shellcheck -S warning "$NODE_HELPER" "$ORCHESTRATOR"; }
+archive_scripts_are_lintable() {
+    bash -n "$NODE_HELPER" "$ORCHESTRATOR" &&
+        PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile \
+            "$ROLLOUT" "$FREEZE_MODULE" "$FREEZE_MODULE_TEST" &&
+        PYTHONDONTWRITEBYTECODE=1 python3 -m unittest \
+            "$REPO_ROOT/scripts/recovery/test_recovery_rollout.py" >/dev/null &&
+        PYTHONDONTWRITEBYTECODE=1 python3 "$FREEZE_MODULE_TEST" >/dev/null &&
+        PYTHONDONTWRITEBYTECODE=1 python3 \
+            "$REPO_ROOT/scripts/recovery/test_archive_node_quarantine_runtime.py" \
+            >/dev/null &&
+        PYTHONDONTWRITEBYTECODE=1 python3 \
+            "$REPO_ROOT/scripts/recovery/test_quarantine_rounds.py" >/dev/null &&
+        PYTHONDONTWRITEBYTECODE=1 python3 \
+            "$REPO_ROOT/scripts/recovery/test_community_reward_probe.py" >/dev/null &&
+        python3 -m json.tool "$SCHEMA" >/dev/null &&
+        shellcheck -S warning "$NODE_HELPER" "$ORCHESTRATOR"
+}
 
 run_test 'exact authorizations bind every domain' exact_authorizations_bind_every_domain
 run_test 'capture id and destination fail closed' capture_id_and_destination_fail_closed
+run_test 'timer units normalize an empty MainPID to zero' timer_units_with_empty_mainpid_normalize_to_zero
 run_test 'sealed stake proof never claims global halt' sealed_stake_quorum_never_claims_global_halt
 run_test 'all six exact writers stop before capture' all_six_exact_writers_stop_before_content_capture
 run_test 'first quarantine boundary is temporally authorized before write' first_quarantine_boundary_is_temporally_authorized_before_write
@@ -2581,5 +2616,5 @@ run_test 'persisted-head truncated partials resume at every completed-at offset'
 run_test 'stateful fake nft/systemctl quarantine crash matrix is fail-closed' stateful_fake_nft_systemctl_quarantine_contract
 run_test 'quarantine retirement is exact, one-way, read-only on status, and crash-resumable' quarantine_retirement_is_one_way_resumable_and_exact
 run_test 'shared archive inputs stream without work-root materialization' shared_inputs_stream_without_work_root_materialization
-run_test 'archive scripts pass syntax and lint' archive_scripts_are_lintable
+run_test 'archive scripts pass syntax, lint, and embedded runtime suites' archive_scripts_are_lintable
 finish_tests

--- a/tests/release/release_assembly_test.sh
+++ b/tests/release/release_assembly_test.sh
@@ -7,6 +7,7 @@ REPO_ROOT="$(CDPATH='' cd -- "$TEST_DIR/../.." && pwd)"
 . "$TEST_DIR/helpers/testlib.sh"
 
 ASSEMBLER="$REPO_ROOT/scripts/release/assemble-release.sh"
+RELEASE_HANDOFF="$REPO_ROOT/scripts/release/release-manifest-handoff.py"
 CUTOVER_FIXTURE_BUILDER="$TEST_DIR/make_cutover_release_fixture.py"
 CUTOVER_ASSET_DERIVER="$REPO_ROOT/scripts/release/assemble-cutover-assets.py"
 CANONICAL_HEADLESS_ASSETS='
@@ -228,6 +229,7 @@ assert set(descriptor) == {
     "recovery_manifest_sha256", "release_commit", "release_tag", "repository",
     "schema_version", "verified_quorum",
 }
+
 assert descriptor["schema_version"] == "arc-recovery-checkpoint-descriptor/v1"
 assert descriptor["repository"] == "FerrumVir/arc-chain"
 assert descriptor["release_tag"] == "v0.8.0"
@@ -340,6 +342,69 @@ assert [(row["address"], row["stake"]) for row in policy["legacy_validators"]] =
 ]
 assert policy["checkpoint_quorum"] == descriptor["verified_quorum"]
 PY
+}
+
+complete_cutover_release_stages_through_signing_handoff() {
+    local sandbox stage_dir github_output metadata_sha
+    new_assembly_fixture
+    sandbox="$NEW_ASSEMBLY_SANDBOX"
+    stage_dir="$sandbox/unsigned-release-handoff"
+    github_output="$sandbox/handoff-output"
+
+    if ! run_assembler "$sandbox" >"$sandbox/assemble-for-handoff.out" 2>&1; then
+        sed -n '1,160p' "$sandbox/assemble-for-handoff.out"
+        return 1
+    fi
+    if ! python3 "$RELEASE_HANDOFF" stage \
+        --repository FerrumVir/arc-chain \
+        --commit 9999999999999999999999999999999999999999 \
+        --tag v0.8.0 \
+        --run-id 2468 \
+        --run-attempt 1 \
+        --source-dir "$sandbox/output" \
+        --stage-dir "$stage_dir" \
+        --github-output "$github_output" \
+        >"$sandbox/stage-handoff.out" 2>&1; then
+        sed -n '1,160p' "$sandbox/stage-handoff.out"
+        return 1
+    fi
+
+    metadata_sha="$(awk -F= '$1 == "metadata_sha" { print $2 }' "$github_output")"
+    case "$metadata_sha" in
+        ''|*[!0-9a-f]*)
+            printf 'release handoff did not emit a metadata SHA-256\n'
+            return 1
+            ;;
+    esac
+    [ "${#metadata_sha}" -eq 64 ] || {
+        printf 'release handoff emitted a malformed metadata SHA-256\n'
+        return 1
+    }
+    python3 "$RELEASE_HANDOFF" verify \
+        --repository FerrumVir/arc-chain \
+        --commit 9999999999999999999999999999999999999999 \
+        --tag v0.8.0 \
+        --run-id 2468 \
+        --run-attempt 1 \
+        --handoff-dir "$stage_dir" \
+        --expected-metadata-sha "$metadata_sha" \
+        >"$sandbox/verify-handoff.out" 2>&1 || {
+            sed -n '1,160p' "$sandbox/verify-handoff.out"
+            return 1
+        }
+
+    assert_equals 31 \
+        "$(find "$stage_dir/release-files" -maxdepth 1 -type f | wc -l | tr -d ' ')" \
+        'signing handoff must retain the complete 31-file cutover release' || return 1
+    for asset in \
+        arc-legacy-maintenance-boundary.json \
+        arc-recovery-checkpoint-descriptor.json \
+        arc-cutover-policy.json; do
+        [ -s "$stage_dir/release-files/$asset" ] || {
+            printf 'signing handoff dropped required cutover asset: %s\n' "$asset"
+            return 1
+        }
+    done
 }
 
 complete_scheduled_genesis_is_preserved() {
@@ -543,6 +608,7 @@ assembler_preserves_unowned_and_last_good_outputs() {
 }
 
 run_test 'complete fixture produces exact-tag manifest and verified SHA256SUMS' complete_fixture_produces_verifiable_contract
+run_test 'complete assembled cutover release crosses the signing handoff intact' complete_cutover_release_stages_through_signing_handoff
 run_test 'complete production genesis preserves its explicit activation schedule' complete_scheduled_genesis_is_preserved
 run_test 'unsafe production genesis is rejected before a publishable manifest exists' unsafe_production_genesis_is_rejected_before_manifest
 run_test 'each of the ten canonical headless assets is independently required' every_headless_asset_is_individually_required

--- a/tests/release/run.sh
+++ b/tests/release/run.sh
@@ -26,6 +26,7 @@ for test_file in \
     "$TEST_DIR/release_publication_contract_test.sh" \
     "$TEST_DIR/validator_vault_rewrap_contract_test.sh" \
     "$TEST_DIR/validator_vault_restore_contract_test.sh" \
+    "$TEST_DIR/cutover_handoff_commit_test.sh" \
     "$TEST_DIR/release_assembly_test.sh" \
     "$TEST_DIR/release_manifest_signature_test.sh" \
     "$TEST_DIR/signing_key_backup_behavior_test.sh" \

--- a/tests/release/static_contract_test.sh
+++ b/tests/release/static_contract_test.sh
@@ -26,6 +26,7 @@ UPDATER_VERIFIER_MANIFEST="$TEST_DIR/tauri-updater-verifier/Cargo.toml"
 UPDATER_FIXTURE_DIR="$TEST_DIR/fixtures/tauri-updater"
 RELEASE_ALLOWED_SIGNERS="$REPO_ROOT/release/arc-release-allowed-signers"
 RELEASE_PREFLIGHT_WORKFLOW="$REPO_ROOT/.github/workflows/release-signing-preflight.yml"
+RECOVERY_RELEASE_HANDOFF_WORKFLOW="$REPO_ROOT/.github/workflows/recovery-release-handoff.yml"
 SIGNING_BACKUP_WORKFLOW="$REPO_ROOT/.github/workflows/release-signing-backup.yml"
 SIGNING_BACKUP_VERIFY="$REPO_ROOT/scripts/release/verify-signing-key-backup.sh"
 PRETAG_SELECTOR="$REPO_ROOT/scripts/release/select-pretag-artifacts.py"
@@ -533,6 +534,69 @@ pretag_exact_byte_handoff_is_fail_closed() {
     do
         grep -Fq -- "$required" "$PRETAG_SELECTOR" || {
             printf 'pre-tag selector omits fail-closed check: %s\n' "$required"
+            return 1
+        }
+    done
+}
+
+upload_artifact_digests_are_canonicalized_at_job_boundaries() {
+    # The exact pinned actions/upload-artifact implementation exposes its
+    # artifact-digest output as 64 bare lowercase hex characters. GitHub's
+    # artifact REST objects expose the same value as sha256:<hex>. Keep the
+    # repository-facing job-output contract in the REST form, exactly once at
+    # each producer boundary, so downstream validators never receive a bare or
+    # double-prefixed digest.
+    local upload_pin evidence_boundary evidence_boundary_count
+    upload_pin='actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'
+    evidence_boundary="evidence_digest: \${{ format('sha256:{0}', steps.evidence.outputs.artifact-digest) }}"
+    for workflow in \
+        "$RECOVERY_RELEASE_HANDOFF_WORKFLOW" \
+        "$RELEASE_PREFLIGHT_WORKFLOW" \
+        "$RELEASE_WORKFLOW"
+    do
+        grep -Fq "$upload_pin" "$workflow" || {
+            printf 'digest contract is not tied to the reviewed upload-artifact implementation: %s\n' \
+                "$workflow"
+            return 1
+        }
+    done
+
+    grep -Fq \
+        "artifact-digest: \${{ format('sha256:{0}', steps.upload.outputs.artifact-digest) }}" \
+        "$RECOVERY_RELEASE_HANDOFF_WORKFLOW" || {
+        printf 'recovery handoff does not canonicalize its job digest output\n'
+        return 1
+    }
+    for required in \
+        "artifact_digest: \${{ format('sha256:{0}', steps.upload.outputs.artifact-digest) }}" \
+        '[[ "$EXPECTED_ARTIFACT_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]'
+    do
+        grep -Fq -- "$required" "$RELEASE_PREFLIGHT_WORKFLOW" || {
+            printf 'desktop signer handoff digest boundary omits: %s\n' "$required"
+            return 1
+        }
+    done
+    for required in \
+        "artifact_digest: \${{ format('sha256:{0}', steps.unsigned-upload.outputs.artifact-digest) }}" \
+        "artifact_digest: \${{ format('sha256:{0}', steps.sealed-upload.outputs.artifact-digest) }}" \
+        "evidence_digest: \${{ format('sha256:{0}', steps.evidence.outputs.artifact-digest) }}"
+    do
+        grep -Fq -- "$required" "$RELEASE_WORKFLOW" || {
+            printf 'release handoff digest boundary omits: %s\n' "$required"
+            return 1
+        }
+    done
+    evidence_boundary_count="$(grep -Fc "$evidence_boundary" "$RELEASE_WORKFLOW")"
+    [ "$evidence_boundary_count" -eq 2 ] || {
+        printf 'both draft and published evidence outputs must canonicalize exactly once\n'
+        return 1
+    }
+    for required in \
+        '[[ "$ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ]]' \
+        '--arg digest "sha256:$ARTIFACT_DIGEST"'
+    do
+        grep -Fq -- "$required" "$RECOVERY_RELEASE_HANDOFF_WORKFLOW" || {
+            printf 'same-step recovery artifact/API digest comparison omits: %s\n' "$required"
             return 1
         }
     done
@@ -1407,6 +1471,15 @@ release_secret_jobs_require_the_owner_environment() {
         'Select and download the exact-main ciphertext before secret access' \
         'npm ci --prefix desktop --ignore-scripts' \
         'Restore only the four bounded members and exercise both keys' \
+        'canonicalize_manifest_public_key' \
+        'NR != 1 { exit 1 }' \
+        'if (NF != 2 && NF != 3) exit 1' \
+        'if ($1 != "ssh-ed25519") exit 1' \
+        'if ($2 !~ /^[A-Za-z0-9+\/]+={0,2}$/) exit 1' \
+        'if (NF == 3 && $3 != "arc-release-manifest-v1") exit 1' \
+        '"$expected_manifest" "$expected_manifest_canonical"' \
+        '"$derived_manifest_canonical" "$expected_manifest_canonical"' \
+        '"$restored_manifest_canonical" "$expected_manifest_canonical"' \
         'cleanup_plaintext' \
         'Verify the updater canary only after all recovered secrets are gone' \
         'ARC_SIGNING_BACKUP_PASSPHRASE: ${{ secrets.ARC_SIGNING_BACKUP_PASSPHRASE }}'
@@ -1675,14 +1748,22 @@ ref: ${{ needs.validate.outputs.sha }}' ]; then
     for required in \
         'repos/FerrumVir/arc-chain/immutable-releases' \
         'Run that command from the existing owner/admin `gh` session immediately before' \
-        'immediately deletes that exact release ID without' \
-        'deleting the protected tag'
+        'Before publication, a failed upload or independent verification may delete' \
+        'Once the publication PATCH has been attempted, every failure path retains' \
+        'stops for manual verification' \
+        'do not rerun the' \
+        'tag or release workflow'
     do
         grep -Fq -- "$required" "$REPO_ROOT/docs/VALIDATOR-FLEET-ROLLOUT.md" || {
             printf 'operator pre-tag immutable-settings runbook omits: %s\n' "$required"
             return 1
         }
     done
+    if grep -Fq -- 'immediately deletes that exact release ID without' \
+        "$REPO_ROOT/docs/VALIDATOR-FLEET-ROLLOUT.md"; then
+        printf 'operator runbook still claims a post-publication release is deleted\n'
+        return 1
+    fi
     for required in \
         'needs: [validate, manifest-sign]' \
         'This privileged job deliberately has no checkout' \
@@ -2258,6 +2339,7 @@ run_test 'release publishes and gates a SHA256SUMS manifest' checksum_manifest_i
 run_test 'installer and update-only path verify SHA-256 before replacement' installer_and_updater_verify_checksums
 run_test 'headless manifest is owner-signed and both protected keys have a pre-tag canary' release_manifest_has_owner_signature_and_preflight
 run_test 'pre-tag artifacts are complete, immutable-ID bound, digest-verified, and never rebuilt after tagging' pretag_exact_byte_handoff_is_fail_closed
+run_test 'upload-artifact digests are canonicalized exactly once at every job boundary' upload_artifact_digests_are_canonicalized_at_job_boundaries
 run_test 'raw node consumers use exact versioned release URLs' raw_node_downloads_are_version_pinned
 run_test 'update-only path refuses equal and older semantic versions' updater_has_semver_downgrade_guard
 run_test 'installer normalizes service identity and protects its seed' installer_normalizes_service_identity_and_secret_permissions

--- a/tests/release/test_cutover_handoff_commit.py
+++ b/tests/release/test_cutover_handoff_commit.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import contextlib
 import hashlib
+import importlib.util
 import json
 import os
 import subprocess
@@ -9,6 +11,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -25,6 +28,13 @@ COMMIT_VALIDATOR = (
 COMMIT_CREATOR = (
     REPO_ROOT / "scripts" / "release" / "create-cutover-handoff-commit.py"
 )
+CREATOR_SPEC = importlib.util.spec_from_file_location(
+    "arc_create_cutover_handoff_commit_test", COMMIT_CREATOR
+)
+assert CREATOR_SPEC is not None and CREATOR_SPEC.loader is not None
+creator = importlib.util.module_from_spec(CREATOR_SPEC)
+sys.modules[CREATOR_SPEC.name] = creator
+CREATOR_SPEC.loader.exec_module(creator)
 PRODUCER_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "recovery-release-handoff.yml"
 FIXTURE_BUILDER = REPO_ROOT / "tests" / "release" / "make_cutover_release_fixture.py"
 PUBLIC_FILES = (
@@ -153,32 +163,33 @@ class CutoverHandoffCommitValidationTests(GitFixture):
 
 
 class CutoverHandoffCreationCommandTests(GitFixture):
-    def test_local_command_creates_and_pushes_only_compact_assets_without_worktree_edits(
-        self,
-    ) -> None:
-        full_handoff = self.root / "full-handoff"
-        fake_binary = self.root / "arc-node"
-        inspector_binary = self.root / "arc-node-release-inspector"
+    def setUp(self) -> None:
+        super().setUp()
+        self.full_handoff = self.root / "full-handoff"
+        self.fake_binary = self.root / "arc-node"
+        self.inspector_binary = self.root / "arc-node-release-inspector"
         subprocess.run(
             [
                 sys.executable,
                 str(FIXTURE_BUILDER),
                 "--handoff-dir",
-                str(full_handoff),
+                str(self.full_handoff),
                 "--binary",
-                str(fake_binary),
+                str(self.fake_binary),
                 "--genesis",
                 str(REPO_ROOT / "genesis.toml"),
             ],
             check=True,
         )
-        inspector_binary.write_bytes(fake_binary.read_bytes())
-        inspector_binary.chmod(0o755)
-        fake_binary.chmod(0o600)
-        fake_binary.write_bytes(fake_binary.read_bytes() + b"# local platform verifier\n")
-        fake_binary.chmod(0o755)
-        boundary_path = full_handoff / "legacy-maintenance-boundary.json"
-        manifest_path = full_handoff / "arc-recovery-final.lock.json"
+        self.inspector_binary.write_bytes(self.fake_binary.read_bytes())
+        self.inspector_binary.chmod(0o755)
+        self.fake_binary.chmod(0o600)
+        self.fake_binary.write_bytes(
+            self.fake_binary.read_bytes() + b"# local platform verifier\n"
+        )
+        self.fake_binary.chmod(0o755)
+        boundary_path = self.full_handoff / "legacy-maintenance-boundary.json"
+        manifest_path = self.full_handoff / "arc-recovery-final.lock.json"
         boundary = json.loads(boundary_path.read_bytes())
         manifest = json.loads(manifest_path.read_bytes())
         original_source_commit = manifest["provenance"]["source_main_commit"]
@@ -199,73 +210,417 @@ class CutoverHandoffCreationCommandTests(GitFixture):
         manifest_path.chmod(0o600)
         manifest_path.write_bytes(manifest_payload)
         manifest_path.chmod(0o444)
-        sidecar = full_handoff / "arc-recovery-final.lock.json.sha256"
+        sidecar = self.full_handoff / "arc-recovery-final.lock.json.sha256"
         sidecar.chmod(0o600)
         sidecar.write_text(
             f"{hashlib.sha256(manifest_payload).hexdigest()}  arc-recovery-final.lock.json\n",
             encoding="ascii",
         )
         sidecar.chmod(0o444)
-
-        remote = self.root / "remote.git"
-        subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
-        self.git("remote", "add", "origin", str(remote))
-        before = self.git("status", "--porcelain=v1", "--untracked-files=all")
-        command = [
+        self.ref_name = f"refs/arc-recovery-handoffs/{self.main_commit}"
+        self.command = [
             sys.executable,
             str(COMMIT_CREATOR),
             "--repository-root",
             str(self.repository),
             "--full-handoff-dir",
-            str(full_handoff),
+            str(self.full_handoff),
             "--verifier-binary",
-            str(fake_binary),
+            str(self.fake_binary),
             "--inspector-binary",
-            str(inspector_binary),
+            str(self.inspector_binary),
             "--genesis",
             str(REPO_ROOT / "genesis.toml"),
             "--main-commit",
             self.main_commit,
             "--tag",
             "v0.8.0",
-            "--push-remote",
-            "origin",
         ]
-        result = subprocess.run(
-            command,
+
+    def run_creator(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            self.command,
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             check=False,
         )
+
+    def create_local_handoff(self) -> dict[str, object]:
+        result = self.run_creator()
         self.assertEqual(result.returncode, 0, result.stderr)
-        receipt = json.loads(result.stdout)
-        handoff = receipt["handoff_commit_sha"]
-        ref_name = f"refs/arc-recovery-handoffs/{self.main_commit}"
-        self.assertEqual(receipt["handoff_ref"], ref_name)
+        return json.loads(result.stdout)
+
+    def test_fresh_and_exact_local_retry_are_deterministic_and_worktree_clean(
+        self,
+    ) -> None:
+        before = self.git("status", "--porcelain=v1", "--untracked-files=all")
+        first = self.create_local_handoff()
+        self.assertEqual(first["local_ref_state"], "created")
+        self.assertIsNone(first["remote_ref_state"])
+        self.assertIsNone(first["pushed_remote"])
+        handoff = str(first["handoff_commit_sha"])
+        self.assertEqual(first["handoff_ref"], self.ref_name)
         self.assertEqual(
             self.git("rev-list", "--parents", "-n", "1", handoff),
             f"{handoff} {self.main_commit}",
         )
-        self.assertEqual(self.git("ls-tree", "-r", "--name-only", handoff).splitlines(), list(PUBLIC_FILES))
-        self.assertEqual(self.git("status", "--porcelain=v1", "--untracked-files=all"), before)
         self.assertEqual(
-            self.git("--git-dir", str(remote), "rev-parse", ref_name, cwd=self.root),
-            handoff,
+            self.git("ls-tree", "-r", "--name-only", handoff).splitlines(),
+            list(PUBLIC_FILES),
         )
-        listing = self.git("ls-tree", "-r", "--name-only", handoff)
+        listing = self.git("ls-tree", "-r", handoff)
         self.assertNotIn("recovery.arcchkpt", listing)
         self.assertNotIn("arc-recovery-final.lock.json", listing)
+        self.assertEqual(
+            self.git("status", "--porcelain=v1", "--untracked-files=all"), before
+        )
 
-        repeated = subprocess.run(
-            command,
+        repeated = self.run_creator()
+        self.assertEqual(repeated.returncode, 0, repeated.stderr)
+        second = json.loads(repeated.stdout)
+        self.assertEqual(second["local_ref_state"], "reused")
+        self.assertEqual(second["handoff_commit_sha"], first["handoff_commit_sha"])
+        self.assertEqual(second["handoff_tree_sha"], first["handoff_tree_sha"])
+        self.assertEqual(self.git("rev-parse", self.ref_name), handoff)
+        self.assertEqual(
+            self.git("status", "--porcelain=v1", "--untracked-files=all"), before
+        )
+
+    def test_local_ref_parent_tree_asset_or_metadata_mismatch_is_never_replaced(
+        self,
+    ) -> None:
+        expected = self.create_local_handoff()
+        expected_commit = str(expected["handoff_commit_sha"])
+        expected_tree = str(expected["handoff_tree_sha"])
+        other_parent = self.commit(self.git("rev-parse", "HEAD^{tree}"), self.main_commit)
+        variants = {
+            "parent": self.commit(expected_tree, other_parent),
+            "tree": self.commit(
+                self.tree(
+                    {
+                        **self.exact_entries(),
+                        PUBLIC_FILES[0]: ("100644", b"changed asset\n"),
+                    }
+                ),
+                self.main_commit,
+            ),
+            "mode": self.commit(
+                self.tree(
+                    {
+                        **self.exact_entries(),
+                        PUBLIC_FILES[0]: ("100755", b"changed mode\n"),
+                    }
+                ),
+                self.main_commit,
+            ),
+            "metadata": self.git(
+                "commit-tree",
+                expected_tree,
+                "-p",
+                self.main_commit,
+                input_text="tampered handoff metadata\n",
+            ),
+        }
+        for label, alternate in variants.items():
+            with self.subTest(label=label):
+                self.git("update-ref", self.ref_name, alternate, expected_commit)
+                result = self.run_creator()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("differs from the freshly derived commit", result.stderr)
+                self.assertEqual(self.git("rev-parse", self.ref_name), alternate)
+                self.git("update-ref", self.ref_name, expected_commit, alternate)
+
+    def test_receipt_reports_local_and_remote_created_or_reused_state(self) -> None:
+        arguments = self.command[2:] + ["--push-remote", "origin"]
+        with mock.patch.object(
+            creator, "publish_remote_ref", return_value="created"
+        ) as publisher, mock.patch("builtins.print") as output:
+            self.assertEqual(creator.main(arguments), 0)
+        receipt = json.loads(output.call_args.args[0])
+        self.assertEqual(receipt["local_ref_state"], "created")
+        self.assertEqual(receipt["remote_ref_state"], "created")
+        self.assertEqual(receipt["pushed_remote"], "origin")
+        publisher.assert_called_once_with(
+            self.repository.resolve(),
+            "origin",
+            "FerrumVir/arc-chain",
+            self.ref_name,
+            receipt["handoff_commit_sha"],
+        )
+
+        with mock.patch.object(
+            creator, "publish_remote_ref", return_value="reused"
+        ), mock.patch("builtins.print") as output:
+            self.assertEqual(creator.main(arguments), 0)
+        retried = json.loads(output.call_args.args[0])
+        self.assertEqual(retried["local_ref_state"], "reused")
+        self.assertEqual(retried["remote_ref_state"], "reused")
+        self.assertEqual(retried["handoff_commit_sha"], receipt["handoff_commit_sha"])
+
+    def test_symbolic_local_handoff_ref_is_rejected_without_mutation(self) -> None:
+        self.git("symbolic-ref", self.ref_name, "refs/heads/main")
+        result = self.run_creator()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("handoff ref is symbolic", result.stderr)
+        self.assertEqual(self.git("symbolic-ref", self.ref_name), "refs/heads/main")
+
+
+class CutoverHandoffRemotePublicationTests(GitFixture):
+    def setUp(self) -> None:
+        super().setUp()
+        self.ref_name = f"refs/arc-recovery-handoffs/{self.main_commit}"
+        self.handoff = self.commit(self.tree(self.exact_entries()), self.main_commit)
+        self.remote = self.root / "remote.git"
+        subprocess.run(
+            ["git", "init", "--bare", str(self.remote)],
+            check=True,
+            capture_output=True,
+        )
+        self.git("remote", "add", "origin", str(self.remote))
+
+    @contextlib.contextmanager
+    def local_remote_contract(self):
+        identity = (str(self.remote), str(self.remote))
+        with mock.patch.object(
+            creator, "verify_remote_identity", return_value=identity
+        ), mock.patch.object(
+            creator,
+            "remote_push_environment",
+            side_effect=lambda _url: contextlib.nullcontext({}),
+        ):
+            yield
+
+    def publish(self) -> str:
+        return creator.publish_remote_ref(
+            self.repository,
+            "origin",
+            "FerrumVir/arc-chain",
+            self.ref_name,
+            self.handoff,
+        )
+
+    def remote_target(self) -> str | None:
+        completed = subprocess.run(
+            ["git", "--git-dir", str(self.remote), "rev-parse", "--verify", self.ref_name],
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             check=False,
         )
-        self.assertNotEqual(repeated.returncode, 0)
-        self.assertIn("create-only handoff ref already exists", repeated.stderr)
+        return completed.stdout.strip() if completed.returncode == 0 else None
+
+    def test_fresh_remote_create_then_exact_remote_reuse(self) -> None:
+        with self.local_remote_contract():
+            self.assertEqual(self.publish(), "created")
+            self.assertEqual(self.remote_target(), self.handoff)
+            self.assertEqual(self.publish(), "reused")
+            self.assertEqual(self.remote_target(), self.handoff)
+
+    def test_existing_remote_mismatch_is_an_incident_and_never_replaced(self) -> None:
+        alternate = self.commit(self.git("rev-parse", "HEAD^{tree}"), self.main_commit)
+        self.git("push", "origin", f"{alternate}:{self.ref_name}")
+        with self.local_remote_contract(), self.assertRaises(
+            creator.HandoffCommitError
+        ) as raised:
+            self.publish()
+        self.assertIn("different commit", str(raised.exception))
+        self.assertEqual(self.remote_target(), alternate)
+
+    def test_unavailable_initial_probe_is_not_mistaken_for_absence(self) -> None:
+        unavailable = self.root / "remote-unavailable.git"
+        self.git("remote", "set-url", "origin", str(unavailable))
+        identity = (str(unavailable), str(unavailable))
+        with mock.patch.object(
+            creator, "verify_remote_identity", return_value=identity
+        ), self.assertRaises(creator.RemoteProbeError) as raised:
+            self.publish()
+        self.assertIn("absence was not proven", str(raised.exception))
+
+    def test_created_then_transport_error_is_reprobed_as_success(self) -> None:
+        original_run_git = creator.run_git
+
+        def lose_push_response(repository, arguments, **kwargs):
+            if arguments and arguments[0] == "push":
+                original_run_git(repository, arguments, **kwargs)
+                raise creator.GitCommandError("simulated lost push response")
+            return original_run_git(repository, arguments, **kwargs)
+
+        with self.local_remote_contract(), mock.patch.object(
+            creator, "run_git", side_effect=lose_push_response
+        ):
+            self.assertEqual(self.publish(), "created")
+        self.assertEqual(self.remote_target(), self.handoff)
+
+    def test_absent_after_push_error_fails_safe_and_retry_succeeds(self) -> None:
+        original_run_git = creator.run_git
+
+        def fail_before_push(repository, arguments, **kwargs):
+            if arguments and arguments[0] == "push":
+                raise creator.GitCommandError("simulated authentication failure")
+            return original_run_git(repository, arguments, **kwargs)
+
+        with self.local_remote_contract(), mock.patch.object(
+            creator, "run_git", side_effect=fail_before_push
+        ), self.assertRaises(creator.HandoffCommitError) as raised:
+            self.publish()
+        self.assertIn("safe to retry", str(raised.exception))
+        self.assertIsNone(self.remote_target())
+        with self.local_remote_contract():
+            self.assertEqual(self.publish(), "created")
+        self.assertEqual(self.remote_target(), self.handoff)
+
+    def test_different_ref_appearing_during_push_is_an_incident(self) -> None:
+        alternate = self.commit(self.git("rev-parse", "HEAD^{tree}"), self.main_commit)
+        original_run_git = creator.run_git
+
+        def race_different_ref(repository, arguments, **kwargs):
+            if arguments and arguments[0] == "push":
+                self.git("push", "origin", f"{alternate}:{self.ref_name}")
+                return ""
+            return original_run_git(repository, arguments, **kwargs)
+
+        with self.local_remote_contract(), mock.patch.object(
+            creator, "run_git", side_effect=race_different_ref
+        ), self.assertRaises(creator.HandoffCommitError) as raised:
+            self.publish()
+        self.assertIn("treat this as an incident", str(raised.exception))
+        self.assertEqual(self.remote_target(), alternate)
+
+    def test_remote_identity_requires_one_exact_credential_free_github_url(self) -> None:
+        with self.assertRaises(creator.HandoffCommitError):
+            creator.verify_remote_identity(
+                self.repository, "origin", "FerrumVir/arc-chain"
+            )
+        exact = "https://github.com/FerrumVir/arc-chain.git"
+        self.git("remote", "set-url", "origin", exact)
+        self.assertEqual(
+            creator.verify_remote_identity(
+                self.repository, "origin", "FerrumVir/arc-chain"
+            ),
+            (exact, exact),
+        )
+        credentialed = "https://secret-token@github.com/FerrumVir/arc-chain.git"
+        self.git("remote", "set-url", "origin", credentialed)
+        with self.assertRaises(creator.HandoffCommitError) as raised:
+            creator.verify_remote_identity(
+                self.repository, "origin", "FerrumVir/arc-chain"
+            )
+        self.assertNotIn("secret-token", str(raised.exception))
+
+    def test_remote_name_and_https_askpass_are_bounded_and_token_free_on_disk(
+        self,
+    ) -> None:
+        self.git(
+            "remote", "set-url", "origin", "https://github.com/FerrumVir/arc-chain.git"
+        )
+        with self.assertRaises(creator.HandoffCommitError):
+            creator.verify_remote_identity(
+                self.repository, "--upload-pack=owned", "FerrumVir/arc-chain"
+            )
+        secret = "ghp_SENTINEL_ASKPASS_TOKEN_1234567890"
+        with mock.patch.dict(os.environ, {"GH_TOKEN": secret}, clear=False):
+            with creator.remote_push_environment(
+                "https://github.com/FerrumVir/arc-chain.git"
+            ) as environment:
+                askpass = Path(environment["GIT_ASKPASS"])
+                self.assertTrue(askpass.is_file())
+                self.assertEqual(askpass.stat().st_mode & 0o777, 0o700)
+                self.assertNotIn(secret.encode(), askpass.read_bytes())
+                self.assertEqual(environment["ARC_HANDOFF_PUSH_TOKEN"], secret)
+                self.assertNotIn("GH_TOKEN", environment)
+                self.assertNotIn("GITHUB_TOKEN", environment)
+                self.assertIn("credential.helper", environment.values())
+                self.assertIn("http.extraHeader", environment.values())
+                askpass_path = askpass
+            self.assertFalse(askpass_path.exists())
+
+        with mock.patch.dict(os.environ, {"GH_TOKEN": "bad token"}, clear=False):
+            with self.assertRaises(creator.HandoffCommitError):
+                with creator.remote_push_environment(
+                    "https://github.com/FerrumVir/arc-chain.git"
+                ):
+                    pass
+
+
+class CutoverHandoffIsolationTests(unittest.TestCase):
+    def test_pythonpath_sitecustomize_and_tokens_do_not_reach_derived_tools(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            malicious = root / "malicious"
+            malicious.mkdir()
+            sitecustomize_marker = root / "sitecustomize-ran"
+            (malicious / "sitecustomize.py").write_text(
+                "from pathlib import Path\n"
+                f"Path({str(sitecustomize_marker)!r}).write_text('executed')\n",
+                encoding="utf-8",
+            )
+            observed = root / "observed.json"
+            probe = root / "probe.py"
+            probe.write_text(
+                "import json, os, sys\n"
+                "from pathlib import Path\n"
+                "Path(sys.argv[1]).write_text(json.dumps({"
+                "'argv': sys.argv, 'environment': dict(os.environ)"
+                "}, sort_keys=True))\n",
+                encoding="utf-8",
+            )
+            safe_home = root / "safe-home"
+            safe_home.mkdir(mode=0o700)
+            secret = "ghp_SENTINEL_TOKEN_MUST_NOT_ESCAPE_123456789"
+            hostile_environment = {
+                "PYTHONPATH": str(malicious),
+                "PYTHONHOME": str(malicious),
+                "GH_TOKEN": secret,
+                "GITHUB_TOKEN": secret,
+                "SSH_AUTH_SOCK": str(root / "agent.sock"),
+                "GOOGLE_APPLICATION_CREDENTIALS": str(root / "cloud.json"),
+            }
+            with mock.patch.dict(os.environ, hostile_environment, clear=False):
+                creator.run_isolated_python(
+                    probe,
+                    [str(observed)],
+                    "hostile isolation probe",
+                    safe_home=safe_home,
+                )
+            self.assertFalse(sitecustomize_marker.exists())
+            payload = json.loads(observed.read_text(encoding="utf-8"))
+            expected_environment = {
+                "HOME": str(safe_home),
+                "PATH": "/usr/bin:/bin",
+                "LANG": "C",
+                "LC_ALL": "C",
+                "TZ": "UTC",
+            }
+            for name, value in expected_environment.items():
+                self.assertEqual(payload["environment"].get(name), value)
+            self.assertLessEqual(
+                set(payload["environment"]) - set(expected_environment),
+                {"__CF_USER_TEXT_ENCODING"},
+            )
+            serialized = json.dumps(payload, sort_keys=True)
+            self.assertNotIn(secret, serialized)
+            self.assertNotIn("PYTHONPATH", serialized)
+            self.assertEqual(payload["argv"], [str(probe), str(observed)])
+
+    def test_isolated_tool_failure_diagnostic_cannot_echo_parent_token(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            safe_home = root / "safe-home"
+            safe_home.mkdir(mode=0o700)
+            probe = root / "fail.py"
+            probe.write_text(
+                "import os, sys\nprint(dict(os.environ), file=sys.stderr)\nraise SystemExit(7)\n",
+                encoding="utf-8",
+            )
+            secret = "ghp_SENTINEL_TOKEN_MUST_NOT_ESCAPE_987654321"
+            with mock.patch.dict(os.environ, {"GH_TOKEN": secret}, clear=False), self.assertRaises(
+                creator.HandoffCommitError
+            ) as raised:
+                creator.run_isolated_python(
+                    probe, [], "failing isolation probe", safe_home=safe_home
+                )
+            self.assertNotIn(secret, str(raised.exception))
 
 
 class RecoveryHandoffWorkflowContractTests(unittest.TestCase):

--- a/tests/release/test_privileged_workflow_boundaries.py
+++ b/tests/release/test_privileged_workflow_boundaries.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import subprocess
 import textwrap
 import unittest
 from dataclasses import dataclass
@@ -87,7 +88,7 @@ SHELL_BUILTINS = {
 }
 
 PRE_SECRET_COMMANDS = {
-    "$node_bin", "/usr/bin/awk", "/usr/bin/cmp", "/usr/bin/find",
+    "$node_bin", "$python_bin", "$python_candidate", "/usr/bin/awk", "/usr/bin/cmp", "/usr/bin/find",
     "/usr/bin/gh", "/usr/bin/jq", "/usr/bin/python3", "/usr/bin/sha256sum",
     "/usr/bin/shasum", "/usr/bin/sort", "/usr/bin/tr", "/usr/bin/wc",
     "awk", "command", "cmp", "find", "gh", "git", "install", "jq", "mv", "npm",
@@ -398,11 +399,14 @@ def require_exact_command_heads(run: str, allowed: set[str], *, label: str) -> N
         raise BoundaryError(f"{label} contains legacy command substitution")
     if re.search(r"(?m)(?:^|[;&|])[ \t]*[\"']?\$\((?!\()", run):
         raise BoundaryError(f"{label} executes the output of a command substitution")
-    python_heads = len(re.findall(r"(?<![A-Za-z0-9_./-])/usr/bin/python3(?:\s|$)", run))
+    isolated_python = r'(?:/usr/bin/python3|"\$python_bin")'
+    python_heads = len(
+        re.findall(rf"(?m)^\s*{isolated_python}(?:\s|$)", run)
+    )
     python_bodies = [
         textwrap.dedent(match.group("body"))
         for match in re.finditer(
-            r"/usr/bin/python3\s+-I\s+-(?:[^\n]*\\\n)*[^\n]*<<'PY'\n"
+            rf"{isolated_python}\s+-I\s+-(?:[^\n]*\\\n)*[^\n]*<<'PY'\n"
             r"(?P<body>.*?)^\s*PY\s*$",
             run,
             re.MULTILINE | re.DOTALL,
@@ -479,6 +483,110 @@ def require_privileged_shell_isolation(step: Step, *, label: str) -> None:
             raise BoundaryError(f"{label} lacks in-shell isolation: {literal}")
 
 
+def require_platform_node_resolution(job: Job, *, label: str) -> None:
+    step_names = {
+        "updater-key": "Install the locked Tauri signer",
+        "desktop-bundle": "Freeze the exact locked file-signing surface without executing it",
+    }
+    expected_name = step_names[job.name]
+    matching = [step for step in job.steps if step.name == expected_name]
+    if len(matching) != 1:
+        raise BoundaryError(f"{label} lacks its unique locked Node resolution step")
+    run = matching[0].run
+    resolution = textwrap.dedent(
+        '''\
+        case "$RUNNER_OS" in
+          Windows)
+            node_bin="$(command -v node.exe)"
+            ;;
+          Linux|macOS)
+            node_bin="$(command -v node)"
+            ;;
+          *)
+            echo "::error::Unsupported runner OS for the locked Node runtime: $RUNNER_OS"
+            exit 1
+            ;;
+        esac
+        case "$node_bin" in
+          /*) ;;
+          *)
+            echo "::error::The locked Node runtime did not resolve to an absolute executable."
+            exit 1
+            ;;
+        esac
+        '''
+    ).strip()
+    if resolution not in textwrap.dedent(run):
+        raise BoundaryError(f"{label} does not resolve the locked Node executable per OS")
+    if '[ -f "$node_bin" ] && [ ! -L "$node_bin" ] && [ -x "$node_bin" ]' not in run:
+        raise BoundaryError(f"{label} does not reject a missing, linked, or non-executable Node path")
+
+
+def require_platform_python_resolution(job: Job, *, label: str) -> None:
+    matching = [
+        step
+        for step in job.steps
+        if step.name == "Validate the sealed handoff and make payloads non-executable"
+    ]
+    if len(matching) != 1:
+        raise BoundaryError(f"{label} lacks its unique sealed-handoff validator")
+    run = textwrap.dedent(matching[0].run)
+    resolution = textwrap.dedent(
+        '''\
+        case "$RUNNER_OS" in
+          Windows)
+            python_candidate="$(command -v python.exe)"
+            python_bin="$python_candidate"
+            ;;
+          Linux|macOS)
+            python_candidate="$(command -v python3)"
+            case "$python_candidate" in
+              /*) ;;
+              *)
+                echo "::error::Python did not resolve to an absolute executable."
+                exit 1
+                ;;
+            esac
+            python_bin="$("$python_candidate" -I -c \\
+              'import os, sys; print(os.path.realpath(sys.executable))')"
+            ;;
+          *)
+            echo "::error::Unsupported runner OS for the isolated Python runtime: $RUNNER_OS"
+            exit 1
+            ;;
+        esac
+        '''
+    ).strip()
+    normalized_run = "\n".join(line.strip() for line in run.splitlines())
+    normalized_resolution = "\n".join(
+        line.strip() for line in resolution.splitlines()
+    )
+    if normalized_resolution not in normalized_run:
+        raise BoundaryError(f"{label} does not resolve the isolated Python executable per OS")
+    for literal in (
+        'case "$python_bin" in',
+        '[ -f "$python_bin" ] && [ ! -L "$python_bin" ] && [ -x "$python_bin" ]',
+        'python_sha256="$(/usr/bin/shasum -a 256 "$python_bin"',
+        'python_sha256="$(/usr/bin/sha256sum "$python_bin"',
+        'current_python_sha256="$(/usr/bin/shasum -a 256 "$python_bin"',
+        'current_python_sha256="$(/usr/bin/sha256sum "$python_bin"',
+        '[ "$current_python_sha256" = "$python_sha256" ]',
+        '"$python_bin" -I - "$GITHUB_REPOSITORY" "$EXPECTED_SHA"',
+    ):
+        if literal not in run:
+            raise BoundaryError(f"{label} omits frozen Python boundary: {literal}")
+
+
+def require_platform_verifier_suffix(job: Job, *, label: str) -> None:
+    suffix_name = "exe-suffix" if job.name == "updater-key" else "binary-suffix"
+    invocation = (
+        '"$verifier_target/debug/tauri-updater-verifier'
+        f'${{{{ matrix.{suffix_name} }}}}"'
+    )
+    if invocation not in job.text:
+        raise BoundaryError(f"{label} omits the native verifier executable suffix")
+
+
 def reject_repo_execution(text: str, *, label: str, allow_inline_python: bool = True) -> None:
     forbidden = {
         "repository script path": r"scripts/",
@@ -494,6 +602,25 @@ def reject_repo_execution(text: str, *, label: str, allow_inline_python: bool = 
             raise BoundaryError(f"{label} contains {description}")
 
 
+def backup_manifest_public_key_awk(text: str) -> str:
+    """Return the exact inline canonicalizer exercised by backup readiness."""
+    start = text.find("          canonicalize_manifest_public_key() {")
+    if start < 0:
+        raise BoundaryError("backup readiness lacks the manifest public-key canonicalizer")
+    end = text.find("\n          }", start)
+    if end < 0:
+        raise BoundaryError("backup readiness manifest public-key canonicalizer is unterminated")
+    function = text[start:end]
+    match = re.search(
+        r"/usr/bin/awk '\n(?P<body>.*?)\n            ' \"\$input_path\" > \"\$output_path\"",
+        function,
+        re.DOTALL,
+    )
+    if match is None:
+        raise BoundaryError("backup readiness manifest public-key canonicalizer is not the reviewed awk form")
+    return textwrap.dedent(match.group("body"))
+
+
 def validate_secret_workflows(texts: dict[str, str]) -> None:
     allowed_jobs = {
         ("preflight", "backup-readiness"),
@@ -507,6 +634,17 @@ def validate_secret_workflows(texts: dict[str, str]) -> None:
     secret_steps = 0
     for workflow_name, text in texts.items():
         for job_name, job in parse_jobs(text).items():
+            if workflow_name == "preflight" and job_name in {"updater-key", "desktop-bundle"}:
+                require_platform_node_resolution(
+                    job, label=f"locked Node surface {workflow_name}/{job_name}"
+                )
+                require_platform_verifier_suffix(
+                    job, label=f"updater verifier surface {workflow_name}/{job_name}"
+                )
+            if workflow_name == "preflight" and job_name == "desktop-bundle":
+                require_platform_python_resolution(
+                    job, label=f"isolated Python surface {workflow_name}/{job_name}"
+                )
             matching = [index for index, step in enumerate(job.steps) if "${{ secrets." in step.text]
             if not matching:
                 continue
@@ -571,6 +709,16 @@ def validate_secret_workflows(texts: dict[str, str]) -> None:
                     reject_repo_execution(step.run, label="backup readiness secret step", allow_inline_python=False)
                     for required in (
                         "/usr/bin/gpg", "signer sign", "cleanup_plaintext",
+                        "canonicalize_manifest_public_key",
+                        "NR != 1 { exit 1 }",
+                        "if (NF != 2 && NF != 3) exit 1",
+                        'if ($1 != "ssh-ed25519") exit 1',
+                        'if ($2 !~ /^[A-Za-z0-9+\\/]+={0,2}$/) exit 1',
+                        'if (NF == 3 && $3 != "arc-release-manifest-v1") exit 1',
+                        'print $1 " " $2',
+                        '"$derived_manifest_canonical" "$expected_manifest_canonical"',
+                        '"$restored_manifest_canonical" "$expected_manifest_canonical"',
+                        '"$expected_manifest" "$expected_manifest_canonical"',
                         "ARC_NODE_SHA256:", "ARC_TAURI_CLI_SHA256:",
                         "node-version: 24.20.0",
                     ):
@@ -679,6 +827,59 @@ class PrivilegedWorkflowBoundaryTests(unittest.TestCase):
     def test_current_secret_and_publication_boundaries(self) -> None:
         validate_secret_workflows(self.texts)
         validate_publish_authority(self.texts["release"])
+
+    def test_backup_manifest_public_key_canonicalizer(self) -> None:
+        text = self.texts["preflight"]
+        self.assertIn(
+            'canonicalize_manifest_public_key \\\n'
+            '            "$expected_manifest" "$expected_manifest_canonical"',
+            text,
+        )
+        self.assertNotIn(
+            '> "$expected_manifest_canonical"',
+            text,
+        )
+        expected_match = re.search(
+            r"^          ARC_EXPECTED_MANIFEST_PUBLIC_KEY: (ssh-ed25519 [A-Za-z0-9+/=]+)$",
+            text,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(expected_match)
+        expected = expected_match.group(1)
+        algorithm, key = expected.split(" ")
+        program = backup_manifest_public_key_awk(text)
+
+        def accepted(value: str) -> bool:
+            completed = subprocess.run(
+                ["/usr/bin/awk", program],
+                input=value,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            return completed.returncode == 0 and completed.stdout == expected + "\n"
+
+        for value in (
+            expected + "\n",
+            expected + " arc-release-manifest-v1\n",
+            f"  {algorithm}\t{key}   arc-release-manifest-v1  \n",
+        ):
+            with self.subTest(valid=value):
+                self.assertTrue(accepted(value))
+
+        for value in (
+            "",
+            f"ssh-rsa {key}\n",
+            f"{algorithm} {key} unreviewed-comment\n",
+            f"{algorithm} {key} arc-release-manifest-v1 extra\n",
+            f"{algorithm} {key[:-1]}*\n",
+            f"{algorithm} AAAAC3NzaC1lZDI1NTE5AAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n",
+            expected + "\r\n",
+            expected + "\n\n",
+            expected + "\n" + expected + "\n",
+        ):
+            with self.subTest(invalid=value):
+                self.assertFalse(accepted(value))
 
     def assert_secret_mutation_rejected(self, workflow: str, old: str, new: str) -> None:
         mutated = dict(self.texts)
@@ -844,6 +1045,57 @@ class PrivilegedWorkflowBoundaryTests(unittest.TestCase):
         ):
             with self.subTest(old=old):
                 self.assert_secret_mutation_rejected("preflight", old, new)
+
+    def test_rejects_extensionless_or_linkable_windows_node_runtime(self) -> None:
+        original = self.texts["preflight"]
+        attacks = (
+            ('node_bin="$(command -v node.exe)"', 'node_bin="$(command -v node)"'),
+            (
+                '[ -f "$node_bin" ] && [ ! -L "$node_bin" ] && [ -x "$node_bin" ]',
+                '[ -x "$node_bin" ]',
+            ),
+        )
+        for old, new in attacks:
+            positions = [match.start() for match in re.finditer(re.escape(old), original)]
+            self.assertEqual(len(positions), 2)
+            for occurrence, position in enumerate(positions):
+                with self.subTest(old=old, occurrence=occurrence):
+                    mutated_text = original[:position] + new + original[position + len(old):]
+                    mutated = dict(self.texts)
+                    mutated["preflight"] = mutated_text
+                    with self.assertRaises(BoundaryError):
+                        validate_secret_workflows(mutated)
+
+    def test_rejects_unfrozen_or_nonisolated_windows_python_runtime(self) -> None:
+        attacks = (
+            ('python_candidate="$(command -v python.exe)"',
+             'python_candidate="$(command -v python3)"'),
+            (
+                '[ -f "$python_bin" ] && [ ! -L "$python_bin" ] && [ -x "$python_bin" ]',
+                '[ -x "$python_bin" ]',
+            ),
+            ('[ "$current_python_sha256" = "$python_sha256" ]', 'true'),
+            (
+                '"$python_bin" -I - "$GITHUB_REPOSITORY" "$EXPECTED_SHA"',
+                '"$python_bin" - "$GITHUB_REPOSITORY" "$EXPECTED_SHA"',
+            ),
+        )
+        for old, new in attacks:
+            with self.subTest(old=old):
+                self.assert_secret_mutation_rejected("preflight", old, new)
+
+    def test_rejects_extensionless_windows_updater_verifier(self) -> None:
+        for suffix_name in ("exe-suffix", "binary-suffix"):
+            old = (
+                '"$verifier_target/debug/tauri-updater-verifier'
+                f'${{{{ matrix.{suffix_name} }}}}"'
+            )
+            with self.subTest(suffix=suffix_name):
+                self.assert_secret_mutation_rejected(
+                    "preflight",
+                    old,
+                    '"$verifier_target/debug/tauri-updater-verifier"',
+                )
 
     def test_rejects_post_patch_delete_or_unbounded_immutability_wait(self) -> None:
         for old, new in (

--- a/tests/release/test_unsigned_desktop_handoff.py
+++ b/tests/release/test_unsigned_desktop_handoff.py
@@ -430,6 +430,18 @@ class UnsignedDesktopHandoffTests(unittest.TestCase):
             succeeds=False,
         )
 
+        _, writable = self.materialized("macos-x86_64")
+        (writable / "arc-desktop-macos-x86_64.dmg").chmod(0o600)
+        (writable / "arc-desktop-macos-x86_64.app.tar.gz.sig").write_bytes(b"sig")
+        result = self.invoke(
+            "verify-signed",
+            "macos-x86_64",
+            "--workspace",
+            str(writable),
+            succeeds=False,
+        )
+        self.assertIn("regained permissions", result.stderr)
+
         _, extra = self.materialized("windows-x86_64")
         (extra / "arc-desktop-windows-x86_64-setup.exe.sig").write_bytes(b"sig")
         (extra / "unexpected.sig").write_bytes(b"extra")

--- a/tests/release/test_unsigned_desktop_windows_permissions.py
+++ b/tests/release/test_unsigned_desktop_windows_permissions.py
@@ -151,7 +151,8 @@ class PermissionModelTests(unittest.TestCase):
             "if: runner.os == 'Windows'",
             "test_unsigned_desktop_windows_permissions.py -v",
             "MSYS_NO_PATHCONV=1 taskkill.exe",
-            "Native taskkill did not terminate the Windows probe.",
+            "kill -KILL \"$probe_pid\"",
+            "Native Windows cleanup did not terminate the probe.",
         ):
             with self.subTest(literal=literal):
                 self.assertIn(literal, job)

--- a/tests/release/test_unsigned_desktop_windows_permissions.py
+++ b/tests/release/test_unsigned_desktop_windows_permissions.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Native-Windows and hostile tests for the desktop signer permission gate."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELPER = REPO_ROOT / "scripts" / "release" / "unsigned-desktop-handoff.py"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-signing-preflight.yml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+REPOSITORY = "FerrumVir/arc-chain"
+COMMIT = "0123456789abcdef0123456789abcdef01234567"
+RUN_ID = 12345
+RUN_ATTEMPT = 2
+VERSION = "0.8.0"
+PLATFORM = "windows-x86_64"
+TARGET = "x86_64-pc-windows-msvc"
+PAYLOAD_NAMES = (
+    "arc-desktop-windows-x86_64-setup.exe",
+    "arc-desktop-windows-x86_64.msi",
+)
+UPDATER_NAME = PAYLOAD_NAMES[0]
+
+spec = importlib.util.spec_from_file_location("unsigned_handoff_windows", HELPER)
+assert spec is not None and spec.loader is not None
+HANDOFF = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(HANDOFF)
+
+
+class PermissionModelTests(unittest.TestCase):
+    def test_posix_contract_remains_exact_owner_read_only(self) -> None:
+        for mode, accepted in ((0o400, True), (0o444, False), (0o600, False)):
+            with self.subTest(mode=oct(mode)):
+                metadata = SimpleNamespace(st_mode=stat.S_IFREG | mode)
+                self.assertEqual(
+                    HANDOFF.signer_input_permissions_are_read_only(
+                        metadata, windows=False
+                    ),
+                    accepted,
+                )
+
+    def test_windows_contract_requires_attribute_and_rejects_writes_and_reparse(self) -> None:
+        readonly = stat.FILE_ATTRIBUTE_READONLY
+        reparse = stat.FILE_ATTRIBUTE_REPARSE_POINT
+        cases = (
+            (0o444, readonly, True),
+            (0o444, 0, False),
+            (0o644, readonly, False),
+            (0o444, readonly | reparse, False),
+            (0o444, None, False),
+        )
+        for mode, attributes, accepted in cases:
+            with self.subTest(mode=oct(mode), attributes=attributes):
+                values = {"st_mode": stat.S_IFREG | mode}
+                if attributes is not None:
+                    values["st_file_attributes"] = attributes
+                metadata = SimpleNamespace(**values)
+                self.assertEqual(
+                    HANDOFF.signer_input_permissions_are_read_only(
+                        metadata, windows=True
+                    ),
+                    accepted,
+                )
+
+    def test_open_file_mode_rejects_descriptor_identity_change(self) -> None:
+        with tempfile.TemporaryDirectory(
+            prefix="arc-open-file-mode-identity."
+        ) as temporary:
+            path = Path(temporary) / "receipt"
+            descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            try:
+                original = os.fstat(descriptor)
+                replacement = SimpleNamespace(
+                    st_mode=original.st_mode,
+                    st_dev=original.st_dev,
+                    st_ino=original.st_ino + 1,
+                    st_nlink=1,
+                )
+                with mock.patch.object(
+                    HANDOFF.os, "fstat", side_effect=(original, replacement)
+                ):
+                    with self.assertRaisesRegex(
+                        SystemExit, "identity changed during chmod"
+                    ):
+                        HANDOFF.set_open_file_mode(path, descriptor, 0o400)
+            finally:
+                os.close(descriptor)
+
+    def test_protected_workflow_freezes_a_native_windows_python(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        start = workflow.index(
+            "- name: Validate the sealed handoff and make payloads non-executable"
+        )
+        end = workflow.index(
+            "- name: Rehydrate the exact locked signer after materialization", start
+        )
+        validator = workflow[start:end]
+        self.assertIn('python_candidate="$(command -v python.exe)"', validator)
+        self.assertIn(
+            '[ -f "$python_bin" ] && [ ! -L "$python_bin" ] && [ -x "$python_bin" ]',
+            validator,
+        )
+        self.assertIn('current_python_sha256', validator)
+        self.assertIn('[ "$current_python_sha256" = "$python_sha256" ]', validator)
+        self.assertIn('"$python_bin" -I - "$GITHUB_REPOSITORY"', validator)
+        self.assertNotIn(
+            '/usr/bin/python3 -I - "$GITHUB_REPOSITORY"', validator
+        )
+
+    def test_windows_headless_cleanup_is_scoped_bounded_and_nonblocking(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        start = workflow.index(
+            "- name: Boot the headless node and require a truthful health response"
+        )
+        end = workflow.index(
+            "- name: Package a hash-bound validator-staging artifact", start
+        )
+        cleanup = workflow[start:end]
+        for literal in (
+            "cleanup_rc=$?",
+            "MSYS_NO_PATHCONV=1 taskkill.exe",
+            "for _ in {1..40}; do",
+            "kill -KILL \"$node_pid\"",
+            "for _ in {1..20}; do",
+            "The Windows headless smoke process could not be terminated.",
+            "exit \"$cleanup_rc\"",
+        ):
+            with self.subTest(literal=literal):
+                self.assertIn(literal, cleanup)
+        self.assertNotIn("taskkill.exe /PID", cleanup)
+
+    def test_required_windows_ci_executes_native_permission_and_process_probes(self) -> None:
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+        start = workflow.index("  desktop-tauri-test:")
+        end = workflow.index("  desktop-e2e:", start)
+        job = workflow[start:end]
+        for literal in (
+            "os: [ubuntu-latest, macos-15, macos-15-intel, windows-latest]",
+            "- name: Native Windows signer handoff permission boundary",
+            "if: runner.os == 'Windows'",
+            "test_unsigned_desktop_windows_permissions.py -v",
+            "MSYS_NO_PATHCONV=1 taskkill.exe",
+            "Native taskkill did not terminate the Windows probe.",
+        ):
+            with self.subTest(literal=literal):
+                self.assertIn(literal, job)
+
+
+@unittest.skipUnless(os.name == "nt", "requires native Windows chmod semantics")
+class NativeWindowsPermissionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(
+            prefix="arc-unsigned-desktop-windows-permissions."
+        )
+        self.root = Path(self.temporary.name)
+
+    def tearDown(self) -> None:
+        # A rejected workspace intentionally retains read-only files. Clear the
+        # attribute so TemporaryDirectory can remove them on every CPython.
+        for path in self.root.rglob("*"):
+            if path.is_file():
+                try:
+                    os.chmod(path, stat.S_IREAD | stat.S_IWRITE)
+                except OSError:
+                    pass
+        self.temporary.cleanup()
+
+    def make_workspace(self, name: str) -> tuple[Path, argparse.Namespace]:
+        workspace = self.root / name
+        workspace.mkdir()
+        hashes: dict[str, str] = {}
+        for index, filename in enumerate(PAYLOAD_NAMES, start=1):
+            payload = f"ARC native Windows payload {index}\n".encode()
+            path = workspace / filename
+            path.write_bytes(payload)
+            hashes[filename] = hashlib.sha256(payload).hexdigest()
+        receipt = {
+            "schema": "arc.unsigned-desktop-materialization.v1",
+            "repository": REPOSITORY,
+            "commit": COMMIT,
+            "workflow_run_id": RUN_ID,
+            "workflow_run_attempt": RUN_ATTEMPT,
+            "platform": PLATFORM,
+            "rust_target": TARGET,
+            "version": VERSION,
+            "files": hashes,
+            "modes": {filename: 0o644 for filename in PAYLOAD_NAMES},
+            "updater_file": UPDATER_NAME,
+        }
+        (workspace / "HANDOFF-RECEIPT.json").write_bytes(
+            HANDOFF.canonical_json(receipt)
+        )
+        (workspace / f"{UPDATER_NAME}.sig").write_bytes(b"fixture signature")
+        for filename in PAYLOAD_NAMES:
+            os.chmod(workspace / filename, stat.S_IREAD)
+        args = argparse.Namespace(
+            repository=REPOSITORY,
+            commit=COMMIT,
+            run_id=RUN_ID,
+            run_attempt=RUN_ATTEMPT,
+            platform=PLATFORM,
+            rust_target=TARGET,
+            version=VERSION,
+            workspace=workspace,
+            github_output=None,
+        )
+        return workspace, args
+
+    def test_native_python312_fallback_packages_exact_read_only_handoff(self) -> None:
+        package_root = self.root / "package-python312"
+        payload_dir = package_root / "payload"
+        payload_dir.mkdir(parents=True)
+        for index, filename in enumerate(PAYLOAD_NAMES, start=1):
+            (payload_dir / filename).write_bytes(
+                f"ARC native Windows package payload {index}\n".encode()
+            )
+        stage_dir = package_root / "stage"
+        github_output = package_root / "github-output"
+        args = argparse.Namespace(
+            repository=REPOSITORY,
+            commit=COMMIT,
+            run_id=RUN_ID,
+            run_attempt=RUN_ATTEMPT,
+            platform=PLATFORM,
+            rust_target=TARGET,
+            version=VERSION,
+            payload_dir=payload_dir,
+            stage_dir=stage_dir,
+            github_output=github_output,
+        )
+
+        # Python 3.12 on the hosted Windows image has no os.fchmod. Keep this
+        # exact fallback exercised even after the runner eventually advances.
+        with mock.patch.object(HANDOFF.os, "fchmod", None, create=True):
+            HANDOFF.package(args)
+
+        outputs = dict(
+            line.split("=", 1)
+            for line in github_output.read_text(encoding="utf-8").splitlines()
+        )
+        expected_members = {
+            "BUILD-METADATA.json",
+            "SHA256SUMS",
+            outputs["archive_name"],
+        }
+        self.assertEqual({path.name for path in stage_dir.iterdir()}, expected_members)
+        for path in stage_dir.iterdir():
+            metadata = path.lstat()
+            self.assertEqual(
+                metadata.st_file_attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT, 0
+            )
+            self.assertNotEqual(
+                metadata.st_file_attributes & stat.FILE_ATTRIBUTE_READONLY, 0
+            )
+
+    def test_native_read_only_payload_passes_and_release_mode_is_restored(self) -> None:
+        workspace, args = self.make_workspace("accepted")
+        for filename in PAYLOAD_NAMES:
+            metadata = (workspace / filename).lstat()
+            self.assertNotEqual(
+                metadata.st_file_attributes & stat.FILE_ATTRIBUTE_READONLY, 0
+            )
+            self.assertTrue(
+                HANDOFF.signer_input_permissions_are_read_only(
+                    metadata, windows=True
+                )
+            )
+
+        HANDOFF.verify_signed(args)
+
+        for filename in PAYLOAD_NAMES:
+            metadata = (workspace / filename).lstat()
+            self.assertEqual(
+                metadata.st_file_attributes & stat.FILE_ATTRIBUTE_READONLY, 0
+            )
+
+    def test_native_writable_payload_is_rejected_with_identical_bytes(self) -> None:
+        workspace, args = self.make_workspace("writable")
+        hostile = workspace / PAYLOAD_NAMES[1]
+        os.chmod(hostile, stat.S_IREAD | stat.S_IWRITE)
+        metadata = hostile.lstat()
+        self.assertEqual(
+            metadata.st_file_attributes & stat.FILE_ATTRIBUTE_READONLY, 0
+        )
+
+        with self.assertRaisesRegex(SystemExit, "regained permissions"):
+            HANDOFF.verify_signed(args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/release/unsigned_desktop_handoff_test.sh
+++ b/tests/release/unsigned_desktop_handoff_test.sh
@@ -7,6 +7,7 @@ TEST_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 
 unsigned_handoff_is_exact_and_adversarially_verified() {
     python3 "$TEST_DIR/test_unsigned_desktop_handoff.py"
+    python3 "$TEST_DIR/test_unsigned_desktop_windows_permissions.py"
 }
 
 run_test \


### PR DESCRIPTION
## What this fixes

- unblocks the protected v0.8.0 pre-tag signing flow on Windows and Linux
- normalizes GitHub artifact digests across job/API boundaries
- makes unsigned desktop handoff permissions work on hosted Windows Python 3.12
- hardens create-only cutover handoff, release publication, and Pages provenance
- fixes archive sealing for systemd timer units and expands crash/recovery coverage
- corrects desktop inference timeouts for prompt + generation parallel verification budgets
- adds an executable, resumable six-validator recovery and production release runbook

## Validation

- exact Node 24.20.0 quick quality gate: 17/17 categories passed
- release harness: 35 static, 45 recovery, 19 cutover, 10 assembly, 48 installer/update cases passed
- dashboard: 32/32; explorer: 30/30
- workspace/release/benchmark tests and Clippy passed
- actionlint, ShellCheck, rustfmt, and git diff checks passed
- native Windows handoff/cleanup tests are required by the PR matrix

This PR preserves all legacy histories and forks; it does not mutate the live fleet. Production recovery proceeds only after exact-main CI, signing backup, vault rewrap, and preflight evidence succeed.