### PR TITLE
Normalize inert timer MainPID in recovery contracts

### DIFF
--- a/scripts/recovery/archive-fleet-to-drive.sh
+++ b/scripts/recovery/archive-fleet-to-drive.sh
@@ -1388,6 +1388,14 @@ for prepare_unit in prepare_units:
     activation_closure[prepare_unit] = {
         name: prepare_prop(name) for name in closure_properties
     }
+    # MainPID is not defined for timer units.  systemd may render that
+    # service-only property as either an empty string or "0", depending on
+    # whether the timer came from a full vendor unit or the inert recovery
+    # anchor.  Seal one canonical quiescent representation so the state row
+    # and activation-closure row cannot disagree semantically.
+    if (prepare_unit.endswith(".timer")
+            and not activation_closure[prepare_unit]["MainPID"]):
+        activation_closure[prepare_unit]["MainPID"] = "0"
     if (activation_closure[prepare_unit]["Names"] != prepare_unit
             or activation_closure[prepare_unit]["Id"] != prepare_unit
             or activation_closure[prepare_unit]["Following"]):

--- a/scripts/recovery/recovery_freeze.py
+++ b/scripts/recovery/recovery_freeze.py
@@ -1110,10 +1110,18 @@ def _validate_prepare_barrier(
                 f"node {node_name} activation closure {unit} has an alias or following target"
             )
         state = states[unit]
+        # MainPID is a service-only property.  Older prepared contracts can
+        # contain systemd's empty rendering for an inert timer, while the
+        # canonical unit-state row represents the same quiescent value as 0.
+        # Normalize only this exact timer field; an empty service MainPID still
+        # fails closed below.
+        closure_main_pid = row["MainPID"]
+        if unit == "arc-node-update.timer" and closure_main_pid == "":
+            closure_main_pid = "0"
         if (
             row["ActiveState"] != state["active_state"]
             or row["SubState"] != state["sub_state"]
-            or row["MainPID"] != str(state["main_pid"])
+            or closure_main_pid != str(state["main_pid"])
             or (row["Job"] or "0") != state["job"]
         ):
             raise FreezeValidationError(

--- a/scripts/recovery/test_recovery_freeze.py
+++ b/scripts/recovery/test_recovery_freeze.py
@@ -654,6 +654,22 @@ class FreezePlanTests(unittest.TestCase):
             with self.subTest(value=value), self.assertRaises(rf.FreezeValidationError):
                 rf.validate_pinned_freeze_plan(raw, hashlib.sha256(raw).hexdigest())
 
+    def test_inert_timer_empty_main_pid_is_canonical_quiescent_zero(self) -> None:
+        timer_blank = plan_value()
+        timer_blank["nodes"][0]["prepare_barrier"]["activation_closure"][
+            "arc-node-update.timer"
+        ]["MainPID"] = ""
+        raw = rf.canonical_json_bytes(timer_blank)
+        rf.validate_pinned_freeze_plan(raw, hashlib.sha256(raw).hexdigest())
+
+        service_blank = plan_value()
+        service_blank["nodes"][0]["prepare_barrier"]["activation_closure"][
+            "arc-self-heal.service"
+        ]["MainPID"] = ""
+        raw = rf.canonical_json_bytes(service_blank)
+        with self.assertRaises(rf.FreezeValidationError):
+            rf.validate_pinned_freeze_plan(raw, hashlib.sha256(raw).hexdigest())
+
 
 class PrepareAndBarrierTests(unittest.TestCase):
     def test_prepare_receipt_is_exact_and_bound_to_plan_node_and_cgroups(self) -> None:


### PR DESCRIPTION
## Summary
- canonicalize the service-only `MainPID` property to `0` for recovery timer units when systemd renders it empty
- accept the same exact empty rendering only for `arc-node-update.timer` when validating older sealed prepare contracts
- prove that an empty service `MainPID` remains fail-closed

## Production finding
The exact-main rollout stopped before freeze/availability impact because the newly materialized inert updater timer reported `MainPID=""` while its canonical unit-state row stored `0`. This fixes that semantic mismatch without relaxing any service PID, process, activation-edge, or unit-state validation.

## Local verification
- `bash -n scripts/recovery/archive-fleet-to-drive.sh`
- `python3 -m unittest scripts.recovery.test_recovery_freeze scripts.recovery.test_archive_node_prepare_runtime`
- `python3 -m py_compile scripts/recovery/recovery_freeze.py scripts/recovery/test_recovery_freeze.py`
- `git diff --check`