### PR TITLE
Make production recovery capture safely resumable

### DIFF
--- a/docs/PRODUCTION-RECOVERY-AUDIT-2026-08-26.md
+++ b/docs/PRODUCTION-RECOVERY-AUDIT-2026-08-26.md
@@ -4,6 +4,16 @@ This is a read-only evidence snapshot plus the contract of the unreleased
 v0.8.0/v3 recovery candidate. It is not a deployment announcement. No seed was
 restarted, upgraded, rekeyed, or otherwise mutated during this audit.
 
+> **Protocol supersession — 2026-09-03:** The observations and actions recorded
+> in this dated audit remain historical evidence. The current capture contract
+> samples the create-only legacy public-height receipt after the slow staging,
+> Drive, and live-observation prerequisites, and requires its completion to be
+> no more than 300 seconds before the authenticated all-writer cross-proof
+> starts. Receipt age is no longer used as the mutation lease. Every quarantine
+> round separately re-samples its still-live targets and requires exact
+> target-specific public/cross proofs plus a same-boot monotonic authorization
+> lease of at most 300 seconds before any writer transition.
+
 ## What community reports correctly identified
 
 - Public v0.7.10 and v0.7.11 were desktop-only releases. The desktop and CLI
@@ -248,25 +258,26 @@ second local copy.
 The supported seal path is `build-production-manifest.py prearchive`, never a
 hand-edited production manifest. It consumes the exact
 protected-main Linux x86_64 pre-tag artifacts and build run, sealed freeze and
-legacy public-height receipt proven fresh at the sealed pre-quarantine
-boundary, canonical six-root
+legacy public-height receipt proven fresh at the authenticated all-writer
+cross-proof boundary, canonical six-root
 `arc.validator-vault.offline-stop-evidence.v2` receipt, source artifacts,
 signed checkpoint, exact Caddy 2.11.4 binary, and reward probe. Capture derives
 that offline-stop receipt from fresh hash-pinned remote stopped-status calls;
 each fixed node/host row binds the real offline-stop.v4 `stop.complete` and
 index roots plus the exact status argv/output hashes.
 
-The live capture path retains the receipt's 300-second wall-clock gate and,
-before writing the first quarantine boundary or mutating a host, atomically
-requires `receipt.completed_at <= authenticated fleet started_at <=
-authenticated fleet completed_at <= first_quarantine_started_at` with a total
-receipt-to-boundary interval of `0..=300` seconds. Once the fleet is stopped,
-the builder deliberately uses no current-time freshness check: resampling the
-six retired origins would be impossible without violating the stop fence. It
-authenticates the exact receipt/freeze/capture/hash bindings and the complete
-sealed chain through all-controlled-stopped and maintenance-boundary creation,
-then repeats the same semantic check after an exact byte-and-SHA re-read just
-before create-only prearchive publication.
+This 2026-08-26 audit recorded the intended receipt timing contract as a
+300-second wall-clock gate through the first quarantine boundary, requiring
+`receipt.completed_at <= authenticated fleet started_at <= authenticated fleet
+completed_at <= first_quarantine_started_at` with a total receipt-to-boundary
+interval of `0..=300` seconds. That timing rule is superseded by the 2026-09-03
+contract above. Once the fleet is stopped, the builder deliberately uses no
+current-time freshness check: resampling the six retired origins would be
+impossible without violating the stop fence. It authenticates the exact
+receipt/freeze/capture/hash bindings and the complete sealed chain through
+all-controlled-stopped and maintenance-boundary creation, then repeats the
+same intrinsic and sealed-timeline checks after an exact byte-and-SHA re-read
+just before create-only prearchive publication.
 
 A committed local first-boundary timestamp is not, by itself, proof that a
 remote quarantine began. On resume, capture challenges all six exact hosts for

--- a/scripts/recovery/README.md
+++ b/scripts/recovery/README.md
@@ -1068,34 +1068,25 @@ scripts/recovery/archive-fleet-to-drive.sh seal-freeze-plan \
   --attest-dedicated-drive-uploader \
   --output /secure/operator/arc-freeze.lock.json
 
-# Copy these exact values from the successful seal-freeze-plan output. Sample
-# while all six legacy HTTPS origins are still live and immediately before the
-# capture plan/execute pair; the receipt is create-only and cannot be refreshed
-# in place.
+# Copy these exact values from the successful seal-freeze-plan output. Give this
+# attempt a unique create-only receipt path, but do not sample it here. The
+# execute phase samples only after the slow inspector, Drive, and live-
+# observation prerequisites, immediately before the authenticated cross-proof.
 freeze_sha256='<freeze-plan hash printed by seal-freeze-plan>'
 capture_id='<capture id printed by seal-freeze-plan>'
 [[ "$freeze_sha256" =~ ^[0-9a-f]{64}$ ]]
 [[ "$capture_id" =~ ^[0-9a-f]{64}$ ]]
-legacy_height_result="$(
-  "$ARC_RECOVERY_PYTHON_PATH" -I scripts/recovery/legacy-public-height.py sample \
-    --source-main "$protected_main_sha" \
-    --freeze-plan /secure/operator/arc-freeze.lock.json \
-    --freeze-plan-sha256 "$freeze_sha256" \
-    --output /secure/operator/legacy-public-height.json \
-    --timeout-seconds 10
+legacy_height_attempt_nonce="$(
+  "$ARC_RECOVERY_PYTHON_PATH" -I -c 'import secrets; print(secrets.token_hex(16))'
 )"
-legacy_public_height_sha256="$(
-  printf '%s' "$legacy_height_result" \
-    | "$ARC_RECOVERY_PYTHON_PATH" -I -c 'import json,sys; print(json.load(sys.stdin)["receipt_sha256"])'
-)"
-[[ "$legacy_public_height_sha256" =~ ^[0-9a-f]{64}$ ]]
-printf 'legacy public-height receipt sha256=%s capture=%s\n' \
-  "$legacy_public_height_sha256" "$capture_id"
+[[ "$legacy_height_attempt_nonce" =~ ^[0-9a-f]{32}$ ]]
+legacy_public_height_receipt="/secure/operator/legacy-public-height.${capture_id}.${legacy_height_attempt_nonce}.json"
+offline_stop_output=/secure/operator/arc-offline-stop-evidence.json
+test ! -e "$legacy_public_height_receipt" && test ! -L "$legacy_public_height_receipt"
 
 scripts/recovery/archive-fleet-to-drive.sh capture \
   --freeze-plan /secure/operator/arc-freeze.lock.json \
-  --legacy-public-height-receipt /secure/operator/legacy-public-height.json \
-  --legacy-public-height-receipt-sha256 "$legacy_public_height_sha256" \
+  --sample-legacy-public-height-output "$legacy_public_height_receipt" \
   --inspector-binary "$arc_node_linux" \
   --inspector-binary-sha256 "$arc_node_linux_sha256" \
   --genesis "$operator_genesis" \
@@ -1104,13 +1095,12 @@ scripts/recovery/archive-fleet-to-drive.sh capture \
   --validator-public-keys-sha256 "$validator_public_keys_sha256" \
   --legacy-validator-set "$legacy_validator_set" \
   --legacy-validator-set-sha256 "$legacy_validator_set_sha256" \
-  --offline-stop-evidence-output /secure/operator/arc-offline-stop-evidence.json
+  --offline-stop-evidence-output "$offline_stop_output"
 
 ARC_RECOVERY_FREEZE_GO="FREEZE $freeze_sha256 CAPTURE $capture_id" \
   scripts/recovery/archive-fleet-to-drive.sh capture \
     --freeze-plan /secure/operator/arc-freeze.lock.json \
-    --legacy-public-height-receipt /secure/operator/legacy-public-height.json \
-    --legacy-public-height-receipt-sha256 "$legacy_public_height_sha256" \
+    --sample-legacy-public-height-output "$legacy_public_height_receipt" \
     --inspector-binary "$arc_node_linux" \
     --inspector-binary-sha256 "$arc_node_linux_sha256" \
     --genesis "$operator_genesis" \
@@ -1119,9 +1109,23 @@ ARC_RECOVERY_FREEZE_GO="FREEZE $freeze_sha256 CAPTURE $capture_id" \
     --validator-public-keys-sha256 "$validator_public_keys_sha256" \
     --legacy-validator-set "$legacy_validator_set" \
     --legacy-validator-set-sha256 "$legacy_validator_set_sha256" \
-    --offline-stop-evidence-output /secure/operator/arc-offline-stop-evidence.json \
+    --offline-stop-evidence-output "$offline_stop_output" \
     --execute
+
+legacy_public_height_sha256="$(arc_sha256 "$legacy_public_height_receipt")"
+[[ "$legacy_public_height_sha256" =~ ^[0-9a-f]{64}$ ]]
+printf 'legacy public-height receipt path=%s sha256=%s capture=%s\n' \
+  "$legacy_public_height_receipt" "$legacy_public_height_sha256" "$capture_id"
 ```
+
+If execution exits after creating the late receipt but before sealing the
+authenticated cross-proof, leave every byte in place. After proving there is
+no selection, mutation dispatch, quarantine ledger, or first boundary and all
+six exact writers remain live and unfenced, choose a new receipt nonce. Keep
+the existing offline-stop namespace only when no authenticated-cross `.partial`
+exists; if that create-only partial exists, preserve it and choose a new
+offline-stop namespace too. A completed cross-proof must instead resume with
+its exact original receipt path and hash; it must never be resampled.
 
 Install the restored keys only after that successful capture. All three
 maintenance artifacts and sidecars are required by the current parser; their
@@ -1129,13 +1133,13 @@ digests are derived from the just-created bytes, not copied from an earlier
 attempt.
 
 ```bash
-legacy_maintenance_evidence_bundle=/secure/operator/arc-offline-stop-evidence.json.legacy-maintenance-evidence-bundle.json
+legacy_maintenance_evidence_bundle="$offline_stop_output.legacy-maintenance-evidence-bundle.json"
 legacy_maintenance_evidence_bundle_sidecar="$legacy_maintenance_evidence_bundle.sha256"
 legacy_maintenance_evidence_bundle_sha256="$(/usr/bin/sha256sum "$legacy_maintenance_evidence_bundle" | /usr/bin/awk '{print $1}')"
-legacy_maintenance_boundary=/secure/operator/arc-offline-stop-evidence.json.legacy-maintenance-boundary.json
+legacy_maintenance_boundary="$offline_stop_output.legacy-maintenance-boundary.json"
 legacy_maintenance_boundary_sidecar="$legacy_maintenance_boundary.sha256"
 legacy_maintenance_boundary_sha256="$(/usr/bin/sha256sum "$legacy_maintenance_boundary" | /usr/bin/awk '{print $1}')"
-offline_stop_evidence=/secure/operator/arc-offline-stop-evidence.json
+offline_stop_evidence="$offline_stop_output"
 offline_stop_evidence_sidecar="$offline_stop_evidence.sha256"
 offline_stop_evidence_sha256="$(/usr/bin/sha256sum "$offline_stop_evidence" | /usr/bin/awk '{print $1}')"
 known_hosts="$ARC_RECOVERY_SSH_KNOWN_HOSTS"
@@ -1788,11 +1792,11 @@ if [ "$prearchive_existing" = 0 ]; then
       --ca-bundle-sha256 "$system_ca_bundle_sha256" \
       --freeze-plan /secure/operator/arc-freeze.lock.json \
       --freeze-plan-sha256 "$freeze_sha256" \
-      --legacy-public-height-receipt /secure/operator/legacy-public-height.json \
-      --legacy-maintenance-evidence-bundle /secure/operator/arc-offline-stop-evidence.json.legacy-maintenance-evidence-bundle.json \
-      --legacy-maintenance-boundary /secure/operator/arc-offline-stop-evidence.json.legacy-maintenance-boundary.json \
-      --legacy-late-fork-source-set /secure/operator/arc-offline-stop-evidence.json.legacy-late-fork-source-set.json \
-      --offline-stop-evidence /secure/operator/arc-offline-stop-evidence.json \
+      --legacy-public-height-receipt "$legacy_public_height_receipt" \
+      --legacy-maintenance-evidence-bundle "$legacy_maintenance_evidence_bundle" \
+      --legacy-maintenance-boundary "$legacy_maintenance_boundary" \
+      --legacy-late-fork-source-set "$offline_stop_output.legacy-late-fork-source-set.json" \
+      --offline-stop-evidence "$offline_stop_evidence" \
       --ssh-known-hosts "$known_hosts" \
       --ssh-identity "$ssh_identity" \
       --validator-vault-restore-receipt /secure/operator/arc-v0.8-validator-restore/RESTORE-RECEIPT.json \

--- a/scripts/recovery/archive-fleet-to-drive.sh
+++ b/scripts/recovery/archive-fleet-to-drive.sh
@@ -12,6 +12,7 @@ ROLLOUT_TOOL="$SCRIPT_DIR/recovery_rollout.py"
 ROLLOUT_SCHEMA="$SCRIPT_DIR/recovery-manifest.schema.json"
 DRIVE_PREFREEZE_GATE="$SCRIPT_DIR/verify-drive-prefreeze.sh"
 LEGACY_HEIGHT_TOOL="$SCRIPT_DIR/legacy-public-height.py"
+RECOVERY_FREEZE_MODULE="$SCRIPT_DIR/recovery_freeze.py"
 QUARANTINE_ROUND_DRIVER="$SCRIPT_DIR/quarantine_round_driver.py"
 QUARANTINE_ROUND_MODULE="$SCRIPT_DIR/quarantine_rounds.py"
 LATE_FORK_INTERLOCK_TOOL="$SCRIPT_DIR/legacy-late-fork-interlock.py"
@@ -687,8 +688,7 @@ Usage:
     --output /absolute/freeze.lock.json
 
   archive-fleet-to-drive.sh capture --freeze-plan /absolute/freeze.lock.json \
-    --legacy-public-height-receipt /absolute/legacy-public-height.json \
-    --legacy-public-height-receipt-sha256 HASH \
+    --sample-legacy-public-height-output /absolute/unique-legacy-public-height.json \
     --inspector-binary /absolute/pretag-linux-x86_64/arc-node \
     --inspector-binary-sha256 HASH --genesis /absolute/genesis.toml \
     --genesis-sha256 HASH --validator-public-keys /absolute/validator-public-keys.json \
@@ -698,8 +698,7 @@ Usage:
     [--offline-stop-evidence-output /absolute/offline-stop-evidence.json] [--plan]
   ARC_RECOVERY_FREEZE_GO='FREEZE PLAN_SHA256 CAPTURE CAPTURE_SHA256' archive-fleet-to-drive.sh capture \
     --freeze-plan /absolute/freeze.lock.json \
-    --legacy-public-height-receipt /absolute/legacy-public-height.json \
-    --legacy-public-height-receipt-sha256 HASH \
+    --sample-legacy-public-height-output /absolute/unique-legacy-public-height.json \
     --inspector-binary /absolute/pretag-linux-x86_64/arc-node \
     --inspector-binary-sha256 HASH --genesis /absolute/genesis.toml \
     --genesis-sha256 HASH --validator-public-keys /absolute/validator-public-keys.json \
@@ -945,6 +944,351 @@ tracked_source_hash() {
     blob_sha="$(git -C "$REPO_ROOT" show "HEAD:$relative" | python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())')"
     [ "$disk_sha" = "$blob_sha" ] || die "tracked recovery source blob differs from HEAD: $relative"
     printf '%s\n' "$disk_sha"
+}
+
+validate_legacy_public_height_sample_output() {
+    local output="$1"
+    python3 - "$output" <<'PY'
+import os
+import pathlib
+import stat
+import sys
+
+path = pathlib.Path(sys.argv[1])
+if (
+    not path.is_absolute()
+    or path.suffix != ".json"
+    or os.path.normpath(os.fspath(path)) != os.fspath(path)
+    or path.name in {"", ".", ".."}
+    or any(part in {".", ".."} for part in path.parts[1:])
+):
+    raise SystemExit("late legacy public-height output path is unsafe")
+flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+directory = os.open("/", flags)
+try:
+    root_details = os.fstat(directory)
+    if (
+        not stat.S_ISDIR(root_details.st_mode)
+        or root_details.st_uid != 0
+        or root_details.st_mode & 0o022
+    ):
+        raise SystemExit("late legacy public-height filesystem root is unsafe")
+    for component in path.parent.parts[1:]:
+        next_directory = os.open(component, flags, dir_fd=directory)
+        os.close(directory)
+        directory = next_directory
+        details = os.fstat(directory)
+        if (
+            not stat.S_ISDIR(details.st_mode)
+            or details.st_uid not in {0, os.geteuid()}
+            or details.st_mode & 0o022
+        ):
+            raise SystemExit("late legacy public-height output ancestry is unsafe")
+    try:
+        details = os.stat(path.name, dir_fd=directory, follow_symlinks=False)
+    except FileNotFoundError:
+        print("absent")
+        raise SystemExit(0)
+    if (
+        not stat.S_ISREG(details.st_mode)
+        or details.st_uid != os.geteuid()
+        or details.st_nlink != 1
+        or stat.S_IMODE(details.st_mode) != 0o400
+        or not 0 < details.st_size <= 16 * 1024 * 1024
+    ):
+        raise SystemExit("late legacy public-height output identity is unsafe")
+    print("sealed")
+finally:
+    os.close(directory)
+PY
+}
+
+sealed_legacy_public_height_receipt_sha() {
+    local path="$1"
+    python3 - "$path" <<'PY'
+import hashlib
+import json
+import os
+import pathlib
+import stat
+import sys
+
+path = pathlib.Path(sys.argv[1])
+descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+try:
+    before = os.fstat(descriptor)
+    stable = lambda value: (
+        value.st_dev, value.st_ino, value.st_mode, value.st_uid, value.st_gid,
+        value.st_nlink, value.st_size, value.st_mtime_ns, value.st_ctime_ns,
+    )
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or before.st_uid != os.geteuid()
+        or before.st_nlink != 1
+        or stat.S_IMODE(before.st_mode) != 0o400
+        or not 0 < before.st_size <= 16 * 1024 * 1024
+    ):
+        raise SystemExit("sealed legacy public-height receipt identity is unsafe")
+    chunks = []
+    while True:
+        chunk = os.read(descriptor, 1024 * 1024)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    payload = b"".join(chunks)
+    if len(payload) != before.st_size or stable(os.fstat(descriptor)) != stable(before):
+        raise SystemExit("sealed legacy public-height receipt changed while read")
+finally:
+    os.close(descriptor)
+value = json.loads(payload)
+canonical = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+if payload != canonical:
+    raise SystemExit("sealed legacy public-height receipt is noncanonical")
+print(hashlib.sha256(payload).hexdigest())
+PY
+}
+
+validate_intrinsic_legacy_public_height_receipt() {
+    local receipt="$1" receipt_sha="$2" freeze_plan="$3" freeze_sha="$4"
+    local source_main
+    source_main="$(manifest_field "$freeze_plan" source_commit)"
+    python3 -B -I - "$LEGACY_HEIGHT_TOOL" "$receipt" "$receipt_sha" \
+        "$source_main" "$freeze_sha" <<'PY'
+import hashlib
+import importlib.util
+import json
+import os
+import pathlib
+import stat
+import sys
+
+tool = pathlib.Path(sys.argv[1])
+receipt = pathlib.Path(sys.argv[2])
+expected, source_main, freeze_sha = sys.argv[3:]
+spec = importlib.util.spec_from_file_location("arc_pinned_legacy_public_height", tool)
+if spec is None or spec.loader is None:
+    raise SystemExit("cannot load pinned legacy public-height validator")
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+descriptor = os.open(receipt, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+try:
+    before = os.fstat(descriptor)
+    stable = lambda value: (
+        value.st_dev, value.st_ino, value.st_mode, value.st_uid, value.st_gid,
+        value.st_nlink, value.st_size, value.st_mtime_ns, value.st_ctime_ns,
+    )
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or before.st_uid != os.geteuid()
+        or before.st_nlink != 1
+        or stat.S_IMODE(before.st_mode) != 0o400
+        or not 0 < before.st_size <= 16 * 1024 * 1024
+    ):
+        raise SystemExit("legacy public-height intrinsic receipt identity is unsafe")
+    chunks = []
+    while True:
+        chunk = os.read(descriptor, 1024 * 1024)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    payload = b"".join(chunks)
+    if len(payload) != before.st_size or stable(os.fstat(descriptor)) != stable(before):
+        raise SystemExit("legacy public-height intrinsic receipt changed while read")
+finally:
+    os.close(descriptor)
+if hashlib.sha256(payload).hexdigest() != expected:
+    raise SystemExit("legacy public-height intrinsic receipt hash differs")
+value = json.loads(payload)
+if payload != module.canonical_bytes(value):
+    raise SystemExit("legacy public-height intrinsic receipt is noncanonical")
+completed = module.parse_utc(value.get("completed_at"), "completed_at")
+module.validate_receipt(
+    value,
+    source_main=source_main,
+    freeze_sha=freeze_sha,
+    now=completed,
+    max_age_seconds=module.MAX_RECEIPT_AGE_SECONDS,
+)
+PY
+}
+
+pin_legacy_public_height_toolchain() {
+    local destination="$1" tool_sha freeze_sha rounds_sha
+    tool_sha="$(tracked_source_hash "$LEGACY_HEIGHT_TOOL")"
+    freeze_sha="$(tracked_source_hash "$RECOVERY_FREEZE_MODULE")"
+    rounds_sha="$(tracked_source_hash "$QUARANTINE_ROUND_MODULE")"
+    python3 - "$destination" \
+        "$LEGACY_HEIGHT_TOOL" "$tool_sha" \
+        "$RECOVERY_FREEZE_MODULE" "$freeze_sha" \
+        "$QUARANTINE_ROUND_MODULE" "$rounds_sha" <<'PY'
+import hashlib
+import os
+import pathlib
+import stat
+import sys
+
+root = pathlib.Path(sys.argv[1])
+pairs = [(pathlib.Path(sys.argv[index]), sys.argv[index + 1]) for index in range(2, 8, 2)]
+output_names = (
+    "legacy-public-height.py",
+    "recovery_freeze.py",
+    "quarantine_rounds.py",
+)
+parent = root.parent
+parent_details = parent.lstat()
+if (
+    not root.is_absolute()
+    or root.name in {"", ".", ".."}
+    or parent.is_symlink()
+    or not stat.S_ISDIR(parent_details.st_mode)
+    or parent_details.st_uid != os.geteuid()
+    or stat.S_IMODE(parent_details.st_mode) != 0o700
+):
+    raise SystemExit("legacy public-height pin root parent is unsafe")
+parent_fd = os.open(parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0))
+try:
+    os.mkdir(root.name, 0o700, dir_fd=parent_fd)
+    os.fsync(parent_fd)
+finally:
+    os.close(parent_fd)
+root_fd = os.open(root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0))
+try:
+    for index, (source, expected) in enumerate(pairs):
+        descriptor = os.open(source, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        try:
+            before = os.fstat(descriptor)
+            stable = lambda value: (
+                value.st_dev, value.st_ino, value.st_mode, value.st_uid, value.st_gid,
+                value.st_nlink, value.st_size, value.st_mtime_ns, value.st_ctime_ns,
+            )
+            if (
+                source.is_symlink()
+                or not stat.S_ISREG(before.st_mode)
+                or before.st_uid not in {0, os.geteuid()}
+                or before.st_nlink < 1
+                or before.st_mode & 0o022
+                or not 0 < before.st_size <= 16 * 1024 * 1024
+            ):
+                raise SystemExit(f"legacy public-height source identity is unsafe: {source}")
+            chunks = []
+            while True:
+                chunk = os.read(descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            payload = b"".join(chunks)
+            if len(payload) != before.st_size or stable(os.fstat(descriptor)) != stable(before):
+                raise SystemExit(f"legacy public-height source changed while read: {source}")
+        finally:
+            os.close(descriptor)
+        if hashlib.sha256(payload).hexdigest() != expected:
+            raise SystemExit(f"legacy public-height source hash differs: {source}")
+        output = os.open(
+            output_names[index],
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o400,
+            dir_fd=root_fd,
+        )
+        with os.fdopen(output, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+            os.fchmod(handle.fileno(), 0o400)
+    os.fsync(root_fd)
+finally:
+    os.close(root_fd)
+os.chmod(root, 0o700, follow_symlinks=False)
+print(root / "legacy-public-height.py")
+PY
+}
+
+validate_durable_legacy_height_cross_proof() {
+    local path="$1" freeze_sha="$2" capture_id="$3" receipt_sha="$4"
+    require_absolute_file "$path" "durable authenticated legacy-height cross-proof"
+    require_hash "$receipt_sha" "legacy public-height receipt hash"
+    python3 - "$path" "$freeze_sha" "$capture_id" "$receipt_sha" <<'PY'
+import json
+import os
+import pathlib
+import stat
+import sys
+
+path = pathlib.Path(sys.argv[1])
+descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+try:
+    before = os.fstat(descriptor)
+    stable = lambda value: (
+        value.st_dev, value.st_ino, value.st_mode, value.st_uid, value.st_gid,
+        value.st_nlink, value.st_size, value.st_mtime_ns, value.st_ctime_ns,
+    )
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or before.st_uid != os.geteuid()
+        or before.st_nlink != 1
+        or stat.S_IMODE(before.st_mode) != 0o400
+        or not 0 < before.st_size <= 16 * 1024 * 1024
+    ):
+        raise SystemExit("durable authenticated legacy-height cross-proof is unsafe")
+    chunks = []
+    while True:
+        chunk = os.read(descriptor, 1024 * 1024)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    payload = b"".join(chunks)
+    if len(payload) != before.st_size or stable(os.fstat(descriptor)) != stable(before):
+        raise SystemExit("durable authenticated legacy-height cross-proof changed while read")
+finally:
+    os.close(descriptor)
+value = json.loads(payload)
+canonical = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+if (
+    payload != canonical
+    or value.get("schema") != "arc.recovery.authenticated-legacy-height-fleet.v1"
+    or value.get("freeze_plan_sha256") != sys.argv[2]
+    or value.get("capture_id") != sys.argv[3]
+    or value.get("legacy_public_height_receipt_sha256") != sys.argv[4]
+):
+    raise SystemExit("durable authenticated legacy-height cross-proof differs")
+PY
+}
+
+sample_legacy_public_height_late() {
+    local freeze_plan="$1" freeze_sha="$2" output="$3"
+    local source_main result receipt_sha state
+    state="$(validate_legacy_public_height_sample_output "$output")"
+    [ "$state" = absent ] || die \
+        "late legacy public-height output already exists; preserve it and choose a new unique output"
+    source_main="$(manifest_field "$freeze_plan" source_commit)"
+    result="$(python3 -B -I "$LEGACY_HEIGHT_TOOL" sample \
+        --source-main "$source_main" --freeze-plan "$freeze_plan" \
+        --freeze-plan-sha256 "$freeze_sha" --output "$output" \
+        --timeout-seconds 10)"
+    receipt_sha="$(python3 - "$result" <<'PY'
+import json
+import re
+import sys
+
+value = json.loads(sys.argv[1])
+if (
+    not isinstance(value, dict)
+    or set(value) != {"legacy_public_max_height", "receipt_sha256"}
+    or isinstance(value.get("legacy_public_max_height"), bool)
+    or not isinstance(value.get("legacy_public_max_height"), int)
+    or value["legacy_public_max_height"] < 0
+    or re.fullmatch(r"[0-9a-f]{64}", str(value.get("receipt_sha256"))) is None
+):
+    raise SystemExit("late legacy public-height sampler output differs")
+print(value["receipt_sha256"])
+PY
+)"
+    require_hash "$receipt_sha" "late legacy public-height receipt hash"
+    state="$(validate_legacy_public_height_sample_output "$output")"
+    [ "$state" = sealed ] || die "late legacy public-height receipt was not sealed"
+    [ "$(sealed_legacy_public_height_receipt_sha "$output")" = "$receipt_sha" ] || \
+        die "late legacy public-height receipt differs from sampler output"
+    printf '%s\n' "$receipt_sha"
 }
 
 capture_id_for_freeze_plan_hash() {
@@ -2277,7 +2621,7 @@ install_freeze_plan() {
         case "$remote_temporary" in /root/.arc-recovery-plan-uploads/upload.*) ;; *) die "unsafe remote freeze-plan temporary path" ;; esac
         scp -q "${SSH_OPTIONS[@]}" "$plan" "$SSH_USER@$host:$remote_temporary"
         ssh_remote_exact "$host" /bin/sh -c \
-            'set -eu; temporary=$1 target=$2 expected=$3; trap '\''rm -f -- "$temporary"'\'' EXIT; test -f "$temporary" && test ! -L "$temporary"; test "$(sha256sum "$temporary" | cut -d" " -f1)" = "$expected"; parent=${target%/*}; grand=${parent%/*}; top=${grand%/*}; for directory in "$top" "$grand" "$parent"; do if test -e "$directory"; then test -d "$directory" && test ! -L "$directory"; else mkdir -m 700 -- "$directory"; fi; done; chmod 400 -- "$temporary"; if ln -- "$temporary" "$target" 2>/dev/null; then :; else test -f "$target" && test ! -L "$target" && test "$(sha256sum "$target" | cut -d" " -f1)" = "$expected" && test ! -w "$target"; fi; sidecar="$target.sha256"; expected_line="$expected  ${target##*/}"; if test -e "$sidecar"; then test -f "$sidecar" && test ! -L "$sidecar" && test "$(cat "$sidecar")" = "$expected_line" && test ! -w "$sidecar"; else side_tmp="$sidecar.partial.$$"; (umask 077; printf "%s\n" "$expected_line" > "$side_tmp"); chmod 400 "$side_tmp"; ln "$side_tmp" "$sidecar"; rm -f "$side_tmp"; fi; python3 - "$target" "$sidecar" <<'\''PY'\''
+            'set -eu; temporary=$1 target=$2 expected=$3; trap '\''rm -f -- "$temporary"'\'' EXIT; test -f "$temporary" && test ! -L "$temporary"; test "$(sha256sum "$temporary" | cut -d" " -f1)" = "$expected"; parent=${target%/*}; grand=${parent%/*}; top=${grand%/*}; for directory in "$top" "$grand" "$parent"; do if test -e "$directory"; then test -d "$directory" && test ! -L "$directory"; else mkdir -m 700 -- "$directory"; fi; done; chmod 400 -- "$temporary"; if ln -- "$temporary" "$target" 2>/dev/null; then :; else test -f "$target" && test ! -L "$target" && test "$(sha256sum "$target" | cut -d" " -f1)" = "$expected" && test "$(/usr/bin/stat -c %u:%g:%a -- "$target")" = 0:0:400; fi; sidecar="$target.sha256"; expected_line="$expected  ${target##*/}"; if test -e "$sidecar"; then test -f "$sidecar" && test ! -L "$sidecar" && test "$(cat "$sidecar")" = "$expected_line" && test "$(/usr/bin/stat -c %u:%g:%a -- "$sidecar")" = 0:0:400; else side_tmp="$sidecar.partial.$$"; (umask 077; printf "%s\n" "$expected_line" > "$side_tmp"); chmod 400 "$side_tmp"; ln "$side_tmp" "$sidecar"; rm -f "$side_tmp"; fi; python3 - "$target" "$sidecar" <<'\''PY'\''
 import os, pathlib, stat, sys
 for raw in sys.argv[1:]:
     path = pathlib.Path(raw); details = path.lstat()
@@ -6606,11 +6950,11 @@ capture_authenticated_legacy_height_cross_proof() {
     local receipt_sha="$5" output="$6" proof_root="$7"
     require_absolute_file "$receipt" "legacy public-height receipt"
     require_hash "$receipt_sha" "legacy public-height receipt hash"
-    [ "$(hash_file "$receipt")" = "$receipt_sha" ] || \
+    [ "$(sealed_legacy_public_height_receipt_sha "$receipt")" = "$receipt_sha" ] || \
         die "legacy public-height receipt differs from its explicit hash"
     local source_main challenge verify_result
     source_main="$(manifest_field "$freeze_plan" source_commit)"
-    verify_result="$(python3 -I "$LEGACY_HEIGHT_TOOL" verify \
+    verify_result="$(python3 -B -I "$LEGACY_HEIGHT_TOOL" verify \
         --source-main "$source_main" --freeze-plan "$freeze_plan" \
         --freeze-plan-sha256 "$freeze_sha" --receipt "$receipt" --max-age-seconds 300)"
     python3 - "$verify_result" "$receipt_sha" <<'PY'
@@ -6673,8 +7017,10 @@ import sys
 
 output = pathlib.Path(sys.argv[1])
 boundary, freeze_sha, capture_id, public_raw, public_sha, authenticated_raw = sys.argv[2:]
-if boundary not in {"first-quarantine-started", "all-controlled-stopped"}:
+if boundary != "all-controlled-stopped":
     raise SystemExit("unsupported stop boundary")
+if any((public_raw, public_sha, authenticated_raw)):
+    raise SystemExit("unexpected public-height inputs for terminal stop boundary")
 if (not output.is_absolute() or output.suffix != ".json"
         or os.fspath(output) != os.path.normpath(os.fspath(output))):
     raise SystemExit("stop boundary output is unsafe")
@@ -6692,99 +7038,6 @@ expected = {
     "freeze_plan_sha256": freeze_sha,
     "capture_id": capture_id,
 }
-
-def locked_json(raw_path, label):
-    candidate = pathlib.Path(raw_path)
-    if not candidate.is_absolute():
-        raise SystemExit(f"first-quarantine {label} path is not absolute")
-    descriptor = os.open(candidate, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
-    try:
-        before = os.fstat(descriptor)
-        stable = lambda item: (
-            item.st_dev, item.st_ino, item.st_mode, item.st_uid, item.st_gid,
-            item.st_nlink, item.st_size, item.st_mtime_ns, item.st_ctime_ns,
-        )
-        if (not stat.S_ISREG(before.st_mode) or before.st_uid not in {0, os.geteuid()}
-                or before.st_nlink != 1 or stat.S_IMODE(before.st_mode) != 0o400
-                or before.st_size <= 0 or before.st_size > 16 * 1024 * 1024):
-            raise SystemExit(f"first-quarantine {label} identity is unsafe")
-        chunks = []
-        while True:
-            chunk = os.read(descriptor, 1024 * 1024)
-            if not chunk:
-                break
-            chunks.append(chunk)
-        payload = b"".join(chunks)
-        if len(payload) != before.st_size or stable(os.fstat(descriptor)) != stable(before):
-            raise SystemExit(f"first-quarantine {label} changed while read")
-    finally:
-        os.close(descriptor)
-    try:
-        decoded = json.loads(payload)
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise SystemExit(f"first-quarantine {label} is invalid JSON") from error
-    if payload != canonical(decoded):
-        raise SystemExit(f"first-quarantine {label} is noncanonical")
-    return decoded, payload
-
-def validate_first_quarantine_authorization(value):
-    if boundary != "first-quarantine-started":
-        if any((public_raw, public_sha, authenticated_raw)):
-            raise SystemExit("unexpected public-height inputs for terminal stop boundary")
-        return
-    if not all((public_raw, public_sha, authenticated_raw)):
-        raise SystemExit("first quarantine requires sealed public-height authorization inputs")
-    if re.fullmatch(r"[0-9a-f]{64}", public_sha) is None:
-        raise SystemExit("first-quarantine public-height hash is malformed")
-    public, public_payload = locked_json(public_raw, "public-height receipt")
-    authenticated, _authenticated_payload = locked_json(
-        authenticated_raw, "authenticated-height fleet proof"
-    )
-    public_fields = {
-        "schema", "source_main_commit", "freeze_plan_sha256", "capture_id",
-        "started_at", "completed_at", "duration_ms", "request_policy", "origins",
-        "legacy_public_max_height",
-    }
-    authenticated_fields = {
-        "schema", "source_main_commit", "freeze_plan_sha256", "capture_id",
-        "legacy_public_height_receipt_sha256", "challenge", "started_at",
-        "completed_at", "conservative_height_floor", "nodes",
-    }
-    if (not isinstance(public, dict) or set(public) != public_fields
-            or hashlib.sha256(public_payload).hexdigest() != public_sha
-            or public.get("schema") != "arc.recovery.legacy-public-height.v1"
-            or (public.get("freeze_plan_sha256"), public.get("capture_id"))
-                != (freeze_sha, capture_id)):
-        raise SystemExit("first-quarantine public-height receipt binding differs")
-    if (not isinstance(authenticated, dict) or set(authenticated) != authenticated_fields
-            or authenticated.get("schema")
-                != "arc.recovery.authenticated-legacy-height-fleet.v1"
-            or (authenticated.get("source_main_commit"),
-                authenticated.get("freeze_plan_sha256"), authenticated.get("capture_id"),
-                authenticated.get("legacy_public_height_receipt_sha256"))
-                != (public.get("source_main_commit"), freeze_sha, capture_id, public_sha)):
-        raise SystemExit("first-quarantine authenticated-height binding differs")
-
-    def utc(raw, label):
-        if not isinstance(raw, str) or re.fullmatch(
-            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", raw
-        ) is None:
-            raise SystemExit(f"first-quarantine {label} is not canonical UTC")
-        try:
-            return datetime.datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ")
-        except ValueError as error:
-            raise SystemExit(f"first-quarantine {label} is invalid") from error
-
-    public_completed = utc(public.get("completed_at"), "public completion")
-    fleet_started = utc(authenticated.get("started_at"), "fleet start")
-    fleet_completed = utc(authenticated.get("completed_at"), "fleet completion")
-    first = utc(value.get("timestamp"), "boundary timestamp")
-    if not public_completed <= fleet_started <= fleet_completed <= first:
-        raise SystemExit("first-quarantine public-height authorization timeline is not ordered")
-    if (first - public_completed).total_seconds() > 300:
-        raise SystemExit(
-            "first-quarantine public-height receipt exceeded the 300-second live boundary"
-        )
 
 def locked_bytes(name, *, modes, links={1}, allow_empty=False):
     fd = os.open(name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0), dir_fd=dfd)
@@ -6835,7 +7088,6 @@ try:
             raise SystemExit("existing stop boundary timestamp is noncanonical")
         if any(value.get(key) != wanted for key, wanted in expected.items()):
             raise SystemExit("existing stop boundary timestamp belongs to another capture")
-        validate_first_quarantine_authorization(value)
         if partial.exists() or partial.is_symlink():
             fragment = locked_bytes(
                 partial.name, modes={0o400, 0o600}, links={1, 2}, allow_empty=True
@@ -6868,7 +7120,6 @@ try:
                     and all(candidate.get(key) == wanted for key, wanted in expected.items())
                     and isinstance(candidate.get("timestamp"), str)
                     and re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", candidate["timestamp"])):
-                validate_first_quarantine_authorization(candidate)
                 os.chmod(partial.name, 0o400, dir_fd=dfd, follow_symlinks=False)
                 descriptor = os.open(
                     partial.name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0), dir_fd=dfd
@@ -6894,10 +7145,6 @@ try:
                 **expected,
                 "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             }
-            # Validate and write in one process so no quarantine command can
-            # interleave between the live <=300-second decision and this
-            # create-only authorization boundary.
-            validate_first_quarantine_authorization(value)
             payload = canonical(value)
             descriptor = os.open(
                 partial.name,
@@ -8042,7 +8289,7 @@ run_quarantine_generation_rounds() {
         attempt_root="$(mktemp -d "$round_dir/attempt.XXXXXX")"
         chmod 700 -- "$attempt_root"
         public_receipt="$attempt_root/target-public-height.json"
-        python3 -I "$LEGACY_HEIGHT_TOOL" sample-targets \
+        python3 -B -I "$LEGACY_HEIGHT_TOOL" sample-targets \
             --source-main "$source_main" --freeze-plan "$freeze_plan" \
             --freeze-plan-sha256 "$freeze_sha" --targets "$targets" \
             --output "$public_receipt" --timeout-seconds 10 >/dev/null
@@ -8301,7 +8548,8 @@ PY
 
 capture_phase() {
     local freeze_plan="" offline_stop_output="" legacy_height_receipt=""
-    local legacy_height_receipt_sha="" inspector_binary="" inspector_binary_sha=""
+    local legacy_height_receipt_sha="" legacy_height_sample_output=""
+    local inspector_binary="" inspector_binary_sha=""
     local inspector_genesis="" inspector_genesis_sha="" inspector_validators=""
     local inspector_validators_sha="" inspector_legacy_validators=""
     local inspector_legacy_validators_sha="" execute=false
@@ -8312,6 +8560,7 @@ capture_phase() {
             --offline-stop-evidence-output) [ "$#" -ge 2 ] || die "--offline-stop-evidence-output needs a value"; offline_stop_output="$2"; shift 2 ;;
             --legacy-public-height-receipt) [ "$#" -ge 2 ] || die "--legacy-public-height-receipt needs a value"; legacy_height_receipt="$2"; shift 2 ;;
             --legacy-public-height-receipt-sha256) [ "$#" -ge 2 ] || die "--legacy-public-height-receipt-sha256 needs a value"; legacy_height_receipt_sha="$2"; shift 2 ;;
+            --sample-legacy-public-height-output) [ "$#" -ge 2 ] || die "--sample-legacy-public-height-output needs a value"; legacy_height_sample_output="$2"; shift 2 ;;
             --inspector-binary) [ "$#" -ge 2 ] || die "--inspector-binary needs a value"; inspector_binary="$2"; shift 2 ;;
             --inspector-binary-sha256) [ "$#" -ge 2 ] || die "--inspector-binary-sha256 needs a value"; inspector_binary_sha="$2"; shift 2 ;;
             --genesis) [ "$#" -ge 2 ] || die "--genesis needs a value"; inspector_genesis="$2"; shift 2 ;;
