### PR TITLE
Canonicalize protected pre-tag metadata

### DIFF
--- a/scripts/recovery/build-production-manifest.py
+++ b/scripts/recovery/build-production-manifest.py
@@ -1513,10 +1513,8 @@ def validate_build_metadata(args: argparse.Namespace) -> tuple[dict[str, Any], s
         "files",
     }
     metadata = require_exact_object(metadata, fields, "pre-tag build metadata")
-    if payload != (
-        json.dumps(metadata, sort_keys=True, indent=2, ensure_ascii=True) + "\n"
-    ).encode("utf-8"):
-        fail("retained pre-tag BUILD-METADATA.json bytes are not the packaged canonical form")
+    if payload != canonical_bytes(metadata):
+        fail("retained pre-tag BUILD-METADATA.json bytes are not canonical JSON")
     expected = {
         "schema": "arc.pretag.artifact.v1",
         "kind": "headless",

--- a/scripts/recovery/recovery_rollout.py
+++ b/scripts/recovery/recovery_rollout.py
@@ -3696,10 +3696,9 @@ def verify_protected_pretag_stage_payloads(
         fail("Linux headless BUILD-METADATA.json is invalid JSON")
     if (
         not isinstance(metadata_value, dict)
-        or metadata_raw
-        != (json.dumps(metadata_value, sort_keys=True, indent=2) + "\n").encode()
+        or metadata_raw != canonical_bytes(metadata_value)
     ):
-        fail("Linux headless BUILD-METADATA.json is not the exact packaged JSON form")
+        fail("Linux headless BUILD-METADATA.json is not canonical JSON")
     metadata = require_keys(
         metadata_value,
         "Linux headless BUILD-METADATA.json",

--- a/scripts/recovery/test_build_production_manifest.py
+++ b/scripts/recovery/test_build_production_manifest.py
@@ -306,7 +306,7 @@ print(json.dumps(value,sort_keys=True))
                 "genesis.toml": sha(self.genesis.read_bytes()),
             },
         }
-        write(self.build_metadata, json.dumps(metadata, sort_keys=True, indent=2).encode() + b"\n", 0o444)
+        write(self.build_metadata, canonical(metadata), 0o444)
         self.raw_actions_zips: dict[tuple[str, str], pathlib.Path] = {}
         self.artifact_ids: dict[tuple[str, str], int] = {}
         input_rows = []
@@ -3734,7 +3734,7 @@ class ProductionManifestBuilderTests(unittest.TestCase):
     def test_prearchive_rejects_tampered_duplicate_symlink_and_wrong_commit(self) -> None:
         metadata = json.loads(self.fixture.build_metadata.read_text())
         metadata["commit"] = "7" * 40
-        write(self.fixture.build_metadata, json.dumps(metadata, sort_keys=True, indent=2).encode() + b"\n", 0o444)
+        write(self.fixture.build_metadata, canonical(metadata), 0o444)
         with self.assertRaisesRegex(builder.BuilderError, "metadata commit differs"):
             builder.prearchive(self.fixture.args())
 

--- a/scripts/release/materialize-pretag-artifacts.py
+++ b/scripts/release/materialize-pretag-artifacts.py
@@ -417,13 +417,11 @@ def verify_group(
                         shutil.copyfileobj(extracted, handle)
                     os.chmod(target, member.mode & 0o777)
 
+            metadata_path = temporary_root / "BUILD-METADATA.json"
             try:
-                metadata = json.loads(
-                    (temporary_root / "BUILD-METADATA.json").read_text(
-                        encoding="utf-8"
-                    )
-                )
-            except (OSError, json.JSONDecodeError) as error:
+                metadata_raw = metadata_path.read_bytes()
+                metadata = json.loads(metadata_raw)
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
                 fail(f"invalid build metadata for {kind}/{platform}: {error}")
             expected_metadata = {
                 "schema": "arc.pretag.artifact.v1",
@@ -435,6 +433,29 @@ def verify_group(
                 "workflow_run_id": args.run_id,
                 "workflow_run_attempt": args.run_attempt,
             }
+            expected_metadata_fields = set(expected_metadata) | {
+                "rust_target",
+                "files",
+            }
+            if not isinstance(metadata, dict) or set(metadata) != expected_metadata_fields:
+                fail(f"metadata field set differs for {kind}/{platform}")
+            try:
+                canonical_metadata = (
+                    json.dumps(
+                        metadata,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                        allow_nan=False,
+                    )
+                    + "\n"
+                ).encode("utf-8")
+            except (TypeError, ValueError) as error:
+                fail(
+                    f"build metadata is not canonical JSON for "
+                    f"{kind}/{platform}: {error}"
+                )
+            if metadata_raw != canonical_metadata:
+                fail(f"build metadata is not canonical JSON for {kind}/{platform}")
             for field, expected in expected_metadata.items():
                 if metadata.get(field) != expected:
                     fail(

--- a/scripts/release/package-pretag-artifact.py
+++ b/scripts/release/package-pretag-artifact.py
@@ -56,6 +56,18 @@ def sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def canonical_json_bytes(value: object) -> bytes:
+    return (
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--kind", required=True, choices=("headless", "desktop"))
@@ -133,9 +145,7 @@ def main() -> None:
         "files": files,
     }
     metadata_path = args.payload_dir / "BUILD-METADATA.json"
-    metadata_path.write_text(
-        json.dumps(metadata, sort_keys=True, indent=2) + "\n", encoding="utf-8"
-    )
+    metadata_path.write_bytes(canonical_json_bytes(metadata))
 
     stem = (
         f"arc-pretag-{args.kind}-{args.platform}-{args.commit}-"

--- a/scripts/release/protected_pretag_artifact.py
+++ b/scripts/release/protected_pretag_artifact.py
@@ -1198,6 +1198,8 @@ def extract_inner(
         metadata = json.loads(metadata_raw)
     except (UnicodeDecodeError, json.JSONDecodeError):
         fail("pre-tag BUILD-METADATA is not valid JSON")
+    if not isinstance(metadata, dict) or metadata_raw != canonical_json(metadata):
+        fail("pre-tag BUILD-METADATA is not canonical JSON")
     metadata = exact_object(
         metadata,
         {

--- a/tests/release/test_pretag_artifacts.py
+++ b/tests/release/test_pretag_artifacts.py
@@ -338,6 +338,13 @@ class PretagArtifactTests(unittest.TestCase):
         metadata = json.loads(
             (output / "BUILD-METADATA.json").read_text(encoding="utf-8")
         )
+        self.assertEqual(
+            (
+                json.dumps(metadata, sort_keys=True, separators=(",", ":"))
+                + "\n"
+            ).encode("utf-8"),
+            (output / "BUILD-METADATA.json").read_bytes(),
+        )
         self.assertEqual("arc.pretag.artifact.v1", metadata["schema"])
         self.assertEqual(COMMIT, metadata["commit"])
         self.assertEqual("macos-arm64", metadata["platform"])
@@ -570,6 +577,30 @@ class PretagArtifactTests(unittest.TestCase):
             "headless", "linux-x86_64", tar_bytes(values)
         )
         self.assert_materialize_fails("payload hash mismatch", "headless:linux-x86_64")
+
+    def test_materializer_rejects_noncanonical_build_metadata(self) -> None:
+        outer = self.fixture.outer_entries("headless", "linux-x86_64")
+        archive_name = next(key for key in outer if key.endswith(".tar.gz"))
+        original = io.BytesIO(outer[archive_name])
+        values: list[tuple[tarfile.TarInfo, bytes]] = []
+        with tarfile.open(fileobj=original, mode="r:gz") as archive:
+            for member in archive.getmembers():
+                extracted = archive.extractfile(member)
+                value = extracted.read() if extracted is not None else b""
+                if member.name == "BUILD-METADATA.json":
+                    metadata = json.loads(value)
+                    value = (
+                        json.dumps(metadata, sort_keys=True, indent=2) + "\n"
+                    ).encode("utf-8")
+                replacement = tarfile.TarInfo(member.name)
+                replacement.mode = member.mode
+                values.append((replacement, value))
+        self.fixture.replace_inner(
+            "headless", "linux-x86_64", tar_bytes(values)
+        )
+        self.assert_materialize_fails(
+            "build metadata is not canonical JSON", "headless:linux-x86_64"
+        )
 
     def test_packager_rejects_wrong_target_and_extra_payload(self) -> None:
         stage = Path(self.temporary.name) / "bad-package"

--- a/tests/release/test_protected_pretag_artifact.py
+++ b/tests/release/test_protected_pretag_artifact.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 
 import email.utils
 import hashlib
+import io
 import importlib.util
 import json
 import os
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 import unittest
 import zipfile
@@ -163,6 +165,56 @@ class Fixture:
             for index, (label, value) in enumerate(values.items(), start=1)
         }
 
+    def replace_build_metadata(self, replacement: bytes) -> None:
+        with zipfile.ZipFile(self.zip, "r") as outer:
+            archive_name = next(
+                name for name in outer.namelist() if name.endswith(".tar.gz")
+            )
+            archive_bytes = outer.read(archive_name)
+
+        rebuilt = io.BytesIO()
+        with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as source:
+            with tarfile.open(
+                fileobj=rebuilt, mode="w:gz", format=tarfile.PAX_FORMAT
+            ) as target:
+                for member in source.getmembers():
+                    extracted = source.extractfile(member)
+                    payload = extracted.read() if extracted is not None else b""
+                    if member.name == "BUILD-METADATA.json":
+                        payload = replacement
+                    member.size = len(payload)
+                    target.addfile(member, io.BytesIO(payload))
+
+        archive_bytes = rebuilt.getvalue()
+        self.archive_sha256 = hashlib.sha256(archive_bytes).hexdigest()
+        stem = (
+            f"arc-pretag-{self.kind}-{self.platform}-{COMMIT}-"
+            f"{RUN_ID}-{RUN_ATTEMPT}"
+        )
+        archive_name = f"{stem}.tar.gz"
+        checksums = "\n".join(
+            (
+                "# ARC pre-tag artifact v1",
+                f"# kind={self.kind}",
+                f"# repository={provenance.REPOSITORY}",
+                f"# commit={COMMIT}",
+                f"# run_id={RUN_ID}",
+                f"# run_attempt={RUN_ATTEMPT}",
+                f"# platform={self.platform}",
+                f"{self.archive_sha256}  {archive_name}",
+                "",
+            )
+        ).encode()
+        self.artifact_name = f"{stem}-{self.archive_sha256}"
+        self.zip.chmod(0o600)
+        with zipfile.ZipFile(self.zip, "w", compression=zipfile.ZIP_STORED) as outer:
+            outer.writestr(archive_name, archive_bytes)
+            outer.writestr("SHA256SUMS", checksums)
+        self.zip.chmod(0o400)
+        self.zip_sha256 = digest(self.zip)
+        self.zip_size = self.zip.stat().st_size
+        self.documents = self.api_documents()
+
     @contextmanager
     def verify(self):
         curl, curl_sha, ca, ca_sha = protected_runtime()
@@ -217,6 +269,30 @@ class ProtectedArtifactTests(unittest.TestCase):
             self.assertEqual(0o400, final.path.stat().st_mode & 0o777)
             root = verified.transaction_root
         self.assertFalse(root.exists())
+
+    def test_rehashed_semantic_build_metadata_must_still_be_canonical(self) -> None:
+        with zipfile.ZipFile(self.fixture.zip, "r") as outer:
+            archive_name = next(
+                name for name in outer.namelist() if name.endswith(".tar.gz")
+            )
+            with tarfile.open(
+                fileobj=io.BytesIO(outer.read(archive_name)), mode="r:gz"
+            ) as archive:
+                metadata_file = archive.extractfile("BUILD-METADATA.json")
+                assert metadata_file is not None
+                metadata = json.loads(metadata_file.read())
+        noncanonical = (
+            json.dumps(metadata, sort_keys=True, indent=2) + "\n"
+        ).encode()
+        self.assertNotEqual(noncanonical, provenance.canonical_json(metadata))
+        self.fixture.replace_build_metadata(noncanonical)
+
+        with self.assertRaisesRegex(
+            provenance.ProvenanceError,
+            "pre-tag BUILD-METADATA is not canonical JSON",
+        ):
+            with self.fixture.verify():
+                pass
 
     def test_forged_local_receipt_is_not_an_authorization_input(self) -> None:
         forged = self.fixture.root / "MATERIALIZATION-RECEIPT.json"


### PR DESCRIPTION
## Summary
- emit BUILD-METADATA.json in the compact canonical form required by protected restore
- enforce the same byte contract in materialization, shared protected verification, production manifest construction, and rollout
- add hostile repack regression coverage with all enclosing hashes recomputed

## Production failure addressed
The first v0.8.0 production attempt failed closed before CMS decryption or any node mutation because the pre-tag producer emitted pretty JSON while the restore boundary required compact canonical JSON. Existing artifacts remain immutable and will be regenerated from the merged exact main commit.

## Verification
- 158 release tests passed (3 native-Windows tests skipped on macOS)
- 194 recovery tests passed
- 42 focused protected artifact/vault tests passed
- Python compilation and git diff checks passed