### PR TITLE
Harden live artifact proofs against stale edge dates

### DIFF
--- a/scripts/release/protected_pretag_artifact.py
+++ b/scripts/release/protected_pretag_artifact.py
@@ -353,7 +353,19 @@ class CurlApiClient:
             character in endpoint for character in ("\r", "\n", "\0", "#")
         ):
             fail("GitHub REST endpoint escaped the fixed repository boundary")
+        if re.search(r"(?:[?&])_arc_proof=", endpoint) is not None:
+            fail("GitHub REST endpoint supplied the reserved proof nonce")
         self.counter += 1
+        # GitHub's anonymous REST edge may return a fresh request ID with an
+        # Age of zero while reusing the cached response Date for up to its
+        # advertised s-maxage.  A unique URL per GET prevents that stale Date
+        # from making the strict initial/final proof ordering nondeterministic.
+        separator = "&" if "?" in endpoint else "?"
+        try:
+            proof_nonce = os.urandom(32).hex()
+        except OSError:
+            fail("GitHub REST proof nonce entropy is unavailable")
+        request_endpoint = f"{endpoint}{separator}_arc_proof={proof_nonce}"
         header = self.transaction_root / f"api-{self.counter}.headers"
         body = self.transaction_root / f"api-{self.counter}.json"
         self._reprove_tools()
@@ -391,7 +403,7 @@ class CurlApiClient:
             "--header",
             "Authorization:",
             "--header",
-            "Cache-Control: no-cache",
+            "Cache-Control: no-cache, no-store, max-age=0",
             "--header",
             "Pragma: no-cache",
             "--user-agent",
@@ -400,7 +412,7 @@ class CurlApiClient:
             str(header),
             "--output",
             str(body),