@@ -8328,9 +8577,16 @@ capture_phase() {
         esac
     done
     [ -n "$freeze_plan" ] || die "--freeze-plan is required"
-    [ -n "$legacy_height_receipt" ] || die "--legacy-public-height-receipt is required"
-    require_hash "$legacy_height_receipt_sha" "legacy public-height receipt hash"
-    require_absolute_file "$legacy_height_receipt" "legacy public-height receipt"
+    if [ -n "$legacy_height_sample_output" ]; then
+        [ -z "$legacy_height_receipt" ] && [ -z "$legacy_height_receipt_sha" ] || die \
+            "--sample-legacy-public-height-output is mutually exclusive with an existing receipt/hash"
+        legacy_height_receipt="$legacy_height_sample_output"
+    else
+        [ -n "$legacy_height_receipt" ] || die \
+            "capture requires --sample-legacy-public-height-output or --legacy-public-height-receipt"
+        require_hash "$legacy_height_receipt_sha" "legacy public-height receipt hash"
+        require_absolute_file "$legacy_height_receipt" "legacy public-height receipt"
+    fi
     local inspector_path inspector_expected
     for inspector_path in "$inspector_binary" "$inspector_genesis" \
         "$inspector_validators" "$inspector_legacy_validators"; do
@@ -8352,7 +8608,18 @@ capture_phase() {
         die "capture inspector legacy-validator-set differs from its explicit hash"
     [ -n "$offline_stop_output" ] || offline_stop_output="${freeze_plan}.offline-stop-evidence.json"
     case "$offline_stop_output" in /*.json) ;; *) die "offline-stop evidence output must be an absolute .json path" ;; esac
+    if [ -n "$legacy_height_sample_output" ]; then
+        case "$legacy_height_receipt" in
+            "$offline_stop_output"|"$offline_stop_output".*) die \
+                "late legacy public-height output collides with the offline-stop evidence namespace" ;;
+        esac
+    fi
+    local legacy_height_cross_proof="${offline_stop_output}.authenticated-height-cross-proof.json"
+    local legacy_height_cross_partial="${legacy_height_cross_proof}.partial"
     configure_operator_transport true
+    if [ -n "$legacy_height_sample_output" ]; then
+        validate_legacy_public_height_sample_output "$legacy_height_receipt" >/dev/null
+    fi
     require_commands python3 ssh scp grep git mktemp
     [ -x "$REMOTE_HELPER" ] || die "remote helper is missing or not executable"
     [ -x "$DRIVE_PREFREEZE_GATE" ] || die "Drive prefreeze gate is missing or not executable"
@@ -8366,6 +8633,28 @@ capture_phase() {
     local freeze_sha capture_id
     freeze_sha="$(freeze_plan_hash "$freeze_plan")"
     capture_id="$(capture_id_for_freeze_plan_hash "$freeze_sha")"
+    if [ -n "$legacy_height_sample_output" ]; then
+        local late_height_output_state
+        printf '%s\n' "${legacy_height_receipt##*/}" | grep -Eq \
+            "^legacy-public-height\\.${capture_id}\\.[0-9a-f]{32}\\.json$" || die \
+            "late legacy public-height output must be capture-scoped with a unique 32-hex nonce"
+        late_height_output_state="$(validate_legacy_public_height_sample_output \
+            "$legacy_height_receipt")"
+        if [ -e "$legacy_height_cross_proof" ] || [ -L "$legacy_height_cross_proof" ]; then
+            [ "$late_height_output_state" = sealed ] || die \
+                "authenticated legacy-height cross-proof exists without its selected receipt"
+            legacy_height_receipt_sha="$(sealed_legacy_public_height_receipt_sha \
+                "$legacy_height_receipt")"
+            validate_durable_legacy_height_cross_proof "$legacy_height_cross_proof" \
+                "$freeze_sha" "$capture_id" "$legacy_height_receipt_sha"
+        else
+            [ "$late_height_output_state" = absent ] || die \
+                "unselected late legacy public-height receipt exists; preserve it and choose a new unique output"
+            [ ! -e "$legacy_height_cross_partial" ] && \
+                [ ! -L "$legacy_height_cross_partial" ] || die \
+                "partial authenticated legacy-height proof exists; preserve this namespace and choose a new offline-stop output"
+        fi
+    fi
     printf 'ARC staged legacy freeze plan\n'
     printf '  freeze:   %s\n' "$freeze_sha"
     printf '  capture:  %s\n' "$capture_id"
@@ -8385,6 +8674,24 @@ capture_phase() {
 
     [ "$(freeze_plan_hash "$freeze_plan")" = "$freeze_sha" ] || \
         die "freeze plan or source bindings changed before execution"
+    # Pin the sampler and its local imports into this invocation's private
+    # root. Both sampling and verification execute these immutable bytes with
+    # bytecode generation disabled.
+    LEGACY_HEIGHT_TOOL="$(pin_legacy_public_height_toolchain \
+        "$ARCHIVE_FLEET_PINNED_ROOT/legacy-height-toolchain")"
+    if [ -f "$legacy_height_receipt" ] && [ ! -L "$legacy_height_receipt" ]; then
+        local actual_legacy_height_receipt_sha
+        actual_legacy_height_receipt_sha="$(sealed_legacy_public_height_receipt_sha \
+            "$legacy_height_receipt")"
+        if [ -n "$legacy_height_sample_output" ]; then
+            legacy_height_receipt_sha="$actual_legacy_height_receipt_sha"
+        else
+            [ "$actual_legacy_height_receipt_sha" = "$legacy_height_receipt_sha" ] || die \
+                "legacy public-height receipt differs from its explicit hash"
+        fi
+        validate_intrinsic_legacy_public_height_receipt "$legacy_height_receipt" \
+            "$legacy_height_receipt_sha" "$freeze_plan" "$freeze_sha"
+    fi
     install_helpers "$(manifest_field "$freeze_plan" remote_helper_sha256)"
     assert_pinned_freeze_bytes "$freeze_plan" "$freeze_sha"
     install_freeze_plan "$freeze_plan" "$freeze_sha"
@@ -8526,29 +8833,31 @@ PY
         "$observation_generation_receipt_sha" \
         "$drive_prefreeze_receipt_sha" "$log_root" "$live_observation_statuses"
     assert_pinned_freeze_bytes "$freeze_plan" "$freeze_sha"
-    local legacy_height_cross_proof="${offline_stop_output}.authenticated-height-cross-proof.json"
     local first_quarantine_started_at all_controlled_stopped_at
     local first_boundary_path="${offline_stop_output}.first-quarantine-started.json"
     if [ -e "$legacy_height_cross_proof" ] || [ -L "$legacy_height_cross_proof" ]; then
-        [ -f "$legacy_height_cross_proof" ] && [ ! -L "$legacy_height_cross_proof" ] || \
-            die "durable authenticated legacy-height cross-proof is unsafe"
-        python3 - "$legacy_height_cross_proof" "$freeze_sha" "$capture_id" \
-            "$legacy_height_receipt_sha" <<'PY'
-import json,pathlib,stat,sys
-path=pathlib.Path(sys.argv[1]);value=json.loads(path.read_text(encoding="utf-8"))
-raw=(json.dumps(value,sort_keys=True,separators=(",",":"))+"\n").encode()
-details=path.lstat()
-if (path.read_bytes()!=raw or stat.S_IMODE(details.st_mode)!=0o400 or details.st_nlink!=1
-        or value.get("schema")!="arc.recovery.authenticated-legacy-height-fleet.v1"
-        or value.get("freeze_plan_sha256")!=sys.argv[2]
-        or value.get("capture_id")!=sys.argv[3]
-        or value.get("legacy_public_height_receipt_sha256")!=sys.argv[4]):
-    raise SystemExit("durable authenticated legacy-height cross-proof differs")
-PY
+        if [ -n "$legacy_height_sample_output" ]; then
+            [ "$(validate_legacy_public_height_sample_output "$legacy_height_receipt")" = sealed ] || \
+                die "selected late legacy public-height receipt is missing or unsafe"
+            legacy_height_receipt_sha="$(sealed_legacy_public_height_receipt_sha \
+                "$legacy_height_receipt")"
+        fi
+        validate_durable_legacy_height_cross_proof "$legacy_height_cross_proof" \
+            "$freeze_sha" "$capture_id" "$legacy_height_receipt_sha"
         printf 'archive fleet: reusing the durable authenticated pre-quarantine height proof\n'
     else
         [ ! -e "$first_boundary_path" ] && [ ! -L "$first_boundary_path" ] || die \
             "first quarantine boundary exists without its durable authenticated height proof"
+        [ ! -e "$legacy_height_cross_partial" ] && \
+            [ ! -L "$legacy_height_cross_partial" ] || die \
+            "partial authenticated legacy-height proof must remain in an abandoned offline-output namespace"
+        if [ -n "$legacy_height_sample_output" ]; then
+            printf 'archive fleet: sampling all six public heights after expensive pre-freeze staging\n'
+            legacy_height_receipt_sha="$(sample_legacy_public_height_late \
+                "$freeze_plan" "$freeze_sha" "$legacy_height_receipt")"
+            printf 'archive fleet: sealed late public-height receipt path=%s sha256=%s\n' \
+                "$legacy_height_receipt" "$legacy_height_receipt_sha"
+        fi
         printf 'archive fleet: cross-proving public height samples against every exact SSH-authenticated loopback writer\n'
         capture_authenticated_legacy_height_cross_proof "$freeze_plan" "$freeze_sha" \
             "$capture_id" "$legacy_height_receipt" "$legacy_height_receipt_sha" \

--- a/scripts/recovery/build-production-manifest.py
+++ b/scripts/recovery/build-production-manifest.py
@@ -108,10 +108,10 @@ APPROVED_ACME_EMAIL = "tj@arc.ai"
 MAX_OFFLINE_STOP_VERIFICATION_AGE_SECONDS = 300
 MAX_OFFLINE_STOP_VERIFICATION_DURATION_MS = 120_000
 # The live capture path enforces this wall-clock bound immediately before the
-# first quarantine.  The post-stop builder must instead re-prove the same
-# bound from the immutable receipt/cross-proof/maintenance-boundary timeline;
-# the six official HTTP origins no longer exist to resample at that point.
-MAX_LEGACY_HEIGHT_TO_FIRST_QUARANTINE_SECONDS = 300
+# authenticated all-writer cross-proof. The post-stop builder re-proves the
+# same bound from the immutable receipt/cross-proof timeline; the six official
+# HTTP origins no longer exist to resample at that point.
+MAX_LEGACY_HEIGHT_TO_AUTHENTICATED_CROSS_SECONDS = 300
 ZERO_HASH = "0" * 64
 MAX_JSON_BYTES = 16 * 1024 * 1024
 MAX_METADATA_BYTES = 64 * 1024
@@ -4587,11 +4587,12 @@ def load_intrinsic_legacy_public_height_receipt(
 ) -> tuple[dict[str, Any], int, str, bytes]:
     """Load a historical stopped-fleet receipt without using the current clock.
 
-    ``archive-fleet-to-drive.sh capture`` retains the live <=300-second check
-    before it may create the first quarantine boundary.  After that boundary,
-    resampling would require restarting the retired writers, so this builder
-    validates intrinsic receipt semantics and later proves freshness from the
-    exact sealed capture timeline instead of comparing against ``now()``.
+    ``archive-fleet-to-drive.sh capture`` performs the live <=300-second check
+    immediately before it seals the authenticated all-writer cross-proof.
+    Actual writer mutations are separately authorized by fresh, bounded
+    per-round target receipts.  After the writers retire, this builder validates
+    intrinsic receipt semantics and the exact sealed capture timeline instead
+    of comparing historical evidence against ``now()``.
     """
 
     payload, _details = read_secure(
@@ -4612,7 +4613,7 @@ def load_intrinsic_legacy_public_height_receipt(
             source_main=args.source_main_sha,
             freeze_sha=freeze_sha,
             now=completed,
-            max_age_seconds=MAX_LEGACY_HEIGHT_TO_FIRST_QUARANTINE_SECONDS,
+            max_age_seconds=MAX_LEGACY_HEIGHT_TO_AUTHENTICATED_CROSS_SECONDS,
         )
     except legacy_height.HeightReceiptError as error:
         fail(f"legacy public-height receipt failed intrinsic validation: {error}")
@@ -4713,7 +4714,7 @@ def validate_sealed_legacy_height_capture_timeline(
                 != ledger_wrapper.get("sha256")):
         fail("sealed quarantine generation ledger roots differ")
 
-    _parse_utc_seconds(
+    height_completed = _parse_utc_seconds(
         height_receipt.get("completed_at"), "sealed legacy public-height completed_at"
     )
     fleet_started = _parse_utc_seconds(
@@ -4757,8 +4758,11 @@ def validate_sealed_legacy_height_capture_timeline(
     boundary_created = _parse_utc_seconds(
         boundary.get("created_at"), "sealed maintenance-boundary created_at"
     )
-    if fleet_started > fleet_completed:
+    if not height_completed <= fleet_started <= fleet_completed:
         fail("sealed authenticated-height fleet receipt timeline regressed")
+    if (fleet_started - height_completed).total_seconds() \
+            > MAX_LEGACY_HEIGHT_TO_AUTHENTICATED_CROSS_SECONDS:
+        fail("sealed legacy public-height receipt exceeded the 300-second authenticated cross-proof boundary")
     # Remote transition/stop UTC values and operator UTC are audit-only.  The
     # exact selection -> authorization -> readiness -> dispatch -> transition
     # -> ledger roots (plus each node's BOOTTIME lease) establish causality.

--- a/scripts/recovery/legacy-public-height.py
+++ b/scripts/recovery/legacy-public-height.py
@@ -3,8 +3,9 @@
 
 The sampler is intentionally independent of the rollout RPC client.  It talks
 only to the fixed, reviewed legacy HTTP origins and writes a private,
-create-only canonical receipt.  The production-manifest builder must reject a
-receipt more than five minutes old.
+create-only canonical receipt.  The live capture orchestrator must verify the
+receipt within five minutes before it seals the authenticated cross-proof;
+post-stop builders validate that immutable historical decision intrinsically.
 """
 
 from __future__ import annotations

--- a/scripts/recovery/test_build_production_manifest.py
+++ b/scripts/recovery/test_build_production_manifest.py
@@ -3712,6 +3712,51 @@ class ProductionManifestBuilderTests(unittest.TestCase):
                 offline_stop=offline,
             )
 
+    def test_capture_timeline_rejects_cross_proof_started_301_seconds_after_receipt(self) -> None:
+        public_completed = (
+            dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+            - dt.timedelta(hours=2)
+        )
+        self.fixture.write_height(completed_at=public_completed)
+        self.fixture.write_offline_stop(
+            fleet_started_at=public_completed + dt.timedelta(seconds=1),
+            fleet_completed_at=public_completed + dt.timedelta(seconds=2),
+            first_quarantine_at=public_completed + dt.timedelta(seconds=3),
+            all_stopped_at=public_completed + dt.timedelta(seconds=4),
+            boundary_created_at=public_completed + dt.timedelta(seconds=5),
+        )
+        height = json.loads(self.fixture.height.read_text())
+        bundle = json.loads(self.fixture.bundle.read_text())
+        boundary = json.loads(self.fixture.boundary.read_text())
+        offline = json.loads(self.fixture.offline_stop.read_text())
+        cross = copy.deepcopy(offline["legacy_height_cross_proof"])
+        cross["started_at"] = (
+            public_completed + dt.timedelta(seconds=301)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        cross["completed_at"] = (
+            public_completed + dt.timedelta(seconds=302)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        cross_sha = sha(canonical(cross))
+        offline["legacy_height_cross_proof"] = copy.deepcopy(cross)
+        bundle["authenticated_prefence_height_cross_proof"] = {
+            "value": copy.deepcopy(cross),
+            "sha256": cross_sha,
+        }
+        boundary["authenticated_prefence_height_cross_proof_sha256"] = cross_sha
+
+        with self.assertRaisesRegex(
+            builder.BuilderError, "300-second authenticated cross-proof boundary"
+        ):
+            builder.validate_sealed_legacy_height_capture_timeline(
+                args=self.fixture.args(),
+                freeze_sha=self.fixture.freeze_sha,
+                height_receipt=height,
+                height_receipt_sha=sha(self.fixture.height.read_bytes()),
+                evidence_bundle=bundle,
+                boundary=boundary,
+                offline_stop=offline,
+            )
+
     def test_final_height_recheck_rejects_same_maximum_byte_substitution(self) -> None:
         original_side_effect = builder.execute_installed_key_verifier.side_effect
 

--- a/scripts/recovery/test_legacy_public_height.py
+++ b/scripts/recovery/test_legacy_public_height.py
@@ -292,6 +292,28 @@ class LegacyPublicHeightTests(unittest.TestCase):
                 now=completed + dt.timedelta(seconds=301),
             )
 
+    def test_late_sampling_survives_425_second_prerequisite_latency(self) -> None:
+        capture_started = dt.datetime(2026, 9, 3, 9, 20, tzinfo=dt.timezone.utc)
+        cross_proof_started = capture_started + dt.timedelta(seconds=425)
+
+        early_receipt = self.receipt(capture_started)
+        with self.assertRaisesRegex(height.HeightReceiptError, r"stale \(425s old"):
+            height.validate_receipt(
+                early_receipt,
+                source_main="1" * 40,
+                freeze_sha="2" * 64,
+                now=cross_proof_started,
+            )
+
+        late_receipt = self.receipt(cross_proof_started)
+        maximum = height.validate_receipt(
+            late_receipt,
+            source_main="1" * 40,
+            freeze_sha="2" * 64,
+            now=cross_proof_started,
+        )
+        self.assertEqual(maximum, 105)
+
     def test_receipt_output_symlink_is_never_followed(self) -> None:
         target = self.root / "target.json"
         target.write_text("untouched", encoding="utf-8")

--- a/tests/release/documentation_contract_test.sh
+++ b/tests/release/documentation_contract_test.sh
@@ -767,8 +767,7 @@ recovery_archive_commands_are_exact_and_resumable() {
     done
 
     for literal in \
-        'scripts/recovery/legacy-public-height.py sample' \
-        '--timeout-seconds 10' \
+        '--sample-legacy-public-height-output "$legacy_public_height_receipt"' \
         'scripts/release/select-pretag-artifacts.py' \
         'scripts/release/verify-pretag-run-and-artifacts.sh' \
         'scripts/release/materialize-pretag-artifacts.py' \
@@ -786,6 +785,43 @@ recovery_archive_commands_are_exact_and_resumable() {
             'recovery README omits an exact protected materialization/finalization command' \
             || return 1
     done
+    python3 - "$RECOVERY_README" <<'PY' || return 1
+import pathlib
+import re
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+start = text.index("scripts/recovery/archive-fleet-to-drive.sh prepare-writers")
+end = text.index("Install the restored keys only after that successful capture.", start)
+capture = text[start:end]
+calls = [
+    match.start()
+    for match in re.finditer(
+        re.escape("scripts/recovery/archive-fleet-to-drive.sh capture \\"), capture
+    )
+]
+if len(calls) != 2:
+    raise SystemExit("recovery README must contain exactly one capture plan and one capture execute call")
+nonce = capture.index('legacy_height_attempt_nonce="$(')
+receipt = capture.index('legacy_public_height_receipt="/secure/operator/legacy-public-height.')
+authorization = capture.index('ARC_RECOVERY_FREEZE_GO="FREEZE $freeze_sha256 CAPTURE $capture_id"')
+execute = capture.index("    --execute", calls[1])
+sealed_hash = capture.index('legacy_public_height_sha256="$(arc_sha256 "$legacy_public_height_receipt")"')
+if not nonce < receipt < calls[0] < authorization < calls[1] < execute < sealed_hash:
+    raise SystemExit("late public-height receipt plan/execute/hash order differs")
+flag = '--sample-legacy-public-height-output "$legacy_public_height_receipt"'
+if capture.count(flag) != 2 or flag not in capture[calls[0]:authorization] or flag not in capture[calls[1]:execute]:
+    raise SystemExit("capture plan and execute must share the exact late-sample output path")
+if "scripts/recovery/legacy-public-height.py sample" in capture:
+    raise SystemExit("recovery README samples public height before capture prerequisites")
+for statement in (
+    "do not sample it here",
+    "execute phase samples only after the slow inspector, Drive, and live-",
+    "observation prerequisites, immediately before the authenticated cross-proof",
+):
+    if statement not in capture:
+        raise SystemExit(f"recovery README omits late-sampling timing contract: {statement}")
+PY
     for literal in \
         '/secure/operator/arc-offline-stop-evidence.json' \
         '/secure/operator/arc-validator-maintenance-ed25519' \

--- a/tests/release/recovery_archive_contract_test.sh
+++ b/tests/release/recovery_archive_contract_test.sh
@@ -92,6 +92,7 @@ all_six_exact_writers_stop_before_content_capture() {
 import pathlib,sys
 t=pathlib.Path(sys.argv[1]).read_text(); b=t[t.index("capture_phase()"):t.index("manifest_field()")]
 assert b.index('run_drive_prefreeze_gate execute') < b.index('capture_all_live_observations')
+late_sample=b.index('legacy_height_receipt_sha="$(sample_legacy_public_height_late')
 height_cross=b.index('capture_authenticated_legacy_height_cross_proof "$freeze_plan"')
 rounds=b.index('run_quarantine_generation_rounds')
 first_boundary=b.index('build-first-boundary')
@@ -100,7 +101,7 @@ capture=b.index('ensure_offline_capture "$capture_id" "$node"')
 persisted=b.index('run_persisted_head_exact "$freeze_plan"')
 boundary=b.index('create_legacy_maintenance_boundary')
 offline=b.index('create_offline_stop_evidence')
-assert b.index('capture_all_live_observations') < height_cross < rounds < first_boundary
+assert b.index('capture_all_live_observations') < late_sample < height_cross < rounds < first_boundary
 assert first_boundary < stop < capture < persisted < boundary < offline
 assert 'ALL SIX CONTROLLED WRITERS HALTED' in b and 'no global halt is claimed' in b
 for required in ('sample-targets', 'quarantine-round-authorize',
@@ -114,73 +115,174 @@ PY
     ! grep -Eq 'pkill[[:space:]]|killall[[:space:]]|kill[[:space:]]+-9' "$NODE_HELPER"
 }
 
-first_quarantine_boundary_is_temporally_authorized_before_write() (
+late_public_height_sampling_is_plan_safe_and_create_only() (
     # shellcheck source=/dev/null
     . "$ORCHESTRATOR" >/dev/null
-    local fixture freeze capture receipt_sha
-    fixture="$(mktemp -d "$REPO_ROOT/.first-boundary-test.XXXXXX")"
+    local fixture output first_sha first_raw pinned status
+    fixture="$(mktemp -d "$REPO_ROOT/.late-height-test.XXXXXX")"
     trap 'chmod -R u+w "$fixture" 2>/dev/null || true; rm -rf -- "$fixture"' EXIT
-    freeze="$(printf 'a%.0s' {1..64})"
-    capture="$(printf 'b%.0s' {1..64})"
-    python3 - "$fixture" "$freeze" "$capture" <<'PY' || return 1
-import datetime, hashlib, json, pathlib, sys
-root=pathlib.Path(sys.argv[1]);freeze,capture=sys.argv[2:]
-canonical=lambda value:(json.dumps(value,sort_keys=True,separators=(",",":"))+"\n").encode()
-now=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
-stamp=lambda value:value.strftime("%Y-%m-%dT%H:%M:%SZ")
-def write_case(name,public_completed,fleet_started,fleet_completed):
-    public={"schema":"arc.recovery.legacy-public-height.v1","source_main_commit":"c"*40,
-        "freeze_plan_sha256":freeze,"capture_id":capture,"started_at":stamp(public_completed),
-        "completed_at":stamp(public_completed),"duration_ms":1,"request_policy":{},
-        "origins":[],"legacy_public_max_height":1}
-    public_raw=canonical(public);public_sha=hashlib.sha256(public_raw).hexdigest()
-    cross={"schema":"arc.recovery.authenticated-legacy-height-fleet.v1",
-        "source_main_commit":"c"*40,"freeze_plan_sha256":freeze,"capture_id":capture,
-        "legacy_public_height_receipt_sha256":public_sha,"challenge":"d"*64,
-        "started_at":stamp(fleet_started),"completed_at":stamp(fleet_completed),
-        "conservative_height_floor":1,"nodes":[]}
-    (root/f"{name}-public.json").write_bytes(public_raw)
-    (root/f"{name}-cross.json").write_bytes(canonical(cross))
-    for path in (root/f"{name}-public.json",root/f"{name}-cross.json"):path.chmod(0o400)
-    (root/f"{name}-sha.txt").write_text(public_sha+"\n",encoding="ascii")
-write_case("valid",now-datetime.timedelta(seconds=2),now-datetime.timedelta(seconds=1),now)
-write_case("stale",now-datetime.timedelta(seconds=301),now-datetime.timedelta(seconds=300),now)
-write_case("reordered",now,now+datetime.timedelta(seconds=1),now+datetime.timedelta(seconds=2))
+    chmod 700 "$fixture"
+    mkdir "$fixture/source"
+    python3 - "$fixture/source/legacy-public-height.py" <<'PY' || return 1
+import pathlib,sys
+path=pathlib.Path(sys.argv[1])
+path.write_text('''#!/usr/bin/env python3
+import hashlib,json,os,pathlib,sys
+output=pathlib.Path(sys.argv[sys.argv.index("--output")+1])
+payload=b'{"sampled_after_prerequisites":true}\\n'
+fd=os.open(output,os.O_WRONLY|os.O_CREAT|os.O_EXCL|getattr(os,"O_NOFOLLOW",0),0o400)
+with os.fdopen(fd,"wb") as handle:
+    handle.write(payload);handle.flush();os.fsync(handle.fileno())
+print(json.dumps({"legacy_public_max_height":425,"receipt_sha256":hashlib.sha256(payload).hexdigest()},sort_keys=True,separators=(",",":")))
+''',encoding="utf-8")
+(path.parent/"recovery_freeze.py").write_text("# pinned dependency\\n",encoding="utf-8")
+(path.parent/"quarantine_rounds.py").write_text("# pinned dependency\\n",encoding="utf-8")
 PY
-    receipt_sha="$(cat "$fixture/valid-sha.txt")"
-    reserve_stop_boundary_timestamp "$fixture/valid-evidence.json" \
-        first-quarantine-started "$freeze" "$capture" \
-        "$fixture/valid-public.json" "$receipt_sha" "$fixture/valid-cross.json" \
-        >/dev/null || return 1
-    [ -f "$fixture/valid-evidence.json.first-quarantine-started.json" ] || return 1
-    python3 - "$fixture/valid-evidence.json.first-quarantine-started.json" <<'PY' || return 1
+    LEGACY_HEIGHT_TOOL="$fixture/source/legacy-public-height.py"
+    RECOVERY_FREEZE_MODULE="$fixture/source/recovery_freeze.py"
+    QUARANTINE_ROUND_MODULE="$fixture/source/quarantine_rounds.py"
+    [ -f "$LEGACY_HEIGHT_TOOL" ] || return 1
+    [ -f "$RECOVERY_FREEZE_MODULE" ] || return 1
+    [ -f "$QUARANTINE_ROUND_MODULE" ] || return 1
+    tracked_source_hash() { hash_file "$1"; }
+    manifest_field() { printf '%s\n' "$(printf '1%.0s' {1..40})"; }
+    pinned="$(pin_legacy_public_height_toolchain "$fixture/pinned")" || return 1
+    [ "$pinned" = "$fixture/pinned/legacy-public-height.py" ] || return 1
+    python3 - "$fixture/pinned" <<'PY' || return 1
 import pathlib,stat,sys
-assert stat.S_IMODE(pathlib.Path(sys.argv[1]).stat().st_mode)==0o400
+root=pathlib.Path(sys.argv[1])
+assert stat.S_IMODE(root.stat().st_mode)==0o700
+for name in ("legacy-public-height.py","recovery_freeze.py","quarantine_rounds.py"):
+    assert stat.S_IMODE((root/name).stat().st_mode)==0o400
 PY
+    [ ! -e "$fixture/pinned/__pycache__" ] || return 1
+    LEGACY_HEIGHT_TOOL="$pinned"
+    [ "$LEGACY_HEIGHT_TOOL" = "$pinned" ] || return 1
+    output="$fixture/late-height.json"
+    [ "$(validate_legacy_public_height_sample_output "$output")" = absent ] || return 1
+    [ ! -e "$output" ] || return 1
+    first_sha="$(sample_legacy_public_height_late \
+        "$fixture/freeze.json" "$(printf '2%.0s' {1..64})" "$output")" || return 1
+    [ "$first_sha" = "$(hash_file "$output")" ] || return 1
+    [ "$(validate_legacy_public_height_sample_output "$output")" = sealed ] || return 1
+    first_raw="$(base64 < "$output")"
+    if ( trap - EXIT; sample_legacy_public_height_late \
+            "$fixture/freeze.json" "$(printf '2%.0s' {1..64})" "$output" \
+            >/dev/null 2>&1 ); then
+        return 1
+    else
+        status=$?
+    fi
+    [ "$status" -ne 0 ] || return 1
+    [ "$(base64 < "$output")" = "$first_raw" ] || return 1
 
-    receipt_sha="$(cat "$fixture/stale-sha.txt")"
-    set +e
-    reserve_stop_boundary_timestamp "$fixture/stale-evidence.json" \
-        first-quarantine-started "$freeze" "$capture" \
-        "$fixture/stale-public.json" "$receipt_sha" "$fixture/stale-cross.json" \
-        >/dev/null 2>&1
-    local stale_status=$?
-    set -e
-    [ "$stale_status" -ne 0 ] || return 1
-    [ ! -e "$fixture/stale-evidence.json.first-quarantine-started.json" ] || return 1
-    [ ! -e "$fixture/stale-evidence.json.first-quarantine-started.json.partial" ] || return 1
+    chmod 600 "$output"
+    if ( trap - EXIT; validate_legacy_public_height_sample_output "$output" \
+            >/dev/null 2>&1 ); then return 1; fi
+    chmod 400 "$output"
+    ln "$output" "$fixture/hardlink.json"
+    if ( trap - EXIT; validate_legacy_public_height_sample_output "$output" \
+            >/dev/null 2>&1 ); then return 1; fi
+    rm "$fixture/hardlink.json"
+    ln -s "$output" "$fixture/symlink.json"
+    if ( trap - EXIT; validate_legacy_public_height_sample_output \
+            "$fixture/symlink.json" >/dev/null 2>&1 ); then return 1; fi
+    mkdir -m 777 "$fixture/writable"
+    if ( trap - EXIT; validate_legacy_public_height_sample_output \
+            "$fixture/writable/new.json" >/dev/null 2>&1 ); then return 1; fi
 
-    receipt_sha="$(cat "$fixture/reordered-sha.txt")"
-    set +e
-    reserve_stop_boundary_timestamp "$fixture/reordered-evidence.json" \
-        first-quarantine-started "$freeze" "$capture" \
-        "$fixture/reordered-public.json" "$receipt_sha" "$fixture/reordered-cross.json" \
-        >/dev/null 2>&1
-    local reordered_status=$?
-    set -e
-    [ "$reordered_status" -ne 0 ] || return 1
-    [ ! -e "$fixture/reordered-evidence.json.first-quarantine-started.json" ] || return 1
-    [ ! -e "$fixture/reordered-evidence.json.first-quarantine-started.json.partial" ] || return 1
+    python3 - "$ORCHESTRATOR" <<'PY' || return 1
+import pathlib,sys
+text=pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+capture=text[text.index("capture_phase()"):text.index("manifest_field()")]
+plan_return=capture.index("if [ \"$execute\" != true ]")
+late_sample=capture.index('legacy_height_receipt_sha="$(sample_legacy_public_height_late')
+live=capture.index("capture_all_live_observations")
+cross=capture.index('capture_authenticated_legacy_height_cross_proof "$freeze_plan"')
+assert plan_return < live < late_sample < cross
+assert "--sample-legacy-public-height-output" in capture
+assert "mutually exclusive with an existing receipt/hash" in capture
+assert "unselected late legacy public-height receipt exists" in capture
+assert "collides with the offline-stop evidence namespace" in capture
+assert "capture-scoped with a unique 32-hex nonce" in capture
+PY
+)
+
+freeze_plan_install_reuse_is_root_safe_and_crash_resumable() (
+    local fixture target sidecar payload_sha
+    fixture="$(mktemp -d "$REPO_ROOT/.freeze-plan-reuse-test.XXXXXX")"
+    trap 'chmod -R u+w "$fixture" 2>/dev/null || true; rm -rf -- "$fixture"' EXIT
+    chmod 700 "$fixture"
+    target="$fixture/freeze.lock.json"
+    sidecar="$target.sha256"
+    printf '%s\n' '{"sealed":true}' > "$target"
+    payload_sha="$(python3 - "$target" <<'PY'
+import hashlib,pathlib,sys
+print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+)"
+    printf '%s  %s\n' "$payload_sha" "${target##*/}" > "$sidecar"
+    chmod 400 "$target" "$sidecar"
+    # Model an interrupted hard-link publication: the immutable inode is
+    # correct, but cleanup did not yet remove the uploader-side link.
+    ln "$target" "$fixture/retained-upload"
+    ln "$sidecar" "$fixture/retained-sidecar-partial"
+    python3 - "$ORCHESTRATOR" "$target" "$sidecar" "$payload_sha" <<'PY' || return 1
+import hashlib
+import os
+import pathlib
+import stat
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+target = pathlib.Path(sys.argv[2])
+sidecar = pathlib.Path(sys.argv[3])
+expected = sys.argv[4]
+install = source[source.index("install_freeze_plan()") : source.index("prepare_writers()")]
+
+assert 'test ! -w "$target"' not in install
+assert 'test ! -w "$sidecar"' not in install
+assert '$(/usr/bin/stat -c %u:%g:%a -- "$target")" = 0:0:400' in install
+assert '$(/usr/bin/stat -c %u:%g:%a -- "$sidecar")" = 0:0:400' in install
+assert "%h" not in install
+
+def identity(path):
+    details = path.lstat()
+    return {
+        "regular": stat.S_ISREG(details.st_mode),
+        "symlink": stat.S_ISLNK(details.st_mode),
+        # The remote command is authenticated as root; normalize this local
+        # fixture to the exact remote numeric identity contract.
+        "uid": 0,
+        "gid": 0,
+        "mode": stat.S_IMODE(details.st_mode),
+        "nlink": details.st_nlink,
+    }
+
+def accepted(details):
+    return (
+        details["regular"]
+        and not details["symlink"]
+        and (details["uid"], details["gid"], details["mode"]) == (0, 0, 0o400)
+    )
+
+target_identity = identity(target)
+sidecar_identity = identity(sidecar)
+assert target_identity["nlink"] == 2 and sidecar_identity["nlink"] == 2
+assert accepted(target_identity) and accepted(sidecar_identity)
+assert hashlib.sha256(target.read_bytes()).hexdigest() == expected
+assert sidecar.read_bytes() == f"{expected}  {target.name}\n".encode("ascii")
+for field, bad in (("uid", 1), ("gid", 1), ("mode", 0o600),
+                   ("regular", False), ("symlink", True)):
+    altered = dict(target_identity); altered[field] = bad
+    assert not accepted(altered), field
+# Link count is deliberately outside the reuse predicate: both the ordinary
+# nlink=1 state and an interrupted nlink=2 publication are recoverable.
+ordinary = dict(target_identity); ordinary["nlink"] = 1
+assert accepted(ordinary) and accepted(target_identity)
+assert hashlib.sha256(target.read_bytes() + b"tamper").hexdigest() != expected
+assert sidecar.read_bytes() + b"tamper" != f"{expected}  {target.name}\n".encode("ascii")
+PY
 )
 
 offline_stop_roots_are_remote_derived_and_archive_bound() {
@@ -2580,7 +2682,8 @@ run_test 'capture id and destination fail closed' capture_id_and_destination_fai
 run_test 'timer units normalize an empty MainPID to zero' timer_units_with_empty_mainpid_normalize_to_zero
 run_test 'sealed stake proof never claims global halt' sealed_stake_quorum_never_claims_global_halt
 run_test 'all six exact writers stop before capture' all_six_exact_writers_stop_before_content_capture
-run_test 'first quarantine boundary is temporally authorized before write' first_quarantine_boundary_is_temporally_authorized_before_write
+run_test 'late public height sampling is plan-safe and create-only' late_public_height_sampling_is_plan_safe_and_create_only
+run_test 'freeze-plan reuse is root-safe and crash-resumable' freeze_plan_install_reuse_is_root_safe_and_crash_resumable
 run_test 'offline-stop roots are remote-derived and archive-bound' offline_stop_roots_are_remote_derived_and_archive_bound
 run_test 'offline-stop receipt is canonical, private, and adversarial' offline_stop_receipt_is_canonical_private_and_adversarial
 run_test 'ordinary and challenged stopped-status execute' ordinary_and_challenged_stopped_status_execute

--- a/tests/release/static_contract_test.sh
+++ b/tests/release/static_contract_test.sh
@@ -1941,7 +1941,7 @@ production_manifest_builder_is_release_gated() {
         'ssh_known_hosts' \
         'MAX_OFFLINE_STOP_VERIFICATION_AGE_SECONDS = 300' \
         'MAX_OFFLINE_STOP_VERIFICATION_DURATION_MS = 120_000' \
-        'MAX_LEGACY_HEIGHT_TO_FIRST_QUARANTINE_SECONDS = 300' \
+        'MAX_LEGACY_HEIGHT_TO_AUTHENTICATED_CROSS_SECONDS = 300' \
         'load_intrinsic_legacy_public_height_receipt' \
         'validate_sealed_legacy_height_capture_timeline' \
         'quarantine_generation_ledger_sha256' \
@@ -1981,8 +1981,8 @@ production_manifest_builder_is_release_gated() {
         '--ssh-sha256' \
         'reviewed Python path differs from /usr/bin/python3 resolution' \
         'arc.recovery.offline-stop-remote-verification.v1' \
-        'first-quarantine public-height authorization timeline is not ordered' \
-        'first-quarantine public-height receipt exceeded the 300-second live boundary' \
+        'sample_legacy_public_height_late' \
+        'validate_durable_legacy_height_cross_proof' \
         'ssh-known-hosts'
     do
         grep -Fq -- "$required" "$REPO_ROOT/scripts/recovery/archive-fleet-to-drive.sh" \
@@ -1991,7 +1991,8 @@ production_manifest_builder_is_release_gated() {
             return 1
         }
     done
-    python3 - "$REPO_ROOT/scripts/recovery/archive-fleet-to-drive.sh" <<'PY' || return 1
+    python3 - "$REPO_ROOT/scripts/recovery/archive-fleet-to-drive.sh" \
+        "$PRODUCTION_MANIFEST_BUILDER" <<'PY' || return 1
 import pathlib, sys
 text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
 phase = text[text.index("verify_offline_stop_phase()") : text.index("create_offline_stop_evidence()")]
@@ -2000,6 +2001,32 @@ assert "/usr/bin/readlink -f" not in phase
 assert 'python3() {' in text
 assert '"$ARC_OPERATOR_PYTHON_BIN" -I "$@"' in text
 assert "python3 -" in phase
+
+capture = text[text.index("capture_phase()") : text.index("manifest_field()")]
+capture_order = (
+    capture.index('if [ "$execute" != true ]'),
+    capture.index("capture_all_live_observations"),
+    capture.index('legacy_height_receipt_sha="$(sample_legacy_public_height_late'),
+    capture.index('capture_authenticated_legacy_height_cross_proof "$freeze_plan"'),
+    capture.index("run_quarantine_generation_rounds"),
+)
+assert capture_order == tuple(sorted(capture_order))
+
+builder = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+timeline = builder[
+    builder.index("def validate_sealed_legacy_height_capture_timeline(") :
+    builder.index("def validate_remote_stop_verification(")
+]
+timeline_order = (
+    timeline.index("height_completed = _parse_utc_seconds("),
+    timeline.index("fleet_started = _parse_utc_seconds("),
+    timeline.index("if not height_completed <= fleet_started <= fleet_completed:"),
+    timeline.index("if (fleet_started - height_completed).total_seconds()"),
+    timeline.index("> MAX_LEGACY_HEIGHT_TO_AUTHENTICATED_CROSS_SECONDS:"),
+    timeline.index("sealed legacy public-height receipt exceeded the 300-second authenticated cross-proof boundary"),
+)
+assert timeline_order == tuple(sorted(timeline_order))
+assert "MAX_LEGACY_HEIGHT_TO_FIRST_QUARANTINE_SECONDS" not in builder
 PY
 }
 


### PR DESCRIPTION
## Incident root causes

- Public-height evidence was sampled before slow artifact, Drive, and fleet-observation prerequisites, so valid receipts expired before authenticated cross-proof.
- Freeze-plan reuse tested writability as root; root reports sealed 0400 files writable, so every resume failed after the first publication.

## Fix

- Pin the sampler and imports from the exact protected source tree.
- Sample create-only public-height evidence immediately before authenticated all-writer cross-proof.
- Preserve ambiguous crash artifacts and require a fresh unique namespace unless a durable bound cross-proof exists.
- Keep mutation safety on fresh target-specific proofs and 300-second same-boot monotonic leases.
- Validate reused freeze plan and sidecar by exact hash, root ownership, group, and 0400 mode while accepting the safe interrupted-publication hard link.
- Update manifest validation, runbook, historical audit supersession, and regression contracts.

## Verification

- recovery archive contract: 46/46
- recovery Python suites: 47/47
- documentation contract: 14/14
- static contract: 35/35
- repo-wide ShellCheck, Bash syntax, and diff check: pass
- independently audited final binary diff SHA-256: ffd65c36934ed350eb2bf6e7816bc63087bfe7e1bcfcf940bdffc8b3bbb990d8

No validator, production service, or preserved recovery artifact was mutated while preparing this change.