### PR TITLE
Handle recovery when legacy updater units are absent

### DIFF
--- a/scripts/recovery/archive-node.sh
+++ b/scripts/recovery/archive-node.sh
@@ -2083,6 +2083,216 @@ if not entries or sorted(entries)[-1] != "zzzz-arc-recovery-freeze.conf":
 PY
 }
 
+materialize_absent_legacy_updater_anchor() {
+    local unit="$1" load_state fragment_path anchor
+    case "$unit" in
+        arc-node-update.service|arc-node-update.timer) ;;
+        *) die "refusing an unreviewed legacy updater anchor: $unit" ;;
+    esac
+    anchor="/etc/systemd/system/$unit"
+    load_state="$(systemctl show "$unit" --property=LoadState --value 2>/dev/null || true)"
+    fragment_path="$(systemctl show "$unit" --property=FragmentPath --value 2>/dev/null || true)"
+    case "$load_state" in
+        loaded)
+            [ -n "$fragment_path" ] || die "loaded legacy updater has no fragment path: $unit"
+            return 0
+            ;;
+        not-found)
+            [ -z "$fragment_path" ] || die "absent legacy updater unexpectedly has a fragment path: $unit"
+            ;;
+        *)
+            die "legacy updater has an unsupported load state before anchor staging: $unit state=${load_state:-unknown}"
+            ;;
+    esac
+
+    # systemd intentionally ignores a drop-in when no base unit exists.  The
+    # old fleet predates the updater units, so materialize a create-only,
+    # permanently non-startable base before relying on the persistent recovery
+    # drop-ins.  Every later source-manifest proof sees and hashes this exact
+    # regular file just like a pre-existing unit fragment.
+    python3 - "$unit" "$anchor" <<'PY'
+import ctypes
+import errno
+import os
+import pathlib
+import stat
+import sys
+
+unit, path_raw = sys.argv[1:]
+path = pathlib.Path(path_raw)
+service = (
+    b"[Unit]\n"
+    b"Description=ARC recovery inert anchor for absent legacy updater service\n"
+    b"DefaultDependencies=no\n"
+    b"RefuseManualStart=yes\n"
+    b"ConditionPathExists=!/dev/null\n"
+    b"\n"
+    b"[Service]\n"
+    b"Type=oneshot\n"
+    b"ExecStart=/usr/bin/false\n"
+)
+timer = (
+    b"[Unit]\n"
+    b"Description=ARC recovery inert anchor for absent legacy updater timer\n"
+    b"DefaultDependencies=no\n"
+    b"RefuseManualStart=yes\n"
+    b"ConditionPathExists=!/dev/null\n"
+    b"\n"
+    b"[Timer]\n"
+    b"OnActiveSec=3153600000s\n"
+    b"Unit=arc-node-update.service\n"
+)
+payloads = {
+    "arc-node-update.service": service,
+    "arc-node-update.timer": timer,
+}
+if unit not in payloads or path.name != unit:
+    raise SystemExit("legacy updater anchor target is not exact")
+payload = payloads[unit]
+parent = path.parent
+parent_details = parent.lstat()
+if (parent.is_symlink() or not stat.S_ISDIR(parent_details.st_mode)
+        or parent_details.st_uid != os.geteuid()
+        or parent_details.st_gid != os.getegid()
+        or parent_details.st_mode & 0o022):
+    raise SystemExit("legacy updater anchor parent is unsafe")
+flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+directory = os.open(parent, flags)
+try:
+    temporary = f".{unit}.arc-recovery-anchor.partial"
+
+    # Reconcile only the deterministic partial owned by this exact unit.  A
+    # crash can leave an empty/prefix mode-0600 write or a complete mode-0444
+    # write, but never makes that partial authoritative.  Any other inode,
+    # bytes, link count, or mode fails closed.
+    try:
+        partial_details = os.stat(temporary, dir_fd=directory, follow_symlinks=False)
+    except FileNotFoundError:
+        partial_details = None
+    if partial_details is not None:
+        partial_mode = stat.S_IMODE(partial_details.st_mode)
+        if (not stat.S_ISREG(partial_details.st_mode)
+                or partial_details.st_uid != os.geteuid()
+                or partial_details.st_gid != os.getegid()
+                or partial_details.st_nlink != 1
+                or partial_mode not in {0o600, 0o444}
+                or partial_details.st_size > len(payload)
+                or (partial_mode == 0o444 and partial_details.st_size != len(payload))):
+            raise SystemExit("legacy updater anchor partial inode is unsafe")
+        descriptor = os.open(
+            temporary, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0), dir_fd=directory
+        )
+        try:
+            partial = os.read(descriptor, len(payload) + 1)
+        finally:
+            os.close(descriptor)
+        if not payload.startswith(partial):
+            raise SystemExit("legacy updater anchor partial bytes are not an exact prefix")
+        os.unlink(temporary, dir_fd=directory)
+        os.fsync(directory)
+
+    try:
+        details = os.stat(unit, dir_fd=directory, follow_symlinks=False)
+    except FileNotFoundError:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=directory,
+        )
+        try:
+            view = memoryview(payload)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise SystemExit("short legacy updater anchor write")
+                view = view[written:]
+            os.fsync(descriptor)
+            os.fchmod(descriptor, 0o444)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+        source = parent / temporary
+        libc = ctypes.CDLL(None, use_errno=True)
+        renameat2 = getattr(libc, "renameat2", None)
+        if renameat2 is not None:
+            renameat2.argtypes = (
+                ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p,
+                ctypes.c_uint,
+            )
+            renameat2.restype = ctypes.c_int
+            result = renameat2(
+                -100, os.fsencode(source), -100, os.fsencode(path), 1
+            )
+        else:
+            # Validator hosts are Linux.  Darwin's exclusive equivalent keeps
+            # local contract tests on the same no-replace publication model.
+            renamex = getattr(libc, "renamex_np", None)
+            if renamex is None:
+                raise SystemExit("exclusive legacy updater anchor publication is unavailable")
+            renamex.argtypes = (
+                ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint,
+            )
+            renamex.restype = ctypes.c_int
+            result = renamex(os.fsencode(source), os.fsencode(path), 4)
+        if result != 0:
+            error = ctypes.get_errno()
+            if error != errno.EEXIST:
+                raise SystemExit(
+                    f"exclusive legacy updater anchor publication failed: errno={error}"
+                )
+            # A same-lock retry can observe a target only after an external
+            # race.  Preserve no ambiguous partial and validate that target
+            # below as the exact immutable anchor.
+            os.unlink(temporary, dir_fd=directory)
+        os.fsync(directory)
+        details = os.stat(unit, dir_fd=directory, follow_symlinks=False)
+    if (not stat.S_ISREG(details.st_mode)
+            or details.st_uid != os.geteuid() or details.st_gid != os.getegid()
+            or stat.S_IMODE(details.st_mode) != 0o444 or details.st_nlink != 1):
+        raise SystemExit("legacy updater anchor inode is unsafe")
+    descriptor = os.open(unit, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0), dir_fd=directory)
+    try:
+        if os.read(descriptor, len(payload) + 1) != payload:
+            raise SystemExit("legacy updater anchor bytes differ")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    os.fsync(directory)
+finally:
+    os.close(directory)
+PY
+}
+
+materialize_absent_legacy_updater_anchors() {
+    local unit
+    # Refresh PID1's view first so a stale not-found result can never shadow a
+    # real vendor or administrator unit fragment.
+    systemctl daemon-reload
+    for unit in arc-node-update.service arc-node-update.timer; do
+        materialize_absent_legacy_updater_anchor "$unit"
+    done
+    sync
+    systemctl daemon-reload
+    for unit in arc-node-update.service arc-node-update.timer; do
+        [ "$(systemctl show "$unit" --property=LoadState --value)" = loaded ] || \
+            die "legacy updater anchor did not produce a loaded unit: $unit"
+        [ -n "$(systemctl show "$unit" --property=FragmentPath --value)" ] || \
+            die "legacy updater anchor has no effective fragment: $unit"
+        case "$(systemctl show "$unit" --property=Job --value)" in ''|0) ;;
+            *) die "legacy updater gained a job during anchor staging: $unit" ;;
+        esac
+        case "$(systemctl show "$unit" --property=ActiveState --value)" in inactive|failed) ;;
+            *) die "legacy updater became active during anchor staging: $unit" ;;
+        esac
+        if [ "${unit##*.}" = service ]; then
+            [ "$(systemctl show "$unit" --property=MainPID --value)" = 0 ] || \
+                die "legacy updater service gained a MainPID during anchor staging"
+        fi
+    done
+}
+
 persist_legacy_restart_fence_files() {
     local unit last_dropin
     if [ "$#" -eq 0 ]; then
@@ -2285,6 +2495,11 @@ PY
         die "alternative node service has a MainPID before fence staging"
     [ "$(systemctl show arc-node-update.service --property=MainPID --value 2>/dev/null || printf 0)" = 0 ] || \
         die "updater service has a MainPID before fence staging"
+    materialize_absent_legacy_updater_anchors
+    [ "$(systemctl show "$selected_unit" --property=MainPID --value)" = "$selected_pid" ] || \
+        die "selected supervisor changed while staging legacy updater anchors"
+    [ "$(systemctl show "$selected_unit" --property=ActiveState --value)" = active ] || \
+        die "selected supervisor stopped while staging legacy updater anchors"
     disable_and_verify_unit "$other_unit"
     disable_and_verify_unit arc-node-update.service
     disable_and_verify_unit arc-node-update.timer

--- a/scripts/recovery/test_archive_node_prepare_runtime.py
+++ b/scripts/recovery/test_archive_node_prepare_runtime.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Focused tests for create-only legacy updater recovery anchors.
+
+The production helper runs the embedded program as root against
+``/etc/systemd/system``.  These tests execute those exact bytes in an isolated
+temporary unit directory and never contact systemd or a production host.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).with_name("archive-node.sh")
+EXPECTED = {
+    "arc-node-update.service": (
+        b"[Unit]\n"
+        b"Description=ARC recovery inert anchor for absent legacy updater service\n"
+        b"DefaultDependencies=no\n"
+        b"RefuseManualStart=yes\n"
+        b"ConditionPathExists=!/dev/null\n\n"
+        b"[Service]\nType=oneshot\nExecStart=/usr/bin/false\n"
+    ),
+    "arc-node-update.timer": (
+        b"[Unit]\n"
+        b"Description=ARC recovery inert anchor for absent legacy updater timer\n"
+        b"DefaultDependencies=no\n"
+        b"RefuseManualStart=yes\n"
+        b"ConditionPathExists=!/dev/null\n\n"
+        b"[Timer]\nOnActiveSec=3153600000s\n"
+        b"Unit=arc-node-update.service\n"
+    ),
+}
+
+
+def anchor_source() -> str:
+    text = SCRIPT.read_text(encoding="utf-8")
+    function = text.index("materialize_absent_legacy_updater_anchor()")
+    marker = 'python3 - "$unit" "$anchor" <<\'PY\'\n'
+    start = text.index(marker, function) + len(marker)
+    end = text.index("\nPY\n}", start)
+    return text[start:end]
+
+
+class LegacyUpdaterAnchorTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.shell = SCRIPT.read_text(encoding="utf-8")
+        cls.program = anchor_source()
+        compile(cls.program, "archive-node-legacy-updater-anchor", "exec")
+
+    def run_anchor(
+        self, root: pathlib.Path, unit: str, *, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        program = root / "anchor.py"
+        program.write_text(self.program, encoding="utf-8")
+        return subprocess.run(
+            [sys.executable, str(program), unit, str(root / unit)],
+            check=check,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    def test_absent_service_and_timer_are_create_only_and_inert(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            for unit, payload in EXPECTED.items():
+                self.run_anchor(root, unit)
+                target = root / unit
+                details = target.lstat()
+                self.assertEqual(target.read_bytes(), payload)
+                self.assertTrue(stat.S_ISREG(details.st_mode))
+                self.assertEqual(stat.S_IMODE(details.st_mode), 0o444)
+                self.assertEqual(details.st_nlink, 1)
+                first_identity = (details.st_dev, details.st_ino)
+                self.run_anchor(root, unit)
+                second = target.lstat()
+                self.assertEqual((second.st_dev, second.st_ino), first_identity)
+                self.assertFalse(
+                    (root / f".{unit}.arc-recovery-anchor.partial").exists()
+                )
+
+    def test_crash_partials_resume_without_ambiguous_links(self) -> None:
+        unit = "arc-node-update.service"
+        payload = EXPECTED[unit]
+        for partial_payload, mode in (
+            (b"", 0o600),
+            (payload[:37], 0o600),
+            (payload, 0o444),
+        ):
+            with self.subTest(size=len(partial_payload), mode=oct(mode)):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = pathlib.Path(temporary)
+                    partial = root / f".{unit}.arc-recovery-anchor.partial"
+                    partial.write_bytes(partial_payload)
+                    partial.chmod(mode)
+                    self.run_anchor(root, unit)
+                    target = root / unit
+                    self.assertEqual(target.read_bytes(), payload)
+                    self.assertEqual(target.lstat().st_nlink, 1)
+                    self.assertFalse(partial.exists())
+
+    def test_unowned_partial_shape_fails_closed(self) -> None:
+        unit = "arc-node-update.timer"
+        payload = EXPECTED[unit]
+        cases = (
+            (b"not-a-prefix", 0o600),
+            (payload, 0o644),
+            (payload[:13], 0o444),
+        )
+        for partial_payload, mode in cases:
+            with self.subTest(mode=oct(mode)):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = pathlib.Path(temporary)
+                    partial = root / f".{unit}.arc-recovery-anchor.partial"
+                    partial.write_bytes(partial_payload)
+                    partial.chmod(mode)
+                    result = self.run_anchor(root, unit, check=False)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertFalse((root / unit).exists())
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            partial = root / f".{unit}.arc-recovery-anchor.partial"
+            partial.write_bytes(payload)
+            os.link(partial, root / "second-link")
+            partial.chmod(0o444)
+            result = self.run_anchor(root, unit, check=False)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("partial inode is unsafe", result.stderr)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            (root / "partial-target").write_bytes(payload)
+            partial = root / f".{unit}.arc-recovery-anchor.partial"
+            partial.symlink_to("partial-target")
+            result = self.run_anchor(root, unit, check=False)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("partial inode is unsafe", result.stderr)
+
+    def test_existing_target_wrong_mode_and_hardlink_fail_closed(self) -> None:
+        unit = "arc-node-update.service"
+        payload = EXPECTED[unit]
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            target = root / unit
+            target.write_bytes(payload)
+            target.chmod(0o644)
+            result = self.run_anchor(root, unit, check=False)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("anchor inode is unsafe", result.stderr)
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            target = root / unit
+            target.write_bytes(payload)
+            target.chmod(0o444)
+            os.link(target, root / "second-link")
+            result = self.run_anchor(root, unit, check=False)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("anchor inode is unsafe", result.stderr)
+
+    def test_existing_different_bytes_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            target = root / "arc-node-update.service"
+            target.write_bytes(b"[Unit]\nDescription=unexpected\n")
+            target.chmod(0o444)
+            result = self.run_anchor(root, target.name, check=False)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("anchor bytes differ", result.stderr)
+
+    def test_symlink_and_unreviewed_name_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            (root / "target").write_bytes(b"x")
+            (root / "arc-node-update.timer").symlink_to("target")
+            symlink = self.run_anchor(root, "arc-node-update.timer", check=False)
+            self.assertNotEqual(symlink.returncode, 0)
+            self.assertIn("anchor inode is unsafe", symlink.stderr)
+            unknown = self.run_anchor(root, "arc-other.service", check=False)
+            self.assertNotEqual(unknown.returncode, 0)
+            self.assertIn("target is not exact", unknown.stderr)
+
+    def test_anchor_staging_precedes_disable_and_persistent_barrier_verification(self) -> None:
+        stage_start = self.shell.index("stage_recovery_barrier()")
+        stage_end = self.shell.index("\nstage_prefreeze_runtime_safety()", stage_start)
+        stage = self.shell[stage_start:stage_end]
+        materialize = stage.index("materialize_absent_legacy_updater_anchors")
+        disable = stage.index('disable_and_verify_unit "$other_unit"')
+        persistent = stage.index("persist_legacy_restart_fence_files")
+        merged = stage.index(
+            'verify_merged_legacy_start_barrier_config "$unit"'
+        )
+        self.assertLess(materialize, disable)
+        self.assertLess(disable, persistent)
+        self.assertLess(persistent, merged)
+        self.assertIn(
+            'ConditionPathExists=!/dev/null',
+            self.program,
+        )
+        self.assertIn(
+            'systemctl show "$unit" --property=LoadState --value',
+            self.shell,
+        )
+
+    @unittest.skipUnless(shutil.which("systemd-analyze"), "systemd-analyze unavailable")
+    def test_exact_anchor_units_pass_systemd_verification(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            for unit in EXPECTED:
+                self.run_anchor(root, unit)
+            environment = dict(os.environ)
+            environment["SYSTEMD_UNIT_PATH"] = ":".join(
+                (
+                    str(root),
+                    "/usr/local/lib/systemd/system",
+                    "/usr/lib/systemd/system",
+                    "/lib/systemd/system",
+                )
+            )
+            subprocess.run(
+                [
+                    shutil.which("systemd-analyze") or "systemd-analyze",
+                    "verify",
+                    "arc-node-update.service",
+                    "arc-node-update.timer",
+                ],
+                check=True,
+                cwd=root,
+                env=environment,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/release/recovery_archive_contract_test.sh
+++ b/tests/release/recovery_archive_contract_test.sh
@@ -2565,6 +2565,9 @@ archive_scripts_are_lintable() {
             "$REPO_ROOT/scripts/recovery/test_archive_node_quarantine_runtime.py" \
             >/dev/null &&
         PYTHONDONTWRITEBYTECODE=1 python3 \
+            "$REPO_ROOT/scripts/recovery/test_archive_node_prepare_runtime.py" \
+            >/dev/null &&
+        PYTHONDONTWRITEBYTECODE=1 python3 \
             "$REPO_ROOT/scripts/recovery/test_quarantine_rounds.py" >/dev/null &&
         PYTHONDONTWRITEBYTECODE=1 python3 \
             "$REPO_ROOT/scripts/recovery/test_community_reward_probe.py" >/dev/null &&


### PR DESCRIPTION
## Production failure reproduced

All six legacy validators predate `arc-node-update.service` and `.timer`. Preparation correctly accepted those units as `not-found` and wrote fail-open recovery drop-ins, but systemd ignores a drop-in-only unit; the later strict `systemctl cat` proof therefore failed before any stop, freeze, mask, quarantine, or availability impact.

## Fix

- materialize base fragments only for those two exact updater unit names and only from exact `not-found` / empty-fragment state
- make both anchors permanently inert (`RefuseManualStart=yes`, always-false condition, static/disabled unit shape)
- publish create-only with `renameat2(RENAME_NOREPLACE)` and deterministic crash-partial reconciliation
- require root/current-owner, mode `0444`, single link, exact bytes, loaded PID1 projection, inactive/job-free state, and zero service PID
- leave any existing loaded updater fragment unchanged and fail closed on every ambiguous state
- re-prove the selected supervisor PID and active state after staging

This preserves the later strict merged-source, pre-mask, quarantine, restart-barrier, and rollout proofs instead of weakening them for missing units.

## Verification

- focused prepare runtime tests: 8/8 on Linux systemd 255; 7/8 + expected systemd skip on macOS
- recovery archive contract: 45/45
- complete release suite: all 26 scripts green, including installer behavior 48/48
- bash syntax, ShellCheck warning gate, and diff check clean
- independent code and live-state audits: pass; all six production writers remained externally reachable with unchanged PID/start identity