-            f"{API_ORIGIN}{endpoint}",
+            f"{API_ORIGIN}{request_endpoint}",
         ]
         environment = {
             "HOME": str(self.transaction_root),

--- a/tests/release/test_protected_pretag_artifact.py
+++ b/tests/release/test_protected_pretag_artifact.py
@@ -9,6 +9,7 @@ import io
 import importlib.util
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -386,11 +387,24 @@ class ProtectedArtifactTests(unittest.TestCase):
         client = provenance.CurlApiClient(
             curl, curl_sha, ca, ca_sha, root, now=NOW
         )
-        with mock.patch.object(provenance.subprocess, "run", side_effect=fake_run):
-            document = client.get_json(
-                f"/repos/{provenance.REPOSITORY}/actions/workflows/release-signing-preflight.yml",
-                label="fixture",
-            )
+        endpoint = (
+            f"/repos/{provenance.REPOSITORY}/actions/workflows/"
+            "release-signing-preflight.yml"
+        )
+        commands: list[list[str]] = []
+
+        def capture_run(command: list[str], **kwargs):
+            result = fake_run(command, **kwargs)
+            commands.append(command)
+            return result
+
+        with mock.patch.object(
+            provenance.os,
+            "urandom",
+            side_effect=(b"a" * 32, b"b" * 32),
+        ), mock.patch.object(provenance.subprocess, "run", side_effect=capture_run):
+            document = client.get_json(endpoint, label="fixture")
+            client.get_json(endpoint, label="fixture")
         self.assertEqual({"id": 1}, document.value)
         command = captured["command"]
         assert isinstance(command, list)
@@ -400,14 +414,65 @@ class ProtectedArtifactTests(unittest.TestCase):
         self.assertNotIn("--location", command)
         self.assertNotIn("-L", command)
         self.assertIn("Authorization:", command)
-        self.assertIn("Cache-Control: no-cache", command)
+        self.assertIn("Cache-Control: no-cache, no-store, max-age=0", command)
         self.assertIn("Pragma: no-cache", command)
         self.assertFalse(any("token " in value.lower() for value in command))
+        urls = [item[-1] for item in commands]
+        self.assertEqual(2, len(set(urls)))
+        for url in urls:
+            self.assertRegex(
+                url,
+                rf"^{re.escape(provenance.API_ORIGIN + endpoint)}\?_arc_proof=[0-9a-f]{{64}}$",
+            )
         kwargs = captured["kwargs"]
         assert isinstance(kwargs, dict)
         environment = kwargs["env"]
         self.assertEqual({"HOME", "PATH", "LANG", "LC_ALL"}, set(environment))
         self.assertNotIn("HTTP_PROXY", environment)
+
+    def test_curl_client_preserves_existing_query_and_reserves_proof_nonce(self) -> None:
+        curl, curl_sha, ca, ca_sha = protected_runtime()
+        root = self.fixture.root / "api-query-root"
+        root.mkdir(mode=0o700)
+        captured_url: list[str] = []
+
+        def fake_run(command: list[str], **_kwargs):
+            captured_url.append(command[-1])
+            header = Path(command[command.index("--dump-header") + 1])
+            body = Path(command[command.index("--output") + 1])
+            response_date = email.utils.formatdate(NOW, usegmt=True)
+            header.write_bytes(
+                f"HTTP/2 200\r\ndate: {response_date}\r\n"
+                "cache-control: public, max-age=60, s-maxage=60\r\nage: 0\r\n"
+                "x-github-request-id: ABCD:1234:5678:9ABC\r\n\r\n".encode()
+            )
+            body.write_bytes(b'{"total_count":0,"artifacts":[]}\n')
+            return subprocess.CompletedProcess(command, 0, b"", b"")
+
+        client = provenance.CurlApiClient(
+            curl, curl_sha, ca, ca_sha, root, now=NOW
+        )
+        endpoint = f"/repos/{provenance.REPOSITORY}/actions/runs/1/artifacts?per_page=100"
+        with mock.patch.object(
+            provenance.os, "urandom", return_value=b"c" * 32
+        ), mock.patch.object(provenance.subprocess, "run", side_effect=fake_run):
+            client.get_json(endpoint, label="fixture")
+        self.assertRegex(
+            captured_url[0],
+            rf"^{re.escape(provenance.API_ORIGIN + endpoint)}&_arc_proof=[0-9a-f]{{64}}$",
+        )
+        with self.assertRaisesRegex(provenance.ProvenanceError, "reserved proof nonce"):
+            client.get_json(
+                f"/repos/{provenance.REPOSITORY}/branches/main?_arc_proof={'a' * 64}",
+                label="fixture",
+            )
+        with mock.patch.object(
+            provenance.os, "urandom", side_effect=OSError("entropy unavailable")
+        ), self.assertRaisesRegex(provenance.ProvenanceError, "entropy is unavailable"):
+            client.get_json(
+                f"/repos/{provenance.REPOSITORY}/branches/main",
+                label="fixture",
+            )
 
     def test_curl_client_rejects_stale_or_multiple_http_responses(self) -> None:
         stale = (

--- a/tests/release/test_validator_vault_restore.py
+++ b/tests/release/test_validator_vault_restore.py
@@ -1450,6 +1450,20 @@ class ValidatorVaultRestoreTests(unittest.TestCase):
         self.assertEqual([], list(remote_root.iterdir()))
 
         value = json.loads(original)
+        cached_window = [1_800_000_000, 1_800_000_001, 1_800_000_001, 1_800_000_002]
+        for phase in ("pretag_initial_provenance", "pretag_final_provenance"):
+            for row, response_unix in zip(
+                value[phase]["api"]["responses"], cached_window
+            ):
+                row["response_unix"] = response_unix
+            value[phase]["live"]["api_verified_at_unix"] = cached_window[0]
+        receipt_path.write_bytes(canonical(value))
+        receipt_path.chmod(0o600)
+        cached_dates = run(command, success=False)
+        self.assertIn("predates the initial proof", cached_dates.stderr)
+        self.assertEqual([], list(remote_root.iterdir()))
+
+        value = json.loads(original)
         for final, initial in zip(
             value["pretag_final_provenance"]["api"]["responses"],
             value["pretag_initial_provenance"]["api"]["responses"],


### PR DESCRIPTION
Fixes the fail-closed production recovery stop caused by GitHub edge caching fresh request IDs with reused Date headers.

- adds a fresh 256-bit cache-busting query to every anonymous protected-artifact proof GET
- strengthens request cache controls without changing provenance schemas or artifact bytes
- preserves strict timestamp ordering, Age=0, fresh request-ID, exact-main, run, artifact, and digest checks
- adds adversarial URL/query/entropy and cached-Date regression coverage

Verified locally and independently:
- release Python: 159 passed, 3 expected platform skips
- recovery Python: 194 passed
- complete release harness green, including installer 48/48, archive 45/45, static contract 35/35
- live GitHub nonce proof returned current ordered Dates with distinct request IDs

The prior rollout stopped before CMS publication or any node mutation. Fresh exact-main artifacts will be generated after merge.