### PR TITLE
Harden v0.8 production recovery and acceptance

### DIFF
--- a/.github/workflows/owner-emergency-recovery-approval.yml
+++ b/.github/workflows/owner-emergency-recovery-approval.yml
@@ -1,0 +1,224 @@
+name: Owner emergency recovery approval
+
+run-name: Owner recovery approval for ${{ inputs.expected_main_sha }} at ${{ inputs.checkpoint_manifest_hash }}
+
+# This workflow is the authentication boundary for the one-person repository-
+# owner emergency decision. It has no secret, deployment, package, or write
+# authority. GitHub supplies both actor identities; a collaborator cannot mint
+# an approval by writing the same JSON locally or by rerunning the owner's job.
+on:
+  workflow_dispatch:
+    inputs:
+      expected_main_sha:
+        description: Exact protected-main commit authorized for recovery
+        required: true
+        type: string
+      checkpoint_manifest_hash:
+        description: Exact 0x-prefixed recovery checkpoint manifest hash
+        required: true
+        type: string
+      validator_public_keys_sha256:
+        description: SHA-256 of the canonical six-validator public-key manifest
+        required: true
+        type: string
+      nyc_public_key:
+        description: NYC validator public key (64 lowercase hex)
+        required: true
+        type: string
+      lax_public_key:
+        description: LAX validator public key (64 lowercase hex)
+        required: true
+        type: string
+      ams_public_key:
+        description: AMS validator public key (64 lowercase hex)
+        required: true
+        type: string
+      lhr_public_key:
+        description: LHR validator public key (64 lowercase hex)
+        required: true
+        type: string
+      nrt_public_key:
+        description: NRT validator public key (64 lowercase hex)
+        required: true
+        type: string
+      sgp_public_key:
+        description: SGP validator public key (64 lowercase hex)
+        required: true
+        type: string
+      confirmation:
+        description: Type AUTHORIZE ARC OWNER EMERGENCY RECOVERY followed by one space and expected_main_sha
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: owner-emergency-recovery-${{ inputs.expected_main_sha }}-${{ inputs.checkpoint_manifest_hash }}
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    name: authenticate owner and seal exact recovery decision
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - id: approval
+        name: Bind GitHub owner actor, protected main, and recovery scope
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR_LOGIN: ${{ github.actor }}
+          ACTOR_ID: ${{ github.actor_id }}
+          TRIGGERING_ACTOR_LOGIN: ${{ github.triggering_actor }}
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+          CHECKPOINT_MANIFEST_HASH: ${{ inputs.checkpoint_manifest_hash }}
+          VALIDATOR_PUBLIC_KEYS_SHA256: ${{ inputs.validator_public_keys_sha256 }}
+          NYC_PUBLIC_KEY: ${{ inputs.nyc_public_key }}
+          LAX_PUBLIC_KEY: ${{ inputs.lax_public_key }}
+          AMS_PUBLIC_KEY: ${{ inputs.ams_public_key }}
+          LHR_PUBLIC_KEY: ${{ inputs.lhr_public_key }}
+          NRT_PUBLIC_KEY: ${{ inputs.nrt_public_key }}
+          SGP_PUBLIC_KEY: ${{ inputs.sgp_public_key }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set +x
+          set -Eeuo pipefail
+          umask 077
+          [ "$GITHUB_REPOSITORY" = FerrumVir/arc-chain ]
+          [ "$GITHUB_REF" = refs/heads/main ]
+          [ "$ACTOR_LOGIN" = FerrumVir ]
+          [ "$ACTOR_ID" = 111036403 ]
+          [ "$TRIGGERING_ACTOR_LOGIN" = FerrumVir ]
+          [ "$CONFIRMATION" = "AUTHORIZE ARC OWNER EMERGENCY RECOVERY $EXPECTED_MAIN_SHA" ]
+          [[ "$EXPECTED_MAIN_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$CHECKPOINT_MANIFEST_HASH" =~ ^0x[0-9a-f]{64}$ ]]
+          [[ "$VALIDATOR_PUBLIC_KEYS_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          for public_key in \
+            "$NYC_PUBLIC_KEY" "$LAX_PUBLIC_KEY" "$AMS_PUBLIC_KEY" \
+            "$LHR_PUBLIC_KEY" "$NRT_PUBLIC_KEY" "$SGP_PUBLIC_KEY"
+          do
+            [[ "$public_key" =~ ^[0-9a-f]{64}$ ]]
+          done
+          [ "$(printf '%s\n' \
+            "$NYC_PUBLIC_KEY" "$LAX_PUBLIC_KEY" "$AMS_PUBLIC_KEY" \
+            "$LHR_PUBLIC_KEY" "$NRT_PUBLIC_KEY" "$SGP_PUBLIC_KEY" \
+            | sort -u | wc -l | tr -d ' ')" = 6 ]
+          [ "$GITHUB_SHA" = "$EXPECTED_MAIN_SHA" ]
+
+          actor_json="$RUNNER_TEMP/actor.json"
+          triggering_actor_json="$RUNNER_TEMP/triggering-actor.json"
+          main_json="$RUNNER_TEMP/main.json"
+          run_json="$RUNNER_TEMP/run.json"
+          gh api users/FerrumVir > "$actor_json"
+          gh api "users/$TRIGGERING_ACTOR_LOGIN" > "$triggering_actor_json"
+          gh api "repos/$GITHUB_REPOSITORY/branches/main" > "$main_json"
+          gh api \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT" \
+            > "$run_json"
+          jq -es 'length == 2 and all(.[]; .login == "FerrumVir" and .id == 111036403)' \
+            "$actor_json" "$triggering_actor_json" >/dev/null
+          jq -e --arg sha "$EXPECTED_MAIN_SHA" '.commit.sha == $sha' \
+            "$main_json" >/dev/null
+          jq -e --arg sha "$EXPECTED_MAIN_SHA" \
+            --argjson id "$GITHUB_RUN_ID" --argjson attempt "$GITHUB_RUN_ATTEMPT" '
+            .id == $id and .run_attempt == $attempt
+            and .head_repository.full_name == "FerrumVir/arc-chain"
+            and .head_branch == "main" and .head_sha == $sha
+            and .path == ".github/workflows/owner-emergency-recovery-approval.yml"
+            and .event == "workflow_dispatch"
+            and .actor.login == "FerrumVir" and .actor.id == 111036403
+            and .triggering_actor.login == "FerrumVir"
+            and .triggering_actor.id == 111036403' "$run_json" >/dev/null
+
+          approved_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          mkdir -m 0700 approval
+          jq -cnS \
+            --arg approved_at "$approved_at" \
+            --arg source "$EXPECTED_MAIN_SHA" \
+            --arg checkpoint "$CHECKPOINT_MANIFEST_HASH" \
+            --arg public_keys_sha "$VALIDATOR_PUBLIC_KEYS_SHA256" \
+            --arg nyc "$NYC_PUBLIC_KEY" --arg lax "$LAX_PUBLIC_KEY" \
+            --arg ams "$AMS_PUBLIC_KEY" --arg lhr "$LHR_PUBLIC_KEY" \
+            --arg nrt "$NRT_PUBLIC_KEY" --arg sgp "$SGP_PUBLIC_KEY" \
+            --argjson run_id "$GITHUB_RUN_ID" \
+            --argjson run_attempt "$GITHUB_RUN_ATTEMPT" '
+            {
+              schema:"arc.recovery.owner-emergency-recovery.v2",
+              decision:{
+                authorization_kind:"owner_emergency_recovery",
+                authority_basis:"repository-owner emergency authorization authenticated by an exact GitHub Actions run; not approval by six independent humans",
+                approver:{github_login:"FerrumVir",github_user_id:111036403,repository_role:"owner"},
+                approved_at:$approved_at,
+                reason_code:"legacy_fleet_divergence_history_preserving_v080_cutover",
+                reason:"The divergent public validator fleet requires the reviewed, history-preserving ARC v0.8 emergency cutover.",
+                risk_acknowledgement:"I authorize five reviewed ARC validator identities to sign the recovery checkpoint rooted at preserved source block 137145 and transition block 137146. I understand that the six legacy forks remain preserved read-only, that rollback cannot rewrite signed history, and that this receipt does not represent approval by six independent humans."
+              },
+              github_authentication:{
+                repository:"FerrumVir/arc-chain",
+                workflow_path:".github/workflows/owner-emergency-recovery-approval.yml",
+                event:"workflow_dispatch",head_branch:"main",head_sha:$source,
+                run_id:$run_id,run_attempt:$run_attempt,
+                actor:{login:"FerrumVir",user_id:111036403},
+                triggering_actor:{login:"FerrumVir",user_id:111036403}
+              },
+              scope:{
+                repository:"FerrumVir/arc-chain",protected_branch:"main",
+                source_main_sha:$source,checkpoint_manifest_hash:$checkpoint,
+                source_height:137145,transition_height:137146,
+                recovery_epoch:1,validator_set_id:1,
+                validator_public_keys_sha256:$public_keys_sha
+              },
+              signing_policy:{
+                validator_count:6,signatures_required:5,total_stake:40000000,
+                minimum_signed_stake:26666667,
+                strict_stake_supermajority_required:true,
+                authorized_signer_order:["NYC","LAX","AMS","LHR","NRT"],
+                unused_recovery_member:"SGP",
+                ordered_validators:[
+                  {ordinal:1,node:"NYC",address:"adf4ff16f997c871c16f3897e67881311d08f975f28ebdcf79e86ea9e3b99d0f",public_key:$nyc,stake:6666667},
+                  {ordinal:2,node:"LAX",address:"44d20543df6e76696da2ebbbd79e4243cd41729fa5b890e2618991e489314780",public_key:$lax,stake:6666667},
+                  {ordinal:3,node:"AMS",address:"5772741c93d8a4b04ec39007cb568a31e13ffba0d3e786596d1900d30e529f21",public_key:$ams,stake:6666667},
+                  {ordinal:4,node:"LHR",address:"228787281308d6c1a560848c2c168814bde1b6153e9e65a286d7211f04628fdd",public_key:$lhr,stake:6666667},
+                  {ordinal:5,node:"NRT",address:"f03cbab49cf553a05541ddebc09b32a4c5507efb157d354b6d7f8c6682c32f5f",public_key:$nrt,stake:6666666},
+                  {ordinal:6,node:"SGP",address:"f521309b041da7aefc742548bdc002c31b47183aacfbbbf245ded09845d0415b",public_key:$sgp,stake:6666666}
+                ]
+              }
+            }' > approval/OWNER-EMERGENCY-RECOVERY.json
+          chmod 0400 approval/OWNER-EMERGENCY-RECOVERY.json
+          jq -cS . approval/OWNER-EMERGENCY-RECOVERY.json \
+            | cmp -s - approval/OWNER-EMERGENCY-RECOVERY.json
+          receipt_sha256="$(sha256sum approval/OWNER-EMERGENCY-RECOVERY.json | cut -d ' ' -f 1)"
+          echo "receipt_sha256=$receipt_sha256" >> "$GITHUB_OUTPUT"
+
+      - id: upload
+        name: Upload owner-authenticated approval
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: arc-owner-emergency-recovery-${{ inputs.expected_main_sha }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          path: approval/OWNER-EMERGENCY-RECOVERY.json
+          if-no-files-found: error
+          compression-level: 9
+          retention-days: 90
+          overwrite: false
+          include-hidden-files: false
+
+      - name: Report authenticated approval identity
+        shell: bash
+        env:
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+          ARTIFACT_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
+          RECEIPT_SHA256: ${{ steps.approval.outputs.receipt_sha256 }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$RECEIPT_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          {
+            echo "Owner-authenticated recovery approval"
+            echo "- run/attempt: \`$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT\`"
+            echo "- artifact ID: \`$ARTIFACT_ID\`"
+            echo "- artifact digest: \`sha256:$ARTIFACT_DIGEST\`"
+            echo "- receipt SHA-256: \`$RECEIPT_SHA256\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/owner-emergency-recovery-approval.yml
+++ b/.github/workflows/owner-emergency-recovery-approval.yml
@@ -194,7 +194,7 @@ jobs:
 
       - id: upload
         name: Upload owner-authenticated approval
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1; gitleaks:allow -- immutable upstream action commit
         with:
           name: arc-owner-emergency-recovery-${{ inputs.expected_main_sha }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}
           path: approval/OWNER-EMERGENCY-RECOVERY.json

--- a/.github/workflows/post-release-acceptance.yml
+++ b/.github/workflows/post-release-acceptance.yml
@@ -1,0 +1,1420 @@
+name: Published artifact acceptance
+
+# This workflow has no publication, deployment, environment, OIDC, or package
+# authority.  It is dispatched only after the exact v0.8.0 release attempt and
+# recovered validator rollout have succeeded.  Every job reuses a sealed API
+# binding and downloads public assets by immutable GitHub release asset ID.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Exact immutable release tag; production acceptance is pinned to v0.8.0
+        required: true
+        type: string
+      release_source_sha:
+        description: Exact 40-character protected-main commit targeted by v0.8.0
+        required: true
+        type: string
+      release_run_id:
+        description: Exact successful Release ARC workflow run ID that published v0.8.0
+        required: true
+        type: string
+      release_run_attempt:
+        description: Exact successful attempt number of that Release ARC run
+        required: true
+        type: string
+
+concurrency:
+  group: published-artifact-acceptance-${{ inputs.tag }}-${{ inputs.release_run_id }}-${{ inputs.release_run_attempt }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  ACCEPTANCE_TOOL: scripts/release/published-artifact-acceptance.py
+  LEGACY_COMMIT: 37df67b526cd0eebf6b55fa940c7646d1f4c947f
+
+jobs:
+  bind-release:
+    name: Bind exact release run, tag, and public assets
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+      artifact_digest: ${{ steps.upload.outputs.artifact-digest }}
+      release_id: ${{ steps.selection.outputs.release_id }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.release_source_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - id: selection
+        name: Capture the exact release attempt and publication evidence artifact
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_COMMIT: ${{ inputs.release_source_sha }}
+          RELEASE_RUN_ATTEMPT: ${{ inputs.release_run_attempt }}
+          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$RELEASE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$RELEASE_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]
+          [ "$RELEASE_TAG" = v0.8.0 ]
+          [ "$GITHUB_REF" = refs/tags/v0.8.0 ]
+          [ "$GITHUB_SHA" = "$RELEASE_COMMIT" ]
+          [ "$(git rev-parse HEAD)" = "$RELEASE_COMMIT" ]
+
+          evidence="$RUNNER_TEMP/release-api"
+          mkdir -m 0700 "$evidence"
+          gh api "repos/$GITHUB_REPOSITORY/actions/workflows/release.yml" \
+            > "$evidence/workflow.json"
+          gh api \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_RUN_ID/attempts/$RELEASE_RUN_ATTEMPT" \
+            > "$evidence/run.json"
+          gh api \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_RUN_ID/attempts/$RELEASE_RUN_ATTEMPT/jobs?per_page=100" \
+            > "$evidence/jobs.json"
+          gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" \
+            > "$evidence/tag-ref.json"
+          gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
+            > "$evidence/release.json"
+          gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/v0.7.7" \
+            > "$evidence/legacy-tag-ref.json"
+          gh api "repos/$GITHUB_REPOSITORY/releases/tags/v0.7.7" \
+            > "$evidence/legacy-release.json"
+
+          release_id="$(jq -er '.id | select(type == "number" and . > 0)' \
+            "$evidence/release.json")"
+          gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_RUN_ID/artifacts?per_page=100" \
+            --jq '.artifacts[]' | jq -s '{artifacts: .}' \
+            > "$evidence/artifacts.json"
+          python3 "$ACCEPTANCE_TOOL" select-published-evidence \
+            --commit "$RELEASE_COMMIT" \
+            --release-run-id "$RELEASE_RUN_ID" \
+            --release-run-attempt "$RELEASE_RUN_ATTEMPT" \
+            --release-json "$evidence/release.json" \
+            --artifacts-json "$evidence/artifacts.json" \
+            --output "$evidence/published-evidence-artifact-api.json"
+          artifact_id="$(jq -er '.id' \
+            "$evidence/published-evidence-artifact-api.json")"
+          [[ "$artifact_id" =~ ^[1-9][0-9]*$ ]]
+          {
+            echo "artifact_id=$artifact_id"
+            echo "release_id=$release_id"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download exact publication evidence by immutable artifact ID
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ steps.selection.outputs.artifact_id }}
+          path: release-published-download
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.release_run_id }}
+          skip-decompress: true
+          digest-mismatch: error
+
+      - name: Seal exact read-only GitHub API selection
+        shell: bash
+        env:
+          RELEASE_COMMIT: ${{ inputs.release_source_sha }}
+          RELEASE_RUN_ATTEMPT: ${{ inputs.release_run_attempt }}
+          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -Eeuo pipefail
+          evidence="$RUNNER_TEMP/release-api"
+          python3 "$ACCEPTANCE_TOOL" bind \
+            --repository "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" \
+            --commit "$RELEASE_COMMIT" \
+            --release-run-id "$RELEASE_RUN_ID" \
+            --release-run-attempt "$RELEASE_RUN_ATTEMPT" \
+            --workflow-json "$evidence/workflow.json" \
+            --run-json "$evidence/run.json" \
+            --jobs-json "$evidence/jobs.json" \
+            --tag-ref-json "$evidence/tag-ref.json" \
+            --release-json "$evidence/release.json" \
+            --published-evidence-artifact-json \
+              "$evidence/published-evidence-artifact-api.json" \
+            --published-evidence-download-root release-published-download \
+            --legacy-tag-ref-json "$evidence/legacy-tag-ref.json" \
+            --legacy-release-json "$evidence/legacy-release.json" \
+            --jobs-output release-attempt-jobs.json \
+            --published-evidence-output release-published.json \
+            --published-evidence-zip-output published-evidence.zip \
+            --published-evidence-artifact-output published-evidence-artifact.json \
+            --output release-binding.json
+          chmod 0400 release-binding.json release-attempt-jobs.json \
+            release-published.json published-evidence.zip \
+            published-evidence-artifact.json
+          release_id="$(python3 -c \
+            'import json; print(json.load(open("release-binding.json"))["release"]["id"])')"
+          [[ "$release_id" =~ ^[1-9][0-9]*$ ]]
+          [ "$release_id" = "${{ steps.selection.outputs.release_id }}" ]
+
+      - id: upload
+        name: Upload immutable release binding
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: arc-published-release-binding-${{ inputs.release_run_id }}-attempt-${{ inputs.release_run_attempt }}
+          path: |
+            release-binding.json
+            release-attempt-jobs.json
+            release-published.json
+            published-evidence.zip
+            published-evidence-artifact.json
+          if-no-files-found: error
+          compression-level: 9
+          retention-days: 90
+
+  linux-x86_64:
+    name: Linux headless, AppImage, and real v0.7.7 migration
+    needs: bind-release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    outputs:
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+      artifact_digest: ${{ steps.upload.outputs.artifact-digest }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.release_source_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download exact release binding by artifact ID
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.bind-release.outputs.artifact_id }}
+          path: binding
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          digest-mismatch: error
+
+      - name: Download v0.8.0 Linux assets by immutable release asset ID
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -m 0700 published
+          download_asset() {
+            local name="$1" id temporary
+            id="$(jq -er --arg name "$name" '.assets[$name].id' binding/release-binding.json)"
+            [[ "$id" =~ ^[1-9][0-9]*$ ]]
+            temporary="published/.${name}.new"
+            gh api -H 'Accept: application/octet-stream' \
+              "repos/$GITHUB_REPOSITORY/releases/assets/$id" > "$temporary"
+            mv -- "$temporary" "published/$name"
+          }
+          for name in \
+            install.sh \
+            arc-node-linux-x86_64 \
+            arc-cli-linux-x86_64 \
+            arc-desktop-linux-x86_64.AppImage \
+            arc-desktop-linux-x86_64.AppImage.sig
+          do
+            download_asset "$name"
+          done
+          python3 "$ACCEPTANCE_TOOL" verify-files \
+            --binding binding/release-binding.json \
+            --directory published \
+            --asset install.sh \
+            --asset arc-node-linux-x86_64 \
+            --asset arc-cli-linux-x86_64 \
+            --asset arc-desktop-linux-x86_64.AppImage \
+            --asset arc-desktop-linux-x86_64.AppImage.sig \
+            --output published-files.json
+
+      - name: Install real AppImage runtime and isolation tools
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get update
+          sudo apt-get install -y \
+            dbus-x11 iptables libappindicator3-1 libayatana-appindicator3-1 \
+            librsvg2-2 libwebkit2gtk-4.1-0 x11-apps x11-utils xdotool xvfb
+
+      - name: Verify updater signature and exercise the published AppImage UI
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          pubkey="$(python3 -c \
+            'import json; print(json.load(open("desktop/src-tauri/tauri.conf.json"))["plugins"]["updater"]["pubkey"])')"
+          cargo run --quiet --locked \
+            --manifest-path tests/release/tauri-updater-verifier/Cargo.toml -- \
+            "$pubkey" \
+            published/arc-desktop-linux-x86_64.AppImage \
+            published/arc-desktop-linux-x86_64.AppImage.sig
+
+          runtime="$RUNNER_TEMP/appimage-runtime"
+          evidence="$PWD/evidence-linux"
+          mkdir -m 0700 "$runtime" "$runtime/home" "$runtime/config" \
+            "$runtime/cache" "$runtime/data" "$evidence"
+          chmod 0500 published/arc-desktop-linux-x86_64.AppImage
+          (
+            cd "$runtime"
+            "$GITHUB_WORKSPACE/published/arc-desktop-linux-x86_64.AppImage" \
+              --appimage-extract > "$evidence/extract.stdout" \
+              2> "$evidence/extract.stderr"
+          )
+          test -x "$runtime/squashfs-root/AppRun"
+
+          # The single-quoted program is intentionally evaluated by the inner
+          # xvfb shell, which receives APP_ROOT and EVIDENCE in its environment.
+          # shellcheck disable=SC2016
+          APP_ROOT="$runtime" EVIDENCE="$evidence" \
+          dbus-run-session -- xvfb-run -a -s '-screen 0 1280x900x24' bash -ceu '
+            export HOME="$APP_ROOT/home"
+            export XDG_CONFIG_HOME="$APP_ROOT/config"
+            export XDG_CACHE_HOME="$APP_ROOT/cache"
+            export XDG_DATA_HOME="$APP_ROOT/data"
+            export NO_AT_BRIDGE=1
+            export WEBKIT_DISABLE_COMPOSITING_MODE=1
+            "$APP_ROOT/squashfs-root/AppRun" \
+              >"$EVIDENCE/app.stdout" 2>"$EVIDENCE/app.stderr" &
+            launcher_pid=$!
+            cleanup() {
+              kill -TERM "$launcher_pid" 2>/dev/null || true
+              wait "$launcher_pid" 2>/dev/null || true
+            }
+            trap cleanup EXIT HUP INT TERM
+            window_id=""
+            for _ in $(seq 1 120); do
+              if ! kill -0 "$launcher_pid" 2>/dev/null; then
+                cat "$EVIDENCE/app.stderr" >&2
+                exit 1
+              fi
+              window_id="$(xdotool search --onlyvisible --name "ARC Node" 2>/dev/null \
+                | head -n 1 || true)"
+              [ -z "$window_id" ] || break
+              sleep 0.25
+            done
+            [ -n "$window_id" ]
+            window_pid="$(xdotool getwindowpid "$window_id")"
+            [[ "$window_pid" =~ ^[1-9][0-9]*$ ]]
+            kill -0 "$window_pid"
+            sleep 5
+            kill -0 "$window_pid"
+            geometry="$(xdotool getwindowgeometry --shell "$window_id")"
+            width="$(printf "%s\n" "$geometry" | sed -n "s/^WIDTH=//p")"
+            height="$(printf "%s\n" "$geometry" | sed -n "s/^HEIGHT=//p")"
+            [[ "$width" =~ ^[0-9]+$ && "$height" =~ ^[0-9]+$ ]]
+            [ "$width" -ge 900 ] && [ "$height" -ge 600 ]
+            printf "%s\n" "$geometry" > "$EVIDENCE/window-geometry.txt"
+            xprop -id "$window_id" > "$EVIDENCE/window-properties.txt"
+            grep -Fq "ARC Node" "$EVIDENCE/window-properties.txt"
+            xwd -silent -id "$window_id" -out "$EVIDENCE/window.xwd"
+            [ "$(wc -c < "$EVIDENCE/window.xwd")" -gt 100000 ]
+            printf "%s\n" "$window_pid" > "$EVIDENCE/window-pid.txt"
+            trap - EXIT HUP INT TERM
+            cleanup
+          '
+          test -s "$evidence/window.xwd"
+
+      - name: Exercise fresh headless install and exact update-only path
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          fresh="$RUNNER_TEMP/fresh-headless"
+          install_root="$fresh/install"
+          data_root="$fresh/data"
+          mkdir -m 0700 "$fresh"
+          chmod 0500 published/install.sh
+          bash published/install.sh --version 0.8.0 \
+            --install-dir "$install_root" --data-dir "$data_root" \
+            --no-service --no-auto-update \
+            > evidence-linux/headless-install.stdout \
+            2> evidence-linux/headless-install.stderr
+          "$install_root/bin/arc-node" --version | grep -F ' 0.8.0'
+          "$install_root/bin/arc-cli" --version | grep -F ' 0.8.0'
+          [ "$(sha256sum "$install_root/bin/arc-node" | awk '{print $1}')" = \
+            "$(jq -er '.assets["arc-node-linux-x86_64"].sha256' binding/release-binding.json)" ]
+          [ "$(sha256sum "$install_root/bin/arc-cli" | awk '{print $1}')" = \
+            "$(jq -er '.assets["arc-cli-linux-x86_64"].sha256' binding/release-binding.json)" ]
+          bash published/install.sh --update-only \
+            --install-dir "$install_root" --no-service --no-auto-update \
+            > evidence-linux/headless-update.stdout \
+            2> evidence-linux/headless-update.stderr
+          grep -Fq 'Already up to date at v0.8.0' \
+            evidence-linux/headless-update.stdout
+          if pgrep -f "$install_root/bin/arc-node" >/dev/null; then
+            echo 'fresh --no-service install started an arc-node process' >&2
+            exit 1
+          fi
+
+      - name: Build real offline v0.7.7 state from pinned historical bytes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          legacy_source="$RUNNER_TEMP/legacy-source"
+          legacy_home="$RUNNER_TEMP/legacy-home"
+          legacy_root="$legacy_home/.arc"
+          mkdir -m 0700 "$legacy_source" "$legacy_home" "$legacy_root" \
+            "$legacy_root/bin" "$legacy_root/data"
+
+          legacy_asset_id="$(jq -er '.legacy_source.asset.id' binding/release-binding.json)"
+          [[ "$legacy_asset_id" =~ ^[1-9][0-9]*$ ]]
+          gh api -H 'Accept: application/octet-stream' \
+            "repos/$GITHUB_REPOSITORY/releases/assets/$legacy_asset_id" \
+            > "$legacy_source/arc-node-linux-x86_64"
+
+          git fetch --no-tags origin "$LEGACY_COMMIT"
+          [ "$(git rev-parse FETCH_HEAD)" = "$LEGACY_COMMIT" ]
+          git show "$LEGACY_COMMIT:scripts/install-community-node.sh" \
+            > "$legacy_source/install-community-node.sh"
+          git show "$LEGACY_COMMIT:testnet-seeds.txt" \
+            > "$legacy_source/testnet-seeds.txt"
+          git show "$LEGACY_COMMIT:genesis.toml" \
+            > "$legacy_source/genesis.toml"
+          python3 "$ACCEPTANCE_TOOL" verify-legacy \
+            --binding binding/release-binding.json \
+            --binary "$legacy_source/arc-node-linux-x86_64" \
+            --installer "$legacy_source/install-community-node.sh" \
+            --seed-config "$legacy_source/testnet-seeds.txt" \
+            --genesis "$legacy_source/genesis.toml" \
+            --output evidence-linux/legacy-source.json
+
+          install -m 0700 "$legacy_source/arc-node-linux-x86_64" \
+            "$legacy_root/bin/arc-node"
+          install -m 0600 "$legacy_source/testnet-seeds.txt" "$legacy_root/seeds.txt"
+          install -m 0600 "$legacy_source/genesis.toml" "$legacy_root/genesis.toml"
+          printf '%s\n' '0.7.7' > "$legacy_root/version.txt"
+          printf '%s\n' 'community-post-release-acceptance-0707' \
+            > "$legacy_root/identity.seed"
+          printf '%s\n' 'ARC pinned migration model fixture v1' \
+            > "$legacy_root/community-model.gguf"
+          chmod 0600 "$legacy_root/version.txt" "$legacy_root/identity.seed" \
+            "$legacy_root/community-model.gguf"
+          "$legacy_root/bin/arc-node" --version \
+            | tee evidence-linux/legacy-version.txt \
+            | grep -F ' 0.7.7'
+
+          # Generate genuine v0.7.7 WAL/genesis history with the released
+          # binary inside a network namespace that has no interface or route.
+          legacy_runtime_image='ubuntu@sha256:1e0a86e57d247923571b75e0aaf48a1449cf8c543d51fb3e07a4a7d7bfa79316'
+          docker pull "$legacy_runtime_image"
+          docker run --rm --network none \
+            --user "$(id -u):$(id -g)" \
+            --volume "$legacy_root:/legacy" \
+            --tmpfs /tmp:rw,nosuid,nodev,noexec,mode=700 \
+            "$legacy_runtime_image" bash -ceu '
+              /legacy/bin/arc-node \
+                --rpc 127.0.0.1:19944 --p2p-port 19945 \
+                --stake 0 --min-stake 0 --eth-rpc-port 0 \
+                --data-dir /legacy/data \
+                --genesis /legacy/genesis.toml \
+                --validator-seed community-post-release-acceptance-0707 \
+                >/legacy/v0.7.7-offline.log 2>&1 &
+              node_pid=$!
+              cleanup() {
+                kill -TERM "$node_pid" 2>/dev/null || true
+                wait "$node_pid" 2>/dev/null || true
+              }
+              trap cleanup EXIT HUP INT TERM
+              ready=false
+              for _ in $(seq 1 120); do
+                kill -0 "$node_pid"
+                if response=$(timeout 1 bash -ceu '\''
+                  exec 3<>/dev/tcp/127.0.0.1/19944
+                  printf "GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" >&3
+                  cat <&3
+                '\'' 2>/dev/null) && printf "%s" "$response" | grep -q "HTTP/1.1 200"; then
+                  ready=true
+                  break
+                fi
+                sleep 0.25
+              done
+              [ "$ready" = true ]
+              [ -s /legacy/data/state.wal ]
+              trap - EXIT HUP INT TERM
+              kill -TERM "$node_pid"
+              for _ in $(seq 1 60); do
+                kill -0 "$node_pid" 2>/dev/null || exit 0
+                sleep 0.25
+              done
+              echo "released v0.7.7 binary did not stop after SIGTERM" >&2
+              exit 1
+            '
+          [ -s "$legacy_root/data/state.wal" ]
+          if pgrep -f "$legacy_root/bin/arc-node" >/dev/null; then
+            echo 'offline v0.7.7 fixture process is still running' >&2
+            exit 1
+          fi
+
+          LEGACY_ROOT="$legacy_root" python3 - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          root = Path(os.environ["LEGACY_ROOT"])
+          data = root / "data"
+          files = {}
+          for path in sorted(data.rglob("*")):
+              if path.is_symlink():
+                  raise SystemExit(f"legacy data contains a symlink: {path}")
+              if path.is_file():
+                  payload = path.read_bytes()
+                  files[path.relative_to(data).as_posix()] = {
+                      "sha256": hashlib.sha256(payload).hexdigest(),
+                      "size": len(payload),
+                  }
+          if "state.wal" not in files or files["state.wal"]["size"] <= 0:
+              raise SystemExit("released v0.7.7 binary produced no persistent state WAL")
+          Path("evidence-linux/legacy-data-before.json").write_text(
+              json.dumps(files, sort_keys=True, separators=(",", ":")) + "\n"
+          )
+          PY
+          sha256sum "$legacy_root/community-model.gguf" \
+            > evidence-linux/legacy-model-before.sha256
+          printf '%s\n' "$legacy_home" > evidence-linux/legacy-home.txt
+
+      - name: Migrate the exact stopped v0.7.7 layout without legacy egress
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          legacy_home="$(cat evidence-linux/legacy-home.txt)"
+          legacy_root="$legacy_home/.arc"
+          legacy_ips=(
+            149.28.32.76 140.82.16.112 136.244.109.1
+            104.238.171.11 202.182.107.41 149.28.153.31
+          )
+          legacy_rules=()
+          cleanup_rules() {
+            local rule
+            for rule in "${legacy_rules[@]}"; do
+              read -r ip port <<< "$rule"
+              sudo iptables -D OUTPUT -p tcp -d "$ip" --dport "$port" \
+                -j REJECT 2>/dev/null || true
+            done
+          }
+          trap cleanup_rules EXIT HUP INT TERM
+          for ip in "${legacy_ips[@]}"; do
+            for port in 9090 3001; do
+              sudo iptables -I OUTPUT -p tcp -d "$ip" --dport "$port" -j REJECT
+              legacy_rules+=("$ip $port")
+              sudo iptables -C OUTPUT -p tcp -d "$ip" --dport "$port" -j REJECT
+            done
+          done
+
+          HOME="$legacy_home" bash published/install.sh --version 0.8.0 \
+            --model "$legacy_root/community-model.gguf" \
+            --no-service --no-auto-update \
+            > evidence-linux/legacy-migration.stdout \
+            2> evidence-linux/legacy-migration.stderr
+          cleanup_rules
+          trap - EXIT HUP INT TERM
+
+          grep -Fq 'Adopted the verified v0.7.7 default install' \
+            evidence-linux/legacy-migration.stdout
+          "$legacy_root/bin/arc-node" --version | grep -F ' 0.8.0'
+          "$legacy_root/bin/arc-cli" --version | grep -F ' 0.8.0'
+          [ "$(sha256sum "$legacy_root/bin/arc-node" | awk '{print $1}')" = \
+            "$(jq -er '.assets["arc-node-linux-x86_64"].sha256' binding/release-binding.json)" ]
+          [ "$(sha256sum "$legacy_root/bin/arc-cli" | awk '{print $1}')" = \
+            "$(jq -er '.assets["arc-cli-linux-x86_64"].sha256' binding/release-binding.json)" ]
+          cmp "$legacy_root/legacy-v0.7-preserved/version.txt" \
+            <(printf '%s\n' '0.7.7')
+          cmp "$legacy_root/legacy-v0.7-preserved/identity.seed" \
+            <(printf '%s\n' 'community-post-release-acceptance-0707')
+          [ "$(sha256sum "$legacy_root/community-model.gguf")" = \
+            "$(cat evidence-linux/legacy-model-before.sha256)" ]
+          jq -e '
+            .schema == "arc.migration.legacy-v07-preexisting-offline-evidence.v1"
+            and .process_identity == null
+            and .supervisor.signals_sent == []
+            and .supervisor.sigkill_sent == false
+          ' "$legacy_root/legacy-v0.7-preserved/retirement-v0.8/stop-evidence.json" \
+            >/dev/null
+          [ -d "$legacy_root/data-v0.8" ]
+          [ ! -L "$legacy_root/data-v0.8" ]
+          if find "$legacy_root/data-v0.8" -mindepth 1 -print -quit | grep -q .; then
+            echo 'no-service migration reused or initialized the fresh v0.8 state directory' >&2
+            exit 1
+          fi
+
+          LEGACY_ROOT="$legacy_root" python3 - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          root = Path(os.environ["LEGACY_ROOT"])
+          data = root / "data"
+          files = {}
+          for path in sorted(data.rglob("*")):
+              if path.is_symlink():
+                  raise SystemExit(f"legacy data acquired a symlink: {path}")
+              if path.is_file():
+                  payload = path.read_bytes()
+                  files[path.relative_to(data).as_posix()] = {
+                      "sha256": hashlib.sha256(payload).hexdigest(),
+                      "size": len(payload),
+                  }
+          before = json.loads(Path("evidence-linux/legacy-data-before.json").read_text())
+          if files != before:
+              raise SystemExit("v0.7.7 state/history bytes changed during migration")
+          Path("evidence-linux/legacy-data-after.json").write_text(
+              json.dumps(files, sort_keys=True, separators=(",", ":")) + "\n"
+          )
+          PY
+          cmp evidence-linux/legacy-data-before.json evidence-linux/legacy-data-after.json
+          bash published/install.sh --update-only \
+            --install-dir "$legacy_root" --no-service --no-auto-update \
+            > evidence-linux/legacy-update.stdout \
+            2> evidence-linux/legacy-update.stderr
+          grep -Fq 'Already up to date at v0.8.0' evidence-linux/legacy-update.stdout
+          if pgrep -f "$legacy_root/bin/arc-node" >/dev/null; then
+            echo 'migration or update-only started an arc-node service/process' >&2
+            exit 1
+          fi
+
+      - name: Seal Linux component receipt
+        shell: bash
+        env:
+          ACCEPTANCE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          ACCEPTANCE_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -Eeuo pipefail
+          python3 - <<'PY'
+          import hashlib, json
+          from pathlib import Path
+          def digest(path):
+              return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+          checks = {
+              "appimage_process_stable": True,
+              "appimage_updater_signature_valid": True,
+              "appimage_visible_window": True,
+              "appimage_window_capture_nonempty": True,
+              "appimage_window_capture_sha256": digest("evidence-linux/window.xwd"),
+              "headless_fresh_install": True,
+              "headless_update_only": True,
+              "legacy_binary_executed_offline": True,
+              "legacy_data_manifest_sha256": digest("evidence-linux/legacy-data-after.json"),
+              "legacy_history_preserved": True,
+              "legacy_installer_source_pinned": True,
+              "legacy_model_preserved": True,
+              "legacy_preexisting_offline": True,
+              "legacy_source_receipt_sha256": digest("evidence-linux/legacy-source.json"),
+              "legacy_state_preserved": True,
+              "service_started": False,
+              "v08_fresh_data": True,
+          }
+          Path("linux-checks.json").write_text(
+              json.dumps(checks, sort_keys=True, separators=(",", ":")) + "\n"
+          )
+          PY
+          mkdir -p artifact/receipt artifact/evidence
+          python3 "$ACCEPTANCE_TOOL" component \
+            --binding binding/release-binding.json \
+            --files-receipt published-files.json \
+            --checks-json linux-checks.json \
+            --platform linux-x86_64 \
+            --acceptance-run-id "$ACCEPTANCE_RUN_ID" \
+            --acceptance-run-attempt "$ACCEPTANCE_RUN_ATTEMPT" \
+            --output artifact/receipt/linux-x86_64.json
+          cp evidence-linux/*.json evidence-linux/*.sha256 evidence-linux/*.txt \
+            artifact/evidence/
+          cp evidence-linux/*.stdout evidence-linux/*.stderr artifact/evidence/
+          cp evidence-linux/window.xwd artifact/evidence/
+
+      - id: upload
+        name: Upload Linux acceptance and evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: arc-published-acceptance-linux-x86_64-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          path: artifact
+          if-no-files-found: error
+          compression-level: 6
+          retention-days: 90
+
+  macos-desktop:
+    name: Packaged desktop (${{ matrix.platform }})
+    needs: bind-release
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-arm64
+            runner: macos-15
+            architecture: arm64
+          - platform: macos-x86_64
+            runner: macos-15-intel
+            architecture: x86_64
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.release_source_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download exact release binding by artifact ID
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.bind-release.outputs.artifact_id }}
+          path: binding
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          digest-mismatch: error
+
+      - name: Download exact macOS package bytes by release asset ID
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -m 0700 published
+          case "$PLATFORM" in
+            macos-arm64) prefix=arc-desktop-macos-arm64 ;;
+            macos-x86_64) prefix=arc-desktop-macos-x86_64 ;;
+            *) exit 1 ;;
+          esac
+          download_asset() {
+            local name="$1" id temporary
+            id="$(jq -er --arg name "$name" '.assets[$name].id' binding/release-binding.json)"
+            [[ "$id" =~ ^[1-9][0-9]*$ ]]
+            temporary="published/.${name}.new"
+            gh api -H 'Accept: application/octet-stream' \
+              "repos/$GITHUB_REPOSITORY/releases/assets/$id" > "$temporary"
+            mv -- "$temporary" "published/$name"
+          }
+          download_asset "$prefix.app.tar.gz"
+          download_asset "$prefix.app.tar.gz.sig"
+          download_asset "$prefix.dmg"
+          python3 "$ACCEPTANCE_TOOL" verify-files \
+            --binding binding/release-binding.json \
+            --directory published \
+            --asset "$prefix.app.tar.gz" \
+            --asset "$prefix.app.tar.gz.sig" \
+            --asset "$prefix.dmg" \
+            --output published-files.json
+          printf '%s\n' "$prefix" > prefix.txt
+
+      - name: Verify signed updater archive, bundle, architecture, and DMG
+        shell: bash
+        env:
+          EXPECTED_ARCH: ${{ matrix.architecture }}
+        run: |
+          set -Eeuo pipefail
+          prefix="$(cat prefix.txt)"
+          pubkey="$(python3 -c \
+            'import json; print(json.load(open("desktop/src-tauri/tauri.conf.json"))["plugins"]["updater"]["pubkey"])')"
+          cargo run --quiet --locked \
+            --manifest-path tests/release/tauri-updater-verifier/Cargo.toml -- \
+            "$pubkey" "published/$prefix.app.tar.gz" \
+            "published/$prefix.app.tar.gz.sig"
+
+          extract="$RUNNER_TEMP/macos-app"
+          mountpoint="$RUNNER_TEMP/macos-dmg"
+          mkdir -m 0700 "$extract" "$mountpoint"
+          ARCHIVE="published/$prefix.app.tar.gz" EXTRACT="$extract" python3 - <<'PY'
+          import os, tarfile
+          from pathlib import Path, PurePosixPath
+          archive = Path(os.environ["ARCHIVE"])
+          root = Path(os.environ["EXTRACT"]).resolve()
+          with tarfile.open(archive, "r:gz") as handle:
+              members = handle.getmembers()
+              if not members:
+                  raise SystemExit("desktop archive is empty")
+              for member in members:
+                  path = PurePosixPath(member.name)
+                  if path.is_absolute() or ".." in path.parts:
+                      raise SystemExit(f"unsafe archive member: {member.name}")
+                  if member.isdev() or member.isfifo():
+                      raise SystemExit(f"special archive member: {member.name}")
+                  if member.issym() or member.islnk():
+                      target = PurePosixPath(member.linkname)
+                      if target.is_absolute() or ".." in target.parts:
+                          raise SystemExit(f"unsafe archive link: {member.name}")
+              handle.extractall(root)
+          PY
+          apps="$(find "$extract" -type d -name '*.app' -prune)"
+          [ "$(printf '%s\n' "$apps" | awk 'NF { count += 1 } END { print count + 0 }')" -eq 1 ]
+          app="$apps"
+          info="$app/Contents/Info.plist"
+          [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$info")" = \
+            network.arc.desktop ]
+          [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$info")" = \
+            0.8.0 ]
+          executable_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$info")"
+          executable="$app/Contents/MacOS/$executable_name"
+          [ -x "$executable" ]
+          [ "$(lipo -archs "$executable")" = "$EXPECTED_ARCH" ]
+          codesign --verify --deep --strict --verbose=2 "$app"
+          hdiutil verify "published/$prefix.dmg"
+          attached=false
+          cleanup() {
+            if [ "$attached" = true ]; then
+              hdiutil detach "$mountpoint" -quiet || true
+            fi
+          }
+          trap cleanup EXIT HUP INT TERM
+          hdiutil attach -readonly -nobrowse -noautoopen \
+            -mountpoint "$mountpoint" "published/$prefix.dmg" >/dev/null
+          attached=true
+          dmg_apps="$(find "$mountpoint" -type d -name '*.app' -prune)"
+          [ "$(printf '%s\n' "$dmg_apps" | awk 'NF { count += 1 } END { print count + 0 }')" -eq 1 ]
+          dmg_app="$dmg_apps"
+          dmg_info="$dmg_app/Contents/Info.plist"
+          [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$dmg_info")" = \
+            network.arc.desktop ]
+          [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$dmg_info")" = \
+            0.8.0 ]
+          dmg_executable_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$dmg_info")"
+          dmg_executable="$dmg_app/Contents/MacOS/$dmg_executable_name"
+          [ "$(lipo -archs "$dmg_executable")" = "$EXPECTED_ARCH" ]
+          codesign --verify --deep --strict --verbose=2 "$dmg_app"
+          [ "$(shasum -a 256 "$executable" | awk '{print $1}')" = \
+            "$(shasum -a 256 "$dmg_executable" | awk '{print $1}')" ]
+          cleanup
+          trap - EXIT HUP INT TERM
+
+          profile="$RUNNER_TEMP/arc-desktop-profile-$EXPECTED_ARCH"
+          mkdir -m 0700 "$profile" "$profile/tmp" evidence-macos
+          service_before="$(launchctl list | awk '$3 ~ /^(network[.]arc|arc[-_.])/ {print $3}' | LC_ALL=C sort)"
+          probe_source="$RUNNER_TEMP/arc-window-probe.swift"
+          probe_binary="$RUNNER_TEMP/arc-window-probe"
+          tee "$probe_source" >/dev/null <<'SWIFT'
+          import CoreGraphics
+          import Darwin
+          import Foundation
+
+          guard let rawPID = ProcessInfo.processInfo.environment["ARC_DESKTOP_PID"],
+                let pid = Int32(rawPID),
+                let output = ProcessInfo.processInfo.environment["ARC_WINDOW_EVIDENCE"] else {
+              exit(2)
+          }
+          guard let windows = CGWindowListCopyWindowInfo(
+              [.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID
+          ) as? [[String: Any]] else {
+              exit(3)
+          }
+          for window in windows {
+              let owner = (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value
+              let layer = (window[kCGWindowLayer as String] as? NSNumber)?.intValue
+              let alpha = (window[kCGWindowAlpha as String] as? NSNumber)?.doubleValue ?? 0
+              guard owner == pid, layer == 0, alpha > 0,
+                    let bounds = window[kCGWindowBounds as String] as? [String: Any],
+                    let width = (bounds["Width"] as? NSNumber)?.doubleValue,
+                    let height = (bounds["Height"] as? NSNumber)?.doubleValue,
+                    width >= 900, height >= 600 else {
+                  continue
+              }
+              let evidence: [String: Any] = [
+                  "height": height,
+                  "owner_name": window[kCGWindowOwnerName as String] as? String ?? "",
+                  "pid": pid,
+                  "title": window[kCGWindowName as String] as? String ?? "",
+                  "width": width,
+              ]
+              let data = try JSONSerialization.data(withJSONObject: evidence, options: [.sortedKeys])
+              try data.write(to: URL(fileURLWithPath: output), options: .atomic)
+              exit(0)
+          }
+          exit(1)
+          SWIFT
+          xcrun swiftc "$probe_source" -o "$probe_binary"
+
+          HOME="$profile" TMPDIR="$profile/tmp" \
+            "$executable" >evidence-macos/desktop.stdout \
+            2>evidence-macos/desktop.stderr &
+          desktop_pid=$!
+          terminate_desktop() {
+            if kill -0 "$desktop_pid" 2>/dev/null; then
+              kill -TERM "$desktop_pid" 2>/dev/null || true
+              for _ in 1 2 3 4 5; do
+                kill -0 "$desktop_pid" 2>/dev/null || return 0
+                sleep 1
+              done
+              kill -KILL "$desktop_pid" 2>/dev/null || true
+            fi
+            wait "$desktop_pid" 2>/dev/null || true
+          }
+          trap terminate_desktop EXIT HUP INT TERM
+          window_evidence="$GITHUB_WORKSPACE/evidence-macos/desktop-window.json"
+          window_found=false
+          for _ in $(seq 1 45); do
+            if ! kill -0 "$desktop_pid" 2>/dev/null; then
+              wait "$desktop_pid" || true
+              cat evidence-macos/desktop.stderr >&2
+              exit 1
+            fi
+            if ARC_DESKTOP_PID="$desktop_pid" ARC_WINDOW_EVIDENCE="$window_evidence" \
+              "$probe_binary"; then
+              window_found=true
+              break
+            fi
+            sleep 1
+          done
+          [ "$window_found" = true ]
+          sleep 5
+          kill -0 "$desktop_pid"
+          ARC_DESKTOP_PID="$desktop_pid" ARC_WINDOW_EVIDENCE="$window_evidence" \
+            "$probe_binary"
+          service_after="$(launchctl list | awk '$3 ~ /^(network[.]arc|arc[-_.])/ {print $3}' | LC_ALL=C sort)"
+          [ "$service_after" = "$service_before" ]
+          terminate_desktop
+          trap - EXIT HUP INT TERM
+
+      - name: Seal macOS component receipt
+        shell: bash
+        env:
+          ACCEPTANCE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          ACCEPTANCE_RUN_ID: ${{ github.run_id }}
+          EXPECTED_ARCH: ${{ matrix.architecture }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -Eeuo pipefail
+          python3 - <<'PY'
+          import json, os
+          checks = {
+              "archive_safe": True,
+              "bundle_architecture": os.environ["EXPECTED_ARCH"],
+              "bundle_codesign_valid": True,
+              "bundle_identifier": "network.arc.desktop",
+              "bundle_version": "0.8.0",
+              "desktop_process_stable": True,
+              "desktop_visible_window": True,
+              "dmg_bundle_matches": True,
+              "dmg_verified": True,
+              "isolated_profile": True,
+              "service_started": False,
+              "updater_signature_valid": True,
+          }
+          open("checks.json", "w").write(
+              json.dumps(checks, sort_keys=True, separators=(",", ":")) + "\n"
+          )
+          PY
+          mkdir -p artifact/receipt artifact/evidence
+          python3 "$ACCEPTANCE_TOOL" component \
+            --binding binding/release-binding.json \
+            --files-receipt published-files.json \
+            --checks-json checks.json \
+            --platform "$PLATFORM" \
+            --acceptance-run-id "$ACCEPTANCE_RUN_ID" \
+            --acceptance-run-attempt "$ACCEPTANCE_RUN_ATTEMPT" \
+            --output "artifact/receipt/$PLATFORM.json"
+          cp evidence-macos/desktop.stdout evidence-macos/desktop.stderr \
+            evidence-macos/desktop-window.json artifact/evidence/
+
+      - id: upload
+        name: Upload macOS component receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: arc-published-acceptance-${{ matrix.platform }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          path: artifact
+          if-no-files-found: error
+          compression-level: 9
+          retention-days: 90
+
+  windows-desktop:
+    name: Packaged desktop (windows-x86_64)
+    needs: bind-release
+    runs-on: windows-latest
+    timeout-minutes: 25
+    outputs:
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+      artifact_digest: ${{ steps.upload.outputs.artifact-digest }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.release_source_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download exact release binding by artifact ID
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.bind-release.outputs.artifact_id }}
+          path: binding
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          digest-mismatch: error
+
+      - name: Download exact Windows package bytes by release asset ID
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -p published
+          download_asset() {
+            local name="$1" id temporary
+            id="$(jq -er --arg name "$name" '.assets[$name].id' binding/release-binding.json)"
+            [[ "$id" =~ ^[1-9][0-9]*$ ]]
+            temporary="published/.${name}.new"
+            gh api -H 'Accept: application/octet-stream' \
+              "repos/$GITHUB_REPOSITORY/releases/assets/$id" > "$temporary"
+            mv -- "$temporary" "published/$name"
+          }
+          download_asset arc-desktop-windows-x86_64-setup.exe
+          download_asset arc-desktop-windows-x86_64-setup.exe.sig
+          download_asset arc-desktop-windows-x86_64.msi
+          python "$ACCEPTANCE_TOOL" verify-files \
+            --binding binding/release-binding.json \
+            --directory published \
+            --asset arc-desktop-windows-x86_64-setup.exe \
+            --asset arc-desktop-windows-x86_64-setup.exe.sig \
+            --asset arc-desktop-windows-x86_64.msi \
+            --output published-files.json
+
+      - name: Verify the published Tauri updater signature
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          pubkey="$(python -c \
+            'import json; print(json.load(open("desktop/src-tauri/tauri.conf.json"))["plugins"]["updater"]["pubkey"])')"
+          cargo run --quiet --locked \
+            --manifest-path tests/release/tauri-updater-verifier/Cargo.toml -- \
+            "$pubkey" \
+            published/arc-desktop-windows-x86_64-setup.exe \
+            published/arc-desktop-windows-x86_64-setup.exe.sig
+
+      - name: Safely inspect PE packages and administratively extract MSI
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Add-Type @'
+          using System;
+          using System.Runtime.InteropServices;
+          public static class ArcWindowProbe {
+            [StructLayout(LayoutKind.Sequential)]
+            public struct RECT { public int Left, Top, Right, Bottom; }
+            [DllImport("user32.dll")]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool IsWindowVisible(IntPtr handle);
+            [DllImport("user32.dll")]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool GetWindowRect(IntPtr handle, out RECT rectangle);
+          }
+          '@
+          function Get-PeMachine([string] $Path) {
+            $stream = [System.IO.File]::OpenRead((Resolve-Path $Path))
+            try {
+              $reader = [System.IO.BinaryReader]::new($stream)
+              if ($reader.ReadUInt16() -ne 0x5A4D) { throw "missing MZ header: $Path" }
+              $stream.Position = 0x3c
+              $offset = $reader.ReadUInt32()
+              $stream.Position = $offset
+              if ($reader.ReadUInt32() -ne 0x00004550) { throw "missing PE header: $Path" }
+              $machine = $reader.ReadUInt16()
+              if ($machine -ne 0x8664) { throw "expected AMD64 PE machine, got $machine in $Path" }
+              return 'AMD64'
+            } finally {
+              $stream.Dispose()
+            }
+          }
+
+          $setup = 'published/arc-desktop-windows-x86_64-setup.exe'
+          if ((Get-PeMachine $setup) -ne 'AMD64') { throw 'setup is not AMD64' }
+          $msiPath = (Resolve-Path 'published/arc-desktop-windows-x86_64.msi').Path
+          $installer = $null
+          $database = $null
+          $view = $null
+          $record = $null
+          try {
+            $installer = New-Object -ComObject WindowsInstaller.Installer
+            $database = $installer.GetType().InvokeMember(
+              'OpenDatabase', [Reflection.BindingFlags]::InvokeMethod, $null,
+              $installer, @($msiPath, 0)
+            )
+            $query = "SELECT ``Value`` FROM ``Property`` WHERE ``Property`` = 'ProductVersion'"
+            $view = $database.GetType().InvokeMember(
+              'OpenView', [Reflection.BindingFlags]::InvokeMethod, $null,
+              $database, @($query)
+            )
+            [void]$view.GetType().InvokeMember(
+              'Execute', [Reflection.BindingFlags]::InvokeMethod, $null, $view, $null
+            )
+            $record = $view.GetType().InvokeMember(
+              'Fetch', [Reflection.BindingFlags]::InvokeMethod, $null, $view, $null
+            )
+            if ($null -eq $record) { throw 'MSI has no ProductVersion property' }
+            $msiProductVersion = $record.GetType().InvokeMember(
+              'StringData', [Reflection.BindingFlags]::GetProperty, $null, $record, @(1)
+            )
+          } finally {
+            foreach ($comObject in @($record, $view, $database, $installer)) {
+              if ($null -ne $comObject) {
+                [void][Runtime.InteropServices.Marshal]::FinalReleaseComObject($comObject)
+              }
+            }
+          }
+          if ($msiProductVersion -cne '0.8.0') {
+            throw "MSI ProductVersion is $msiProductVersion"
+          }
+          $serviceBefore = @(Get-Service | Where-Object {
+            $_.Name -match '(?i)^arc([._-]|$)' -or $_.DisplayName -match '(?i)^ARC([ _-]|$)'
+          } | Select-Object -ExpandProperty Name | Sort-Object)
+          if ($serviceBefore.Count -ne 0) { throw 'runner unexpectedly begins with an ARC service' }
+
+          $target = Join-Path $env:RUNNER_TEMP 'arc-msi-admin'
+          New-Item -ItemType Directory -Force -Path $target | Out-Null
+          $log = Join-Path $env:GITHUB_WORKSPACE 'windows-msi-admin.log'
+          $arguments = @('/a', $msiPath,
+            '/qn', "TARGETDIR=$target", '/l*v', $log)
+          $process = Start-Process msiexec.exe -ArgumentList $arguments -Wait -PassThru
+          if ($process.ExitCode -ne 0) { throw "MSI administrative extraction failed: $($process.ExitCode)" }
+          $applications = @(Get-ChildItem -Path $target -Recurse -File -Filter 'arc-desktop.exe')
+          if ($applications.Count -ne 1) {
+            throw "expected exactly one extracted arc-desktop.exe, got $($applications.Count)"
+          }
+          if ((Get-PeMachine $applications[0].FullName) -ne 'AMD64') {
+            throw 'extracted desktop is not AMD64'
+          }
+          $embeddedProductVersion = $applications[0].VersionInfo.ProductVersion
+          if ($embeddedProductVersion -notmatch '^0[.]8[.]0(?:[.]0)?$') {
+            throw "extracted desktop ProductVersion is $embeddedProductVersion"
+          }
+
+          $profile = Join-Path $env:RUNNER_TEMP 'arc-windows-profile'
+          $roaming = Join-Path $profile 'AppData\Roaming'
+          $local = Join-Path $profile 'AppData\Local'
+          $temporary = Join-Path $profile 'Temp'
+          New-Item -ItemType Directory -Force -Path $profile, $roaming, $local, $temporary |
+            Out-Null
+          $env:USERPROFILE = $profile
+          $env:HOME = $profile
+          $env:APPDATA = $roaming
+          $env:LOCALAPPDATA = $local
+          $env:TEMP = $temporary
+          $env:TMP = $temporary
+          $stdout = Join-Path $env:GITHUB_WORKSPACE 'windows-desktop.stdout'
+          $stderr = Join-Path $env:GITHUB_WORKSPACE 'windows-desktop.stderr'
+          $desktop = Start-Process -FilePath $applications[0].FullName -PassThru `
+            -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+          try {
+            $deadline = [DateTime]::UtcNow.AddSeconds(60)
+            $visible = $false
+            do {
+              Start-Sleep -Seconds 1
+              $desktop.Refresh()
+              if ($desktop.HasExited) {
+                throw "published desktop exited before UI startup: $($desktop.ExitCode)"
+              }
+              $candidateHandle = $desktop.MainWindowHandle
+              $candidateRect = [ArcWindowProbe+RECT]::new()
+              if ($candidateHandle.ToInt64() -ne 0 -and $desktop.Responding -and
+                  [ArcWindowProbe]::IsWindowVisible($candidateHandle) -and
+                  [ArcWindowProbe]::GetWindowRect($candidateHandle, [ref]$candidateRect) -and
+                  ($candidateRect.Right - $candidateRect.Left) -ge 900 -and
+                  ($candidateRect.Bottom - $candidateRect.Top) -ge 600) {
+                $visible = $true
+                break
+              }
+            } while ([DateTime]::UtcNow -lt $deadline)
+            if (-not $visible) { throw 'published desktop never exposed a responsive window' }
+            if ($desktop.MainWindowTitle -notmatch '(?i)ARC') {
+              throw "unexpected desktop window title: $($desktop.MainWindowTitle)"
+            }
+            $initialHandle = $desktop.MainWindowHandle.ToInt64()
+            $initialWidth = $candidateRect.Right - $candidateRect.Left
+            $initialHeight = $candidateRect.Bottom - $candidateRect.Top
+            Start-Sleep -Seconds 5
+            $desktop.Refresh()
+            if ($desktop.HasExited -or -not $desktop.Responding -or
+                $desktop.MainWindowHandle.ToInt64() -ne $initialHandle -or
+                -not [ArcWindowProbe]::IsWindowVisible($desktop.MainWindowHandle)) {
+              throw 'published desktop did not remain healthy with the same visible window'
+            }
+            [ordered]@{
+              height = $initialHeight
+              main_window_handle = $initialHandle
+              main_window_title = $desktop.MainWindowTitle
+              pid = $desktop.Id
+              responding = $desktop.Responding
+              width = $initialWidth
+            } | ConvertTo-Json -Compress |
+              Set-Content -Encoding utf8NoBOM windows-desktop-window.json
+          } finally {
+            if (-not $desktop.HasExited) {
+              [void]$desktop.CloseMainWindow()
+              if (-not $desktop.WaitForExit(5000)) {
+                Stop-Process -Id $desktop.Id -Force -ErrorAction SilentlyContinue
+                [void]$desktop.WaitForExit(5000)
+              }
+            }
+          }
+          $serviceAfter = @(Get-Service | Where-Object {
+            $_.Name -match '(?i)^arc([._-]|$)' -or $_.DisplayName -match '(?i)^ARC([ _-]|$)'
+          } | Select-Object -ExpandProperty Name | Sort-Object)
+          if ($serviceAfter.Count -ne 0) { throw 'MSI administrative extraction installed a service' }
+
+          $checks = [ordered]@{
+            desktop_process_stable = $true
+            desktop_visible_window = $true
+            embedded_app_pe_machine = 'AMD64'
+            embedded_app_product_version = $embeddedProductVersion
+            isolated_profile = $true
+            msi_administrative_extract = $true
+            msi_product_version = $msiProductVersion
+            no_installed_service = $true
+            setup_pe_machine = 'AMD64'
+            updater_signature_valid = $true
+          }
+          $checks | ConvertTo-Json -Compress | Set-Content -Encoding utf8NoBOM windows-checks.json
+
+      - name: Seal Windows component receipt
+        shell: bash
+        env:
+          ACCEPTANCE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          ACCEPTANCE_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -p artifact/receipt artifact/evidence
+          python "$ACCEPTANCE_TOOL" component \
+            --binding binding/release-binding.json \
+            --files-receipt published-files.json \
+            --checks-json windows-checks.json \
+            --platform windows-x86_64 \
+            --acceptance-run-id "$ACCEPTANCE_RUN_ID" \
+            --acceptance-run-attempt "$ACCEPTANCE_RUN_ATTEMPT" \
+            --output artifact/receipt/windows-x86_64.json
+          cp windows-msi-admin.log windows-desktop.stdout windows-desktop.stderr \
+            windows-desktop-window.json artifact/evidence/
+
+      - id: upload
+        name: Upload Windows component receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: arc-published-acceptance-windows-x86_64-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          path: artifact
+          if-no-files-found: error
+          compression-level: 9
+          retention-days: 90
+
+  seal-acceptance:
+    name: Seal canonical published-artifact receipt
+    needs: [bind-release, linux-x86_64, macos-desktop, windows-desktop]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.release_source_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download exact binding
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.bind-release.outputs.artifact_id }}
+          path: binding
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          digest-mismatch: error
+
+      - id: components
+        name: Select exact attempt-bound component artifacts
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LINUX_JOB_ARTIFACT_ID: ${{ needs.linux-x86_64.outputs.artifact_id }}
+          WINDOWS_JOB_ARTIFACT_ID: ${{ needs.windows-desktop.outputs.artifact_id }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -m 0700 selected-components
+          api="$RUNNER_TEMP/component-artifacts.json"
+          found=false
+          for _ in $(seq 1 12); do
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts?per_page=100" \
+              > "$api"
+            count="$(jq --arg run "$GITHUB_RUN_ID" --arg attempt "$GITHUB_RUN_ATTEMPT" \
+              '[.artifacts[] | select(.name == ("arc-published-acceptance-linux-x86_64-" + $run + "-attempt-" + $attempt) or .name == ("arc-published-acceptance-macos-arm64-" + $run + "-attempt-" + $attempt) or .name == ("arc-published-acceptance-macos-x86_64-" + $run + "-attempt-" + $attempt) or .name == ("arc-published-acceptance-windows-x86_64-" + $run + "-attempt-" + $attempt))] | length' \
+              "$api")"
+            if [ "$count" -eq 4 ]; then
+              found=true
+              break
+            fi
+            sleep 5
+          done
+          [ "$found" = true ]
+
+          select_one() {
+            local platform="$1" key="$2" expected name match
+            name="arc-published-acceptance-$platform-$GITHUB_RUN_ID-attempt-$GITHUB_RUN_ATTEMPT"
+            expected="$(jq --arg name "$name" '[.artifacts[] | select(.name == $name)] | length' "$api")"
+            [ "$expected" -eq 1 ]
+            match="selected-components/$platform.json"
+            jq -e --arg name "$name" --arg platform "$platform" \
+              --argjson run_id "$GITHUB_RUN_ID" --arg head_sha "$GITHUB_SHA" '
+                .artifacts[] | select(.name == $name) |
+                select(.expired == false) |
+                select((.id | type) == "number" and .id > 0) |
+                select((.size_in_bytes | type) == "number" and .size_in_bytes > 0) |
+                select(.digest | test("^sha256:[0-9a-f]{64}$")) |
+                select(.workflow_run.id == $run_id) |
+                select(.workflow_run.head_sha == $head_sha) |
+                {
+                  platform: $platform,
+                  name,
+                  id,
+                  digest,
+                  size: .size_in_bytes,
+                  expired,
+                  workflow_run_id: .workflow_run.id,
+                  head_sha: .workflow_run.head_sha
+                }
+              ' "$api" > "$match"
+            [ -s "$match" ]
+            echo "${key}_id=$(jq -er '.id' "$match")" >> "$GITHUB_OUTPUT"
+            echo "${key}_digest=$(jq -er '.digest' "$match")" >> "$GITHUB_OUTPUT"
+          }
+          select_one linux-x86_64 linux
+          select_one macos-arm64 macos_arm64
+          select_one macos-x86_64 macos_x86_64
+          select_one windows-x86_64 windows
+          [ "$(jq -er '.id' selected-components/linux-x86_64.json)" = \
+            "$LINUX_JOB_ARTIFACT_ID" ]
+          [ "$(jq -er '.id' selected-components/windows-x86_64.json)" = \
+            "$WINDOWS_JOB_ARTIFACT_ID" ]
+          jq -S -n \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --argjson run_id "$GITHUB_RUN_ID" \
+            --argjson run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --slurpfile linux selected-components/linux-x86_64.json \
+            --slurpfile macos_arm64 selected-components/macos-arm64.json \
+            --slurpfile macos_x86_64 selected-components/macos-x86_64.json \
+            --slurpfile windows selected-components/windows-x86_64.json '
+              {
+                schema: "arc.published-artifact-component-binding.v1",
+                repository: $repository,
+                acceptance_run_id: $run_id,
+                acceptance_run_attempt: $run_attempt,
+                artifacts: {
+                  "linux-x86_64": ($linux[0] | del(.platform)),
+                  "macos-arm64": ($macos_arm64[0] | del(.platform)),
+                  "macos-x86_64": ($macos_x86_64[0] | del(.platform)),
+                  "windows-x86_64": ($windows[0] | del(.platform))
+                }
+              }
+            ' > component-artifacts.json
+
+      - name: Download exact Linux component artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ steps.components.outputs.linux_id }}
+          path: components/linux
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          digest-mismatch: error
+
+      - name: Download exact macOS arm64 component artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ steps.components.outputs.macos_arm64_id }}
+          path: components/macos-arm64
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          digest-mismatch: error
+
+      - name: Download exact macOS x86_64 component artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ steps.components.outputs.macos_x86_64_id }}
+          path: components/macos-x86_64
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          digest-mismatch: error
+
+      - name: Download exact Windows component artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ steps.components.outputs.windows_id }}
+          path: components/windows
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          digest-mismatch: error
+
+      - name: Aggregate exact component receipts
+        shell: bash
+        env:
+          ACCEPTANCE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          ACCEPTANCE_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -Eeuo pipefail
+          mkdir -m 0700 component-receipts canonical canonical/evidence \
+            canonical/evidence/linux-x86_64 canonical/evidence/macos-arm64 \
+            canonical/evidence/macos-x86_64 canonical/evidence/windows-x86_64 \
+            canonical/evidence/release
+          cp components/linux/receipt/linux-x86_64.json component-receipts/
+          cp components/macos-arm64/receipt/macos-arm64.json component-receipts/
+          cp components/macos-x86_64/receipt/macos-x86_64.json component-receipts/
+          cp components/windows/receipt/windows-x86_64.json component-receipts/
+          cp -a components/linux/evidence/. canonical/evidence/linux-x86_64/
+          cp -a components/macos-arm64/evidence/. canonical/evidence/macos-arm64/
+          cp -a components/macos-x86_64/evidence/. canonical/evidence/macos-x86_64/
+          cp -a components/windows/evidence/. canonical/evidence/windows-x86_64/
+          cp binding/release-attempt-jobs.json binding/release-published.json \
+            binding/published-evidence.zip binding/published-evidence-artifact.json \
+            canonical/evidence/release/
+          python3 "$ACCEPTANCE_TOOL" evidence-manifest \
+            --binding binding/release-binding.json \
+            --component-artifacts component-artifacts.json \
+            --evidence-root canonical/evidence \
+            --acceptance-run-id "$ACCEPTANCE_RUN_ID" \
+            --acceptance-run-attempt "$ACCEPTANCE_RUN_ATTEMPT" \
+            --output canonical/EVIDENCE-MANIFEST.json
+          python3 "$ACCEPTANCE_TOOL" aggregate \
+            --binding binding/release-binding.json \
+            --component-artifacts component-artifacts.json \
+            --components component-receipts \
+            --evidence-manifest canonical/EVIDENCE-MANIFEST.json \
+            --evidence-root canonical/evidence \
+            --acceptance-run-id "$ACCEPTANCE_RUN_ID" \
+            --acceptance-run-attempt "$ACCEPTANCE_RUN_ATTEMPT" \
+            --output canonical/POST-RELEASE-ARTIFACT-ACCEPTANCE.json
+          cp binding/release-binding.json canonical/
+          cp component-artifacts.json canonical/
+          cp component-receipts/*.json canonical/
+          if find canonical -type l -print -quit | grep -q .; then
+            echo 'canonical published acceptance contains a symlink' >&2
+            exit 1
+          fi
+          checksum_manifest="$RUNNER_TEMP/POST-RELEASE-ARTIFACT-ACCEPTANCE.SHA256SUMS"
+          (cd canonical && find . -type f \
+            ! -name POST-RELEASE-ARTIFACT-ACCEPTANCE.SHA256SUMS -print0 \
+            | LC_ALL=C sort -z | xargs -0 sha256sum) > "$checksum_manifest"
+          mv "$checksum_manifest" \
+            canonical/POST-RELEASE-ARTIFACT-ACCEPTANCE.SHA256SUMS
+
+      - id: upload
+        name: Upload canonical published-artifact acceptance receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: arc-published-artifact-acceptance-v0.8.0-${{ inputs.release_source_sha }}-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          path: canonical
+          if-no-files-found: error
+          compression-level: 9
+          retention-days: 90
+
+      - name: Report exact canonical artifact identity
+        shell: bash
+        env:
+          ARTIFACT_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]
+          # upload-artifact exposes its output as the bare SHA-256; the Actions
+          # artifacts API used by the operator later returns the same value with
+          # a `sha256:` prefix.
+          [[ "$ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ]]
+          echo "::notice::Canonical post-release acceptance: run $GITHUB_RUN_ID attempt $GITHUB_RUN_ATTEMPT, artifact $ARTIFACT_ID, digest sha256:$ARTIFACT_DIGEST"

--- a/.github/workflows/recovery-release-handoff.yml
+++ b/.github/workflows/recovery-release-handoff.yml
@@ -102,7 +102,7 @@ jobs:
         id: upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
-          name: arc-recovery-release-handoff-${{ github.sha }}
+          name: arc-recovery-release-handoff-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: derived-cutover-handoff/*
           if-no-files-found: error
           include-hidden-files: false
@@ -124,7 +124,7 @@ jobs:
           gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID" > "$artifact"
           jq -e \
             --argjson id "$ARTIFACT_ID" \
-            --arg name "arc-recovery-release-handoff-$GITHUB_SHA" \
+            --arg name "arc-recovery-release-handoff-$GITHUB_SHA-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" \
             --arg digest "sha256:$ARTIFACT_DIGEST" \
             --argjson run_id "$GITHUB_RUN_ID" \
             '.id == $id and .name == $name and .digest == $digest
@@ -136,6 +136,7 @@ jobs:
             echo
             echo "- main commit: \`$GITHUB_SHA\`"
             echo "- derived commit: \`${{ steps.select.outputs.handoff_commit_sha }}\`"
+            echo "- workflow run/attempt: \`$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT\`"
             echo "- artifact ID: \`$ARTIFACT_ID\`"
             echo "- artifact digest: \`$ARTIFACT_DIGEST\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-signing-preflight.yml
+++ b/.github/workflows/release-signing-preflight.yml
@@ -1,9 +1,18 @@
 name: Release signing preflight
 
-run-name: Release preflight at ${{ github.sha }}
+run-name: Release preflight at ${{ github.sha }} with signing backup ${{ inputs.signing_backup_run_id }}/${{ inputs.signing_backup_run_attempt }}
 
 on:
   workflow_dispatch:
+    inputs:
+      signing_backup_run_id:
+        description: Exact successful signing-key backup workflow run ID for this protected-main SHA
+        required: true
+        type: string
+      signing_backup_run_attempt:
+        description: Exact successful signing-key backup workflow attempt containing the selected ciphertext
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -77,6 +86,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EXPECTED_SHA: ${{ needs.validate.outputs.sha }}
+          REQUESTED_BACKUP_RUN_ID: ${{ inputs.signing_backup_run_id }}
+          REQUESTED_BACKUP_RUN_ATTEMPT: ${{ inputs.signing_backup_run_attempt }}
         run: |
           set +x
           set -Eeuo pipefail
@@ -85,30 +96,46 @@ jobs:
           [ "$(git rev-parse HEAD)" = "$main_sha" ]
           git fetch --no-tags --force origin main:refs/remotes/origin/main
           [ "$main_sha" = "$(git rev-parse refs/remotes/origin/main)" ]
-          backup_run_id="$(gh run list \
-            --repo "$GITHUB_REPOSITORY" \
-            --workflow release-signing-backup.yml \
-            --commit "$main_sha" \
-            --event workflow_dispatch \
-            --status success \
-            --limit 1 \
-            --json databaseId \
-            --jq '.[0].databaseId // empty')"
-          if [ -z "$backup_run_id" ]; then
-            echo "::error::No successful restore-tested signing-key backup exists for exact protected-main commit $main_sha."
-            exit 1
-          fi
+          [[ "$REQUESTED_BACKUP_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$REQUESTED_BACKUP_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]
+          backup_run_id="$REQUESTED_BACKUP_RUN_ID"
+          backup_run_attempt="$REQUESTED_BACKUP_RUN_ATTEMPT"
+          backup_workflow_id="$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/release-signing-backup.yml" \
+            --jq '.id')"
+          [[ "$backup_workflow_id" =~ ^[1-9][0-9]*$ ]]
+          backup_run_json="$RUNNER_TEMP/selected-signing-backup-run.json"
+          gh api \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$backup_run_id/attempts/$backup_run_attempt" \
+            > "$backup_run_json"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg sha "$main_sha" \
+            --argjson workflow_id "$backup_workflow_id" \
+            --argjson run_id "$backup_run_id" \
+            --argjson run_attempt "$backup_run_attempt" '
+            .id == $run_id and .run_attempt == $run_attempt
+            and .workflow_id == $workflow_id
+            and .head_repository.full_name == $repository
+            and .head_branch == "main" and .head_sha == $sha
+            and .path == ".github/workflows/release-signing-backup.yml"
+            and .event == "workflow_dispatch"
+            and .status == "completed" and .conclusion == "success"' \
+            "$backup_run_json" >/dev/null || {
+              echo "::error::Selected signing-key backup run $backup_run_id attempt $backup_run_attempt is not a successful exact-main restore-tested run."
+              exit 1
+            }
           artifact_json="$(gh api \
             "repos/$GITHUB_REPOSITORY/actions/runs/$backup_run_id/artifacts" \
             --jq '[.artifacts[] | select(.expired == false) | {id, name}]')"
           artifact_name="$(printf '%s' "$artifact_json" | jq -r \
-            --arg prefix "arc-signing-backup-$main_sha-$backup_run_id-" \
+            --arg prefix "arc-signing-backup-$main_sha-$backup_run_id-$backup_run_attempt-" \
             '[.[] | select(.name | startswith($prefix))] | if length == 1 then .[0].name else empty end')"
           if [ -z "$artifact_name" ]; then
-            echo "::error::Exact-main backup run $backup_run_id has no unique unexpired ciphertext artifact."
+            echo "::error::Exact-main backup run $backup_run_id attempt $backup_run_attempt has no unique unexpired ciphertext artifact."
             exit 1
           fi
-          if [[ ! "$artifact_name" =~ ^arc-signing-backup-${main_sha}-${backup_run_id}-[1-9][0-9]*-([0-9a-f]{64})$ ]]; then
+          if [[ ! "$artifact_name" =~ ^arc-signing-backup-${main_sha}-${backup_run_id}-${backup_run_attempt}-([0-9a-f]{64})$ ]]; then
             echo "::error::Backup artifact name is not bound to run, attempt, and ciphertext hash."
             exit 1
           fi
@@ -143,6 +170,7 @@ jobs:
           [ "$(jq -r '.version' desktop/node_modules/@tauri-apps/cli/package.json)" = "2.11.4" ]
           {
             echo "backup_run_id=$backup_run_id"
+            echo "backup_run_attempt=$backup_run_attempt"
             echo "ciphertext=$ciphertext"
             echo "cipher_sha256=$cipher_sha256"
             echo "work_dir=$work_dir"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,18 @@ on:
         description: "Exact server digest for that protected handoff (sha256: followed by 64 lowercase hex characters)"
         required: true
         type: string
+      cutover_handoff_run_attempt:
+        description: Exact successful recovery-release-handoff attempt that created the selected artifact
+        required: true
+        type: string
+      pretag_run_id:
+        description: Exact successful release-signing-preflight workflow run ID for the tagged protected-main SHA
+        required: true
+        type: string
+      pretag_run_attempt:
+        description: Exact successful release-signing-preflight workflow attempt containing the selected artifacts
+        required: true
+        type: string
 
 concurrency:
   group: release-${{ inputs.tag || github.ref_name }}
@@ -56,6 +68,7 @@ jobs:
       cutover_artifact_name: ${{ steps.release.outputs.cutover_artifact_name }}
       cutover_artifact_size: ${{ steps.release.outputs.cutover_artifact_size }}
       cutover_run_id: ${{ steps.release.outputs.cutover_run_id }}
+      cutover_run_attempt: ${{ steps.release.outputs.cutover_run_attempt }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -71,6 +84,9 @@ jobs:
           REQUESTED_TAG: ${{ inputs.tag || github.ref_name }}
           REQUESTED_CUTOVER_ARTIFACT_ID: ${{ inputs.cutover_handoff_artifact_id }}
           REQUESTED_CUTOVER_ARTIFACT_DIGEST: ${{ inputs.cutover_handoff_artifact_digest }}
+          REQUESTED_CUTOVER_RUN_ATTEMPT: ${{ inputs.cutover_handoff_run_attempt }}
+          REQUESTED_PREFLIGHT_RUN_ID: ${{ inputs.pretag_run_id }}
+          REQUESTED_PREFLIGHT_RUN_ATTEMPT: ${{ inputs.pretag_run_attempt }}
         run: |
           set -Eeuo pipefail
           TAG="$REQUESTED_TAG"
@@ -109,32 +125,47 @@ jobs:
             echo "::error::Release requires the exact sha256 cutover_handoff_artifact_digest."
             exit 1
           fi
+          if [[ ! "$REQUESTED_CUTOVER_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Release requires the exact positive cutover_handoff_run_attempt."
+            exit 1
+          fi
           CUTOVER_ARTIFACT_JSON="$RUNNER_TEMP/cutover-handoff-artifact.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$REQUESTED_CUTOVER_ARTIFACT_ID" \
             > "$CUTOVER_ARTIFACT_JSON"
-          CUTOVER_ARTIFACT_NAME="arc-recovery-release-handoff-$TAG_COMMIT"
           jq -e \
             --argjson artifact_id "$REQUESTED_CUTOVER_ARTIFACT_ID" \
-            --arg name "$CUTOVER_ARTIFACT_NAME" \
             --arg digest "$REQUESTED_CUTOVER_ARTIFACT_DIGEST" \
-            '.id == $artifact_id and .name == $name and .digest == $digest
+            '.id == $artifact_id and .digest == $digest
              and .expired == false
              and (.size_in_bytes | type == "number" and . > 0 and . <= 33554432)
              and (.workflow_run.id | type == "number" and . > 0)' \
             "$CUTOVER_ARTIFACT_JSON" >/dev/null || {
-              echo "::error::Cutover handoff artifact ID/name/digest/size/liveness differs."
+              echo "::error::Cutover handoff artifact ID/digest/size/liveness differs."
               exit 1
             }
           CUTOVER_RUN_ID="$(jq -er '.workflow_run.id' "$CUTOVER_ARTIFACT_JSON")"
+          CUTOVER_RUN_ATTEMPT="$REQUESTED_CUTOVER_RUN_ATTEMPT"
           CUTOVER_ARTIFACT_SIZE="$(jq -er '.size_in_bytes' "$CUTOVER_ARTIFACT_JSON")"
+          CUTOVER_ARTIFACT_NAME="arc-recovery-release-handoff-$TAG_COMMIT-$CUTOVER_RUN_ID-$CUTOVER_RUN_ATTEMPT"
+          jq -e \
+            --argjson artifact_id "$REQUESTED_CUTOVER_ARTIFACT_ID" \
+            --arg name "$CUTOVER_ARTIFACT_NAME" \
+            --arg digest "$REQUESTED_CUTOVER_ARTIFACT_DIGEST" \
+            '.id == $artifact_id and .name == $name and .digest == $digest' \
+            "$CUTOVER_ARTIFACT_JSON" >/dev/null || {
+              echo "::error::Cutover handoff artifact is not bound to the selected run attempt."
+              exit 1
+            }
           CUTOVER_RUN_JSON="$RUNNER_TEMP/cutover-handoff-run.json"
-          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$CUTOVER_RUN_ID" \
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$CUTOVER_RUN_ID/attempts/$CUTOVER_RUN_ATTEMPT" \
             > "$CUTOVER_RUN_JSON"
           jq -e \
             --arg repository "$GITHUB_REPOSITORY" \
             --arg sha "$TAG_COMMIT" \
             --argjson run_id "$CUTOVER_RUN_ID" \
+            --argjson run_attempt "$CUTOVER_RUN_ATTEMPT" \
             '.id == $run_id and .head_repository.full_name == $repository
+             and .run_attempt == $run_attempt
              and .head_branch == "main" and .head_sha == $sha
              and .path == ".github/workflows/recovery-release-handoff.yml"
              and .event == "workflow_dispatch" and .status == "completed"
@@ -144,29 +175,28 @@ jobs:
               exit 1
             }
 
-          PREFLIGHT_RUN_ID="$(gh run list \
-            --repo "$GITHUB_REPOSITORY" \
-            --workflow release-signing-preflight.yml \
-            --commit "$TAG_COMMIT" \
-            --event workflow_dispatch \
-            --limit 1 \
-            --json databaseId \
-            --jq '.[0].databaseId // empty')"
-          if [ -z "$PREFLIGHT_RUN_ID" ]; then
-            echo "::error::No protected signing preflight exists for exact main commit $TAG_COMMIT."
+          [[ "$REQUESTED_PREFLIGHT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Release requires an explicit positive pretag_run_id."
             exit 1
-          fi
+          }
+          [[ "$REQUESTED_PREFLIGHT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Release requires an explicit positive pretag_run_attempt."
+            exit 1
+          }
+          PREFLIGHT_RUN_ID="$REQUESTED_PREFLIGHT_RUN_ID"
+          PREFLIGHT_RUN_ATTEMPT="$REQUESTED_PREFLIGHT_RUN_ATTEMPT"
           PREFLIGHT_WORKFLOW_ID="$(gh api \
             "repos/$GITHUB_REPOSITORY/actions/workflows/release-signing-preflight.yml" \
             --jq '.id')"
           PREFLIGHT_RUN_JSON="$RUNNER_TEMP/preflight-run.json"
-          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PREFLIGHT_RUN_ID" \
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PREFLIGHT_RUN_ID/attempts/$PREFLIGHT_RUN_ATTEMPT" \
             > "$PREFLIGHT_RUN_JSON"
           jq -e \
             --arg repository "$GITHUB_REPOSITORY" \
             --arg sha "$TAG_COMMIT" \
             --argjson workflow_id "$PREFLIGHT_WORKFLOW_ID" \
             --argjson run_id "$PREFLIGHT_RUN_ID" \
+            --argjson run_attempt "$PREFLIGHT_RUN_ATTEMPT" \
             '.id == $run_id
               and .workflow_id == $workflow_id
               and .head_repository.full_name == $repository
@@ -175,12 +205,11 @@ jobs:
               and .event == "workflow_dispatch"
               and .status == "completed"
               and .conclusion == "success"
-              and (.run_attempt | type == "number" and . > 0)' \
+              and .run_attempt == $run_attempt' \
             "$PREFLIGHT_RUN_JSON" >/dev/null || {
-              echo "::error::The latest exact-commit preflight run is not a completed successful main-branch run of the protected workflow."
+              echo "::error::The selected exact-commit preflight run/attempt is not a completed successful main-branch run of the protected workflow."
               exit 1
             }
-          PREFLIGHT_RUN_ATTEMPT="$(jq -r '.run_attempt' "$PREFLIGHT_RUN_JSON")"
           PREFLIGHT_ARTIFACTS_JSON="$RUNNER_TEMP/preflight-artifacts.json"
           gh api --paginate \
             "repos/$GITHUB_REPOSITORY/actions/runs/$PREFLIGHT_RUN_ID/artifacts?per_page=100" \
@@ -244,6 +273,7 @@ jobs:
             echo "cutover_artifact_name=$CUTOVER_ARTIFACT_NAME"
             echo "cutover_artifact_size=$CUTOVER_ARTIFACT_SIZE"
             echo "cutover_run_id=$CUTOVER_RUN_ID"
+            echo "cutover_run_attempt=$CUTOVER_RUN_ATTEMPT"
           } >> "$GITHUB_OUTPUT"
 
   # A tag is independently releasable only if its validated commit passes
@@ -1329,17 +1359,8 @@ jobs:
             exit 1
           fi
 
-          current_preflight_id="$(/usr/bin/gh run list \
-            --repo "$GITHUB_REPOSITORY" \
-            --workflow release-signing-preflight.yml \
-            --commit "$EXPECTED_SHA" --event workflow_dispatch --limit 1 \
-            --json databaseId --jq '.[0].databaseId // empty')"
-          [ "$current_preflight_id" = "$SELECTED_PREFLIGHT_RUN_ID" ] || {
-            echo "::error::The selected signing preflight was superseded."
-            exit 1
-          }
           preflight_json="$RUNNER_TEMP/current-preflight-run.json"
-          /usr/bin/gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SELECTED_PREFLIGHT_RUN_ID" \
+          /usr/bin/gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SELECTED_PREFLIGHT_RUN_ID/attempts/$SELECTED_PREFLIGHT_RUN_ATTEMPT" \
             > "$preflight_json"
           /usr/bin/jq -e --arg sha "$EXPECTED_SHA" \
             --argjson attempt "$SELECTED_PREFLIGHT_RUN_ATTEMPT" \
@@ -1667,14 +1688,8 @@ jobs:
           [[ "$RELEASE_ID" =~ ^[1-9][0-9]*$ ]]
           [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
 
-          current_preflight_id="$(/usr/bin/gh run list \
-            --repo "$GITHUB_REPOSITORY" \
-            --workflow release-signing-preflight.yml \
-            --commit "$EXPECTED_SHA" --event workflow_dispatch --limit 1 \
-            --json databaseId --jq '.[0].databaseId // empty')"
-          [ "$current_preflight_id" = "$SELECTED_PREFLIGHT_RUN_ID" ]
           preflight_json="$RUNNER_TEMP/current-preflight-run.json"
-          /usr/bin/gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SELECTED_PREFLIGHT_RUN_ID" \
+          /usr/bin/gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SELECTED_PREFLIGHT_RUN_ID/attempts/$SELECTED_PREFLIGHT_RUN_ATTEMPT" \
             > "$preflight_json"
           /usr/bin/jq -e --arg sha "$EXPECTED_SHA" \
             --argjson attempt "$SELECTED_PREFLIGHT_RUN_ATTEMPT" \

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ upstream components vendored for reproducibility are identified under
 
 ## v0.8.0 release status and quickstart
 
+<!-- ARC_PUBLIC_TRUTH_BEGIN -->
 > **Source-freeze snapshot (2026-08-31; tag-stable):** At this commit's review
 > cutoff, v0.8.0 / protocol v3 was not published or deployed, and GitHub
 > `latest` was still the desktop-only v0.7.11 bundle. This is a historical
@@ -81,6 +82,7 @@ cutover is proven, the
 demonstrates install, assignment, inference verification, a mined reward
 receipt, earnings, and the matching explorer block without overstating any
 missing evidence.
+<!-- ARC_PUBLIC_TRUTH_END -->
 
 📄 Paper: *On the Foundations of Trustworthy Artificial Intelligence*
 

--- a/crates/arc-node/src/rpc.rs
+++ b/crates/arc-node/src/rpc.rs
@@ -5516,6 +5516,30 @@ fn live_inference_worker_count(node: &NodeState) -> usize {
         .count()
 }
 
+fn exact_live_inference_worker(node: &NodeState, expected_worker: &str) -> bool {
+    let Ok((_, coordinator_model_id)) = exact_model_identity(node) else {
+        return false;
+    };
+    let Some(entry) = node.community_workers.get(expected_worker) else {
+        return false;
+    };
+    let (worker, refreshed_at) = entry.value();
+    std::time::Instant::now().duration_since(*refreshed_at)
+        <= std::time::Duration::from_secs(COMMUNITY_WORKER_TTL_SECS)
+        && !node.community_active_jobs.contains_key(expected_worker)
+        && worker
+            .capabilities
+            .iter()
+            .any(|capability| capability == "inference")
+        && worker.execution_profile.as_deref()
+            == Some(arc_inference::cached_integer_model::CANONICAL_REWARD_INFERENCE_PROFILE)
+        && worker
+            .model_id
+            .as_deref()
+            .and_then(|model_id| parse_hash256_hex(model_id, "model_id").ok())
+            == Some(coordinator_model_id)
+}
+
 /// Consensus activation plus the operator's local ingress/issuance switch.
 /// This is enough to accept an already-threshold-authorized external 0x25,
 /// but not enough for this coordinator to create one.
@@ -5739,6 +5763,7 @@ fn recovery_probe_status_response(
     node: &NodeState,
     probe_id: Hash256,
     expected_job_id: Hash256,
+    expected_worker_id: Option<&str>,
 ) -> Result<Option<Value>, String> {
     let Some(existing_job_id) = recovery_probe_existing_job(node, probe_id)? else {
         return Ok(None);
@@ -5754,10 +5779,10 @@ fn recovery_probe_status_response(
         pending_mined_receipt_value(node, existing_job_id, &submission)
     } else if let Some(record) = node.community_verified_settlements.get(&existing_job_id) {
         pending_settlement_value(node, &record)
-    } else if node
+    } else if let Some(pending) = node
         .community_work_results
         .as_ref()
-        .is_some_and(|results| results.contains_key(&existing_job_id.to_hex()))
+        .and_then(|results| results.get(&existing_job_id.to_hex()))
     {
         let assigned_worker = node
             .community_active_jobs
@@ -5766,7 +5791,8 @@ fn recovery_probe_status_response(
                 parse_hash256_hex(entry.value(), "active job id")
                     .is_ok_and(|job_id| job_id == existing_job_id)
             })
-            .map(|entry| entry.key().clone());
+            .map(|entry| entry.key().clone())
+            .or_else(|| pending.item.expected_worker_id.clone());
         json!({
             "status": "assignment_in_progress",
             "tx_type": "0x25",
@@ -5784,6 +5810,20 @@ fn recovery_probe_status_response(
     } else {
         return Err("recovery probe job exists without discoverable coordinator state".to_string());
     };
+    if let Some(expected_worker) = expected_worker_id {
+        let actual_worker = settlement
+            .get("worker")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                "recovery probe settlement does not expose its assigned worker".to_string()
+            })?;
+        if actual_worker != expected_worker {
+            return Err(
+                "recovery probe identity is bound to a worker other than the accepted canary"
+                    .to_string(),
+            );
+        }
+    }
     Ok(Some(json!({
         "success": true,
         "idempotent_replay": true,
@@ -5854,6 +5894,7 @@ async fn dispatch_to_community_worker_with_probe(
     max_tokens: u32,
     model_id_hint: Option<String>,
     recovery_probe_id: Option<Hash256>,
+    expected_worker_id: Option<String>,
 ) -> Result<CommunityDispatchOutcome, CommunityDispatchError> {
     if recovery_probe_id.is_some_and(|probe_id| {
         !arc_types::transaction::CommunityInferenceRewardBody::is_recovery_probe_assignment(
@@ -5862,6 +5903,18 @@ async fn dispatch_to_community_worker_with_probe(
     }) {
         return Err(CommunityDispatchError::before_enqueue(
             "recovery_probe_id is outside the protocol recovery namespace",
+        ));
+    }
+    if recovery_probe_id.is_some() != expected_worker_id.is_some() {
+        return Err(CommunityDispatchError::before_enqueue(
+            "recovery probes require one exact expected_worker and normal jobs forbid it",
+        ));
+    }
+    if let Some(expected_worker) = expected_worker_id.as_deref()
+        && parse_hash256_hex(expected_worker, "expected_worker").is_err()
+    {
+        return Err(CommunityDispatchError::before_enqueue(
+            "expected_worker must be one lowercase 32-byte hexadecimal address",
         ));
     }
     let _inference_permit = node
@@ -5957,6 +6010,7 @@ async fn dispatch_to_community_worker_with_probe(
             .state
             .transaction_domain_hash()
             .map(|domain| format!("0x{}", domain.to_hex())),
+        expected_worker_id,
         submitted_at_unix_ms: submitted_at,
         expires_at_unix_ms,
     };
@@ -6069,7 +6123,8 @@ async fn dispatch_to_community_worker(
     max_tokens: u32,
     model_id_hint: Option<String>,
 ) -> Result<CommunityDispatchOutcome, CommunityDispatchError> {
-    dispatch_to_community_worker_with_probe(node, input, max_tokens, model_id_hint, None).await
+    dispatch_to_community_worker_with_probe(node, input, max_tokens, model_id_hint, None, None)
+        .await
 }
 
 /// Tier 1 write ingress is intentionally unavailable.
@@ -6303,6 +6358,32 @@ async fn inference_run(
             Some(probe_id)
         }
     };
+    let recovery_expected_worker = match req.get("expected_worker") {
+        None if recovery_probe_id.is_some() => {
+            return Err(api_error(
+                StatusCode::BAD_REQUEST,
+                "recovery probes require expected_worker from the accepted canary",
+            ));
+        }
+        None => None,
+        Some(_) if recovery_probe_id.is_none() => {
+            return Err(api_error(
+                StatusCode::BAD_REQUEST,
+                "expected_worker is reserved for recovery probes",
+            ));
+        }
+        Some(value) => {
+            let encoded = value.as_str().ok_or_else(|| {
+                api_error(
+                    StatusCode::BAD_REQUEST,
+                    "expected_worker must be a lowercase 32-byte hexadecimal string",
+                )
+            })?;
+            let worker = parse_hash256_hex(encoded, "expected_worker")
+                .map_err(|error| api_error(StatusCode::BAD_REQUEST, error))?;
+            Some(format!("0x{}", worker.to_hex()))
+        }
+    };
 
     // ── Smart router: prefer community workers when any are online ──────
     //
@@ -6343,7 +6424,12 @@ async fn inference_run(
         );
         let existing = {
             let _gate = node.community_verified_settlements_gate.lock();
-            recovery_probe_status_response(&node, probe_id, expected)
+            recovery_probe_status_response(
+                &node,
+                probe_id,
+                expected,
+                recovery_expected_worker.as_deref(),
+            )
         }
         .map_err(|error| api_error(StatusCode::CONFLICT, error))?;
         if let Some(response) = existing {
@@ -6353,10 +6439,15 @@ async fn inference_run(
     } else {
         None
     };
-    if recovery_probe_id.is_some() && (live_workers == 0 || node.community_work_tx.is_none()) {
+    if recovery_probe_id.is_some()
+        && (recovery_expected_worker
+            .as_deref()
+            .is_none_or(|worker| !exact_live_inference_worker(&node, worker))
+            || node.community_work_tx.is_none())
+    {
         return Err(api_error(
             StatusCode::SERVICE_UNAVAILABLE,
-            "sealed recovery probe coordinator has no eligible community worker dispatch path",
+            "sealed recovery probe coordinator cannot dispatch to the exact accepted canary worker",
         ));
     }
     if !force_local && live_workers > 0 && node.community_work_tx.is_some() {
@@ -6370,6 +6461,7 @@ async fn inference_run(
             max_tokens,
             assigned_model_id.clone(),
             recovery_probe_id,
+            recovery_expected_worker.clone(),
         )
         .await
         {
@@ -6436,7 +6528,12 @@ async fn inference_run(
                 {
                     let replay = {
                         let _gate = node.community_verified_settlements_gate.lock();
-                        recovery_probe_status_response(&node, probe_id, expected_job)
+                        recovery_probe_status_response(
+                            &node,
+                            probe_id,
+                            expected_job,
+                            recovery_expected_worker.as_deref(),
+                        )
                     }
                     .map_err(|error| api_error(StatusCode::CONFLICT, error))?;
                     if let Some(response) = replay {
@@ -7123,6 +7220,7 @@ async fn workers_scoreboard(
         .and_then(|l| l.parse::<usize>().ok())
         .unwrap_or(50)
         .min(500);
+    let worker_filter = params.get("worker_id");
 
     let now = std::time::Instant::now();
     let ttl = std::time::Duration::from_secs(COMMUNITY_WORKER_TTL_SECS);
@@ -7149,6 +7247,9 @@ async fn workers_scoreboard(
     let mut rows: Vec<WorkerScore> = Vec::new();
     for entry in node.community_workers.iter() {
         let (w, ts) = entry.value();
+        if worker_filter.is_some_and(|expected| expected != &w.worker_id) {
+            continue;
+        }
         if now.duration_since(*ts) > ttl {
             continue;
         }
@@ -12043,6 +12144,10 @@ pub struct WorkItem {
     /// Absent on legacy/dev networks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transaction_domain: Option<String>,
+    /// Recovery-only target identity. Other workers must leave this item in
+    /// the queue so the accepted pre-tag canary alone can claim it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_worker_id: Option<String>,
     /// Unix timestamp (ms) when the dispatcher queued the job. Workers
     /// echo this back so the dispatcher can compute end-to-end latency.
     pub submitted_at_unix_ms: i64,
@@ -12934,6 +13039,7 @@ fn validate_reward_approval_payload(
             .state
             .transaction_domain_hash()
             .map(|domain| format!("0x{}", domain.to_hex())),
+        expected_worker_id: None,
         submitted_at_unix_ms: 0,
         expires_at_unix_ms: u64::MAX,
     };
@@ -14279,6 +14385,24 @@ pub async fn community_claim_work(
                 return Ok(Json(json!({
                     "status": "no_work",
                     "reason": "job_expired",
+                })));
+            }
+            if item
+                .expected_worker_id
+                .as_deref()
+                .is_some_and(|expected| expected != req.worker_id)
+            {
+                if let Some(ref tx) = node.community_work_tx {
+                    let job_id = item.job_id.clone();
+                    if tx.try_send(item).is_err()
+                        && let Some(results) = node.community_work_results.as_ref()
+                    {
+                        results.remove(&job_id);
+                    }
+                }
+                return Ok(Json(json!({
+                    "status": "no_work",
+                    "reason": "worker_mismatch",
                 })));
             }
             // Exact model commitments, not display names, decide whether this
@@ -17485,6 +17609,7 @@ mod tests {
             model_id: Some("0xdeadbeef".to_string()),
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 1_700_000_000_000,
             expires_at_unix_ms: 1_700_000_001_000,
         };
@@ -17518,6 +17643,7 @@ mod tests {
             model_id: None,
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 0,
             expires_at_unix_ms: u64::MAX,
         };
@@ -18271,6 +18397,7 @@ mod tests {
             execution_profile:
                 arc_inference::cached_integer_model::CANONICAL_REWARD_INFERENCE_PROFILE.to_string(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 1,
             expires_at_unix_ms: u64::MAX,
         };
@@ -18980,6 +19107,7 @@ mod tests {
             model_id: None,
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 1,
             expires_at_unix_ms: u64::MAX,
         })
@@ -19016,6 +19144,7 @@ mod tests {
                 model_id: None,
                 execution_profile: canonical_profile(),
                 transaction_domain: None,
+                expected_worker_id: None,
                 submitted_at_unix_ms: 0,
                 expires_at_unix_ms: u64::MAX,
             })
@@ -19397,9 +19526,10 @@ mod tests {
         )
         .await
         .unwrap();
-        let recovery_replay = recovery_probe_status_response(&node, recovery_probe_id, job_id)
-            .unwrap()
-            .expect("the recovery replay discovers the same pending submission");
+        let recovery_replay =
+            recovery_probe_status_response(&node, recovery_probe_id, job_id, None)
+                .unwrap()
+                .expect("the recovery replay discovers the same pending submission");
         for pending in [
             &pending_by_hash,
             &pending_by_job,
@@ -19453,7 +19583,7 @@ mod tests {
         // submitted once it has neither mempool presence nor chain inclusion,
         // while retaining the durable independently verified job for retry.
         node.mempool.clear();
-        let stale_recovery = recovery_probe_status_response(&node, recovery_probe_id, job_id)
+        let stale_recovery = recovery_probe_status_response(&node, recovery_probe_id, job_id, None)
             .unwrap()
             .expect("durable verified recovery work remains discoverable");
         let stale_recovery = &stale_recovery["settlement"];
@@ -20462,6 +20592,7 @@ mod tests {
                     model_id: Some(test_model_id()),
                     execution_profile: canonical_profile(),
                     transaction_domain: None,
+                    expected_worker_id: None,
                     submitted_at_unix_ms: 0,
                     expires_at_unix_ms: u64::MAX,
                 })
@@ -20553,8 +20684,9 @@ mod tests {
     #[tokio::test]
     async fn recovery_probe_dispatch_is_restart_stable_and_rejects_duplicate_or_tampered_semantics()
     {
+        let expected_worker = format!("0x{}", "1".repeat(64));
         let node = fake_node_with_workers(vec![(
-            worker("w1", &["inference"]),
+            worker(&expected_worker, &["inference"]),
             std::time::Instant::now(),
         )]);
         let mut probe_bytes = [0u8; 32];
@@ -20564,6 +20696,7 @@ mod tests {
         let probe_id = Hash256(probe_bytes);
         let queue = node.community_work_queue.as_ref().unwrap().clone();
         let task_node = node.clone();
+        let task_worker = expected_worker.clone();
         let first = tokio::spawn(async move {
             dispatch_to_community_worker_with_probe(
                 &task_node,
@@ -20571,6 +20704,7 @@ mod tests {
                 1,
                 Some(test_model_id()),
                 Some(probe_id),
+                Some(task_worker),
             )
             .await
         });
@@ -20594,6 +20728,7 @@ mod tests {
             1,
             Some(test_model_id()),
             Some(probe_id),
+            Some(expected_worker.clone()),
         )
         .await
         .expect_err("same probe must discover the existing job");
@@ -20604,6 +20739,7 @@ mod tests {
             1,
             Some(test_model_id()),
             Some(probe_id),
+            Some(expected_worker),
         )
         .await
         .expect_err("one recovery identity cannot bind different input");
@@ -20615,8 +20751,9 @@ mod tests {
 
     #[tokio::test]
     async fn inference_run_recovery_retry_discovers_inflight_job_without_second_enqueue() {
+        let expected_worker = format!("0x{}", "1".repeat(64));
         let node = fake_node_with_workers(vec![(
-            worker("w1", &["inference"]),
+            worker(&expected_worker, &["inference"]),
             std::time::Instant::now(),
         )]);
         let mut probe_bytes = [0u8; 32];
@@ -20628,6 +20765,7 @@ mod tests {
             "input": "ARC RPC recovery probe",
             "max_tokens": 1,
             "recovery_probe_id": format!("0x{}", probe_id.to_hex()),
+            "expected_worker": expected_worker,
         });
         let first_node = node.clone();
         let first_request = request.clone();
@@ -20645,7 +20783,7 @@ mod tests {
         assert_eq!(replay["recovery_probe_id"], request["recovery_probe_id"]);
         assert_eq!(replay["job_id"], format!("0x{}", item.job_id));
         assert_eq!(replay["settlement"]["status"], "assignment_in_progress");
-        assert!(replay["settlement"]["worker"].is_null());
+        assert_eq!(replay["settlement"]["worker"], request["expected_worker"]);
         assert!(replay["settlement"]["tx_hash"].is_null());
         assert_eq!(replay["settlement"]["submitted"], false);
         assert_eq!(replay["settlement"]["included"], false);
@@ -21402,6 +21540,7 @@ mod tests {
             model_id: Some(test_model_id()),
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 1,
             expires_at_unix_ms: u64::MAX,
         };
@@ -21433,6 +21572,7 @@ mod tests {
             model_id: Some(test_model_id()),
             execution_profile: canonical_profile(),
             transaction_domain: Some(format!("0x{}", recovery_domain.to_hex())),
+            expected_worker_id: None,
             submitted_at_unix_ms: 1,
             expires_at_unix_ms: u64::MAX,
         };
@@ -21526,6 +21666,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn recovery_work_can_only_be_claimed_by_its_exact_accepted_worker() {
+        let accepted_key = KeyPair::generate_ed25519();
+        let foreign_key = KeyPair::generate_ed25519();
+        let accepted_worker = format!("0x{}", accepted_key.address().to_hex());
+        let foreign_worker = format!("0x{}", foreign_key.address().to_hex());
+        let node = fake_node_with_workers(vec![
+            (worker(&accepted_worker, &["inference"]), Instant::now()),
+            (worker(&foreign_worker, &["inference"]), Instant::now()),
+        ]);
+        let item = WorkItem {
+            job_id: arc_crypto::hash_bytes(b"accepted-worker-only").to_hex(),
+            input: "ARC exact canary".to_string(),
+            max_tokens: 1,
+            model_id: Some(test_model_id()),
+            execution_profile: canonical_profile(),
+            transaction_domain: None,
+            expected_worker_id: Some(accepted_worker.clone()),
+            submitted_at_unix_ms: 1,
+            expires_at_unix_ms: u64::MAX,
+        };
+        let _receiver = insert_pending_job(&node, item.clone(), None);
+        node.community_work_tx
+            .as_ref()
+            .unwrap()
+            .send(item.clone())
+            .await
+            .unwrap();
+
+        let Json(foreign_response) = community_claim_work(
+            AxumState(node.clone()),
+            Json(ClaimWorkRequest {
+                worker_id: foreign_worker.clone(),
+                capabilities: vec!["inference".to_string()],
+                model_id: test_model_id(),
+                execution_profile: canonical_profile(),
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(foreign_response["status"], "no_work");
+        assert_eq!(foreign_response["reason"], "worker_mismatch");
+        assert!(!node.community_active_jobs.contains_key(&foreign_worker));
+
+        let Json(accepted_response) = community_claim_work(
+            AxumState(node.clone()),
+            Json(ClaimWorkRequest {
+                worker_id: accepted_worker.clone(),
+                capabilities: vec!["inference".to_string()],
+                model_id: test_model_id(),
+                execution_profile: canonical_profile(),
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(accepted_response["status"], "work");
+        assert_eq!(accepted_response["job_id"], item.job_id);
+        assert_eq!(
+            node.community_work_results
+                .as_ref()
+                .unwrap()
+                .get(&item.job_id)
+                .unwrap()
+                .assigned_worker
+                .as_deref(),
+            Some(accepted_worker.as_str())
+        );
+    }
+
+    #[tokio::test]
     async fn second_claim_for_busy_worker_cannot_dequeue_another_job() {
         let worker_key = KeyPair::generate_ed25519();
         let worker_id = worker_key.address().to_hex();
@@ -21538,6 +21747,7 @@ mod tests {
             model_id: Some(test_model_id()),
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 1,
             expires_at_unix_ms: u64::MAX,
         };
@@ -21548,6 +21758,7 @@ mod tests {
             model_id: Some(test_model_id()),
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 2,
             expires_at_unix_ms: u64::MAX,
         };
@@ -21609,6 +21820,7 @@ mod tests {
             model_id: None,
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 1,
             expires_at_unix_ms: u64::MAX,
         };
@@ -21656,6 +21868,7 @@ mod tests {
             model_id: None,
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 1,
             expires_at_unix_ms: u64::MAX,
         };
@@ -21703,6 +21916,7 @@ mod tests {
             model_id: Some(test_model_id()),
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 1,
             expires_at_unix_ms: u64::MAX,
         };
@@ -21781,6 +21995,7 @@ mod tests {
             model_id: Some(test_model_id()),
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 1,
             expires_at_unix_ms: u64::MAX,
         };
@@ -21810,6 +22025,7 @@ mod tests {
             model_id: Some(test_model_id()),
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 1,
             expires_at_unix_ms: u64::MAX,
         };
@@ -21908,6 +22124,7 @@ mod tests {
             model_id: None,
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 1,
             expires_at_unix_ms: u64::MAX,
         };
@@ -21979,6 +22196,7 @@ mod tests {
             model_id: None,
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 1,
             expires_at_unix_ms: u64::MAX,
         };
@@ -22698,6 +22916,7 @@ mod tests {
             )),
             execution_profile: canonical_profile(),
             transaction_domain: None,
+            expected_worker_id: None,
             submitted_at_unix_ms: 1,
             expires_at_unix_ms: u64::MAX,
         };
@@ -22868,6 +23087,25 @@ mod tests {
             Some(10),
             "the walkthrough must use the server-authoritative completion counter"
         );
+    }
+
+    #[tokio::test]
+    async fn scoreboard_exact_worker_filter_is_not_displaced_by_ranking() {
+        let now = std::time::Instant::now();
+        let node = fake_node_with_workers(vec![
+            (worker_with_stats("top", 10, 0, 10, 1), now),
+            (worker_with_stats("accepted-canary", 0, 0, 0, 0), now),
+        ]);
+        let params = HashMap::from([
+            ("limit".to_string(), "1".to_string()),
+            ("worker_id".to_string(), "accepted-canary".to_string()),
+        ]);
+        let value = workers_scoreboard(AxumState(node), Query(params)).await.0;
+        let rows = value["workers"].as_array().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["worker_id"], "accepted-canary");
+        assert_eq!(value["count_visible"], 1);
+        assert_eq!(value["count_total"], 2);
     }
 
     #[tokio::test]

--- a/desktop/src/screens/Onboarding.tsx
+++ b/desktop/src/screens/Onboarding.tsx
@@ -63,7 +63,7 @@ export function Onboarding() {
 
   const [launching, setLaunching] = useState(false);
   const [launchStage, setLaunchStage] = useState<
-    "idle" | "model" | "downloading" | "starting" | "connecting" | "claiming"
+    "idle" | "model" | "downloading" | "starting" | "connecting"
   >("idle");
   const [modelProgress, setModelProgress] =
     useState<ModelDownloadProgress | null>(null);
@@ -188,14 +188,6 @@ export function Onboarding() {
       }
       if (joinResult) {
         setConnectedVia(joinResult.via ?? null);
-      }
-      if (joinResult) {
-        setLaunchStage("claiming");
-        try {
-          await api.faucetClaim();
-        } catch {
-          /* faucet is a best-effort welcome gift; non-fatal */
-        }
       }
       setOnboarded(true);
     } catch (err) {
@@ -750,15 +742,13 @@ export function Onboarding() {
                           ? "Starting your node"
                           : launchStage === "connecting"
                             ? "Connecting to a coordinator"
-                            : launchStage === "claiming"
-                              ? "Claiming welcome tokens"
-                              : "Finishing up"}
+                            : "Finishing up"}
                 </h1>
                 <p className="onboarding-subtitle" data-testid="launch-summary">
                   {!launching &&
                     (selectedTier === "skip"
-                      ? "We'll download the node binary, start an observer/router without local model execution, and request testnet faucet credit. Setup does not guarantee peers, work, or rewards."
-                      : "We'll fetch the selected model, download the node binary, start the process, and request testnet faucet credit. Setup does not guarantee peers, work, or rewards.")}
+                      ? "We'll download the node binary and start an observer/router without local model execution. You can request testnet credit explicitly from Wallet after setup. Setup does not guarantee peers, work, or rewards."
+                      : "We'll fetch the selected model, download the node binary, and start the process. You can request testnet credit explicitly from Wallet after setup. Setup does not guarantee peers, work, or rewards.")}
                   {launching && launchStage === "model" && modelProgress && (
                     <>
                       {formatBytes(modelProgress.downloadedBytes)} of{" "}
@@ -789,9 +779,6 @@ export function Onboarding() {
                       connectedVia={connectedVia}
                     />
                   )}
-                  {launching &&
-                    launchStage === "claiming" &&
-                    "Asking the testnet faucet for your starter balance."}
                 </p>
 
                 {launching && launchStage === "model" && modelProgress && (

--- a/desktop/tests/e2e-flow.spec.ts
+++ b/desktop/tests/e2e-flow.spec.ts
@@ -46,8 +46,8 @@ test.describe("Onboarding → launch end-to-end", () => {
 
     await page.getByTestId("btn-launch").click();
 
-    // Mock flow: ensureBinary + startNode + waitForPeer + faucetClaim all
-    // resolve, then dashboard renders.
+    // Mock flow: ensureBinary + startNode + waitForPeer resolve, then the
+    // dashboard renders without submitting any balance-changing request.
     await expect(page.getByTestId("dashboard")).toBeVisible({ timeout: 15_000 });
   });
 
@@ -84,16 +84,16 @@ test.describe("Onboarding → launch end-to-end", () => {
     expect(src).not.toMatch(/setRole/);
   });
 
-  test("launch pipeline auto-claims faucet after peer count ≥ 1", () => {
+  test("launch pipeline never auto-claims the faucet", () => {
     const src = fs.readFileSync(
       path.resolve(REPO_DESKTOP, "src", "screens", "Onboarding.tsx"),
       "utf8",
     );
-    // Faucet claim must be gated on waitForPeer returning true - not
-    // fired unconditionally (would burn the daily limit on nodes that
-    // never joined).
+    // Onboarding is a setup transaction, not authorization for a wallet
+    // write. The explicit Wallet button remains the only faucet trigger.
     expect(src).toMatch(/waitForPeer/);
-    expect(src).toMatch(/faucetClaim/);
+    expect(src).not.toMatch(/faucetClaim/);
+    expect(src).toMatch(/request testnet credit explicitly from Wallet/);
   });
 });
 

--- a/docs/MACOS-PRETAG-COMMUNITY-CANARY.md
+++ b/docs/MACOS-PRETAG-COMMUNITY-CANARY.md
@@ -187,6 +187,7 @@ scripts/release/macos-community-canary.py install \
 
 scripts/release/macos-community-canary.py start
 scripts/release/macos-community-canary.py status
+scripts/release/macos-community-canary.py accept
 ```
 
 `start` succeeds only after launchd, `ps`, and `lsof` prove the exact PID,
@@ -197,6 +198,16 @@ exposing the RPC listener:
 curl -fsS http://127.0.0.1:19944/health | python3 -m json.tool
 curl -fsS http://127.0.0.1:19944/node/info | python3 -m json.tool
 ```
+
+`accept` repeats the complete installation and live-process proof and then
+create-only seals
+`~/.arc-pretag-community-canary/evidence/ACCEPTED.json`. That canonical receipt
+binds the dedicated worker address to the protected commit/run/attempt,
+artifact ID and digests, exact node/model/genesis bytes, six HTTPS coordinator
+origins, stake-zero/full-integer argv, and proved PID/listeners. Keep the worker
+running: the production manifest must be built within six hours of this
+timestamp, and its reward probes target this exact address. A retry accepts only
+byte-identical already-sealed evidence.
 
 A live process or a `degraded` isolated-chain health classification is not a
 reward claim. Record actual registration, assigned work, mined `0x25` receipt,

--- a/docs/PRODUCTION-RECOVERY-AUDIT-2026-08-26.md
+++ b/docs/PRODUCTION-RECOVERY-AUDIT-2026-08-26.md
@@ -153,6 +153,52 @@ checks H/H+1 continuity and restart convergence, and can require a successful
 reward receipt plus receipt-only earnings on every validator.
 Normal SSH and service audit logs may record plan access.
 
+Checkpoint signing has a separate, durable authorization boundary. The six
+validator identities are controlled recovery members, not evidence that six
+independent humans approved the cutover. Immediately before offline signing,
+the repository owner must manually dispatch the read-only, no-secret
+`owner-emergency-recovery-approval.yml` workflow on the exact protected-main
+commit with the inspected checkpoint manifest hash, public-key manifest hash,
+all six ordered public keys, and exact reviewed confirmation. The operator
+API-selects one new exact workflow/path/event/branch/SHA run and attempt whose
+actor and triggering actor are both the pinned owner, waits for that attempt to
+succeed, and preserves the workflow, run, exact-attempt jobs, artifact metadata,
+and digest-bound ZIP as root-owned mode-`0400` evidence in a new mode-`0700`
+directory.
+
+`owner-emergency-recovery.py verify-github-artifact` receives no GitHub token.
+It authenticates those GitHub API facts, the single successful named job, and
+the one-member artifact, then materializes a fresh, create-only
+`arc.recovery.owner-emergency-recovery.v2` receipt owned by the operator at mode
+`0400` with an exact mode-`0400` SHA-256 sidecar. That receipt records the pinned
+repository owner's GitHub-authenticated `owner_emergency_recovery` decision and
+UTC time, fixed reason and risk acknowledgement, protected-main commit,
+checkpoint manifest, H=137145/H+1=137146, recovery epoch/set 1/1, ordered
+validator public identities/stakes, exact five-signature order, unused sixth
+member, and strict stake-supermajority threshold. Matching locally authored
+text is not authorization. This owner emergency receipt is transparent about
+the authority actually exercised. The signing wrapper accepts no intervening
+operation after verification except root/mode/link checks and explicit
+receipt, sidecar, and attempt-directory durability syncs;
+it does not claim six-human approval and does not replace final checkpoint
+signature verification.
+
+Public live claims have a second evidence boundary. The protected-main
+`build-postrelease-public-truth.py` invocation consumes the preserved release
+API; exact Pages workflow/run/attempt/jobs/deployment/status and deployed CDN
+bytes; exact published-acceptance workflow/run/attempt/jobs/artifact metadata
+and digest-bound ZIP; final rollout manifest; and reward evidence. The outer
+artifact contains nine exact top-level/checksum members and an exact 36-file
+recursive evidence set, including the release publication ZIP itself. The
+builder re-aggregates that evidence with its exact sibling acceptance helper
+and immediately runs the exact sibling rollout verifier against all six live
+validators. It then creates exactly three root-only mode-`0400` outputs in a
+new mode-`0700` directory: `arc.post-release-acceptance.v2`, the derived README,
+and `arc.public-production-status.v1`. Only the README and production-status
+paths are committed; the status embeds the full canonical v2 receipt and its
+SHA-256 so the public claims retain their workflow, job, artifact, Pages, and
+recovery identities.
+
 The legacy archive has a separate, earlier freeze authorization because the
 final checkpoint and archive roots cannot truthfully exist before the forked
 fleet is stopped and indexed. `audit-writers` separately binds the exact

--- a/docs/VALIDATOR-FLEET-ROLLOUT.md
+++ b/docs/VALIDATOR-FLEET-ROLLOUT.md
@@ -595,9 +595,11 @@ evidence.
   ciphertext to ARC Drive and a second independent recovery medium, then
   re-download and hash-match both copies. Do not delete the short-lived Actions
   artifact yet. Keep the passphrase environment secret in place while manually
-  dispatching `release-signing-preflight.yml`: its `backup-readiness` job fails
-  unless the 32+-character secret exists, the exact protected-main SHA has one
-  successful backup artifact, that passphrase decrypts it, and both restored
+  dispatching `release-signing-preflight.yml` with the exact successful backup
+  run ID and run attempt: its `backup-readiness` job fails unless the
+  32+-character secret exists, the selected attempt is a successful backup of
+  the exact protected-main SHA, that passphrase decrypts its one attempt-bound
+  artifact, and both restored
   keys match the committed manifest and updater trust roots. After that job is
   green, delete the short-lived backup artifact; the two independently hash-matched
   ciphertext copies remain the recovery media. The same preflight binds every
@@ -610,8 +612,9 @@ evidence.
   The seal requires exactly nine unexpired, nonempty, unique artifact IDs with
   GitHub server SHA-256 digests. Use the Linux x86_64 payload from that selection
   to stage the six validators before updater users can see v0.8. These exact
-  bytes are both rollout inputs and release assets: the tag workflow re-resolves
-  the latest successful exact-commit preflight, pins its run/attempt and all nine
+  bytes are both rollout inputs and release assets: the manual tag workflow
+  requires the operator-selected successful exact-commit preflight run ID and
+  attempt, pins that attempt and all nine
   artifact IDs, downloads raw ZIPs with digest mismatch set to error, independently
   re-hashes them against the selected server digests, safely extracts them, and
   publishes those bytes without an independent release rebuild.
@@ -622,8 +625,12 @@ evidence.
   commit/run/attempt and canonical GGUF, exposes RPC on loopback only, uses all
   six literal-IP HTTPS community origins, and stops only after exact
   PID/executable/argv proof with the full 4,420-second SIGTERM budget. Preserve
-  its registration/work/receipt evidence; a running process alone is not a
-  successful inference or reward canary.
+  its registration/work/receipt evidence; run the helper's create-only
+  `accept` command while the exact process is live, then import the resulting
+  `ACCEPTED.json` without mutating its source. The production builder accepts
+  it for at most six hours and binds its exact worker address and receipt hash
+  into both reward-probe argv and the rollout manifest. A running process alone
+  is not a successful inference or reward canary.
   Only after every job in that exact-SHA preflight succeeds may the owner create
   `v0.8.0` at that SHA. Then delete only the temporary passphrase environment
   secret. Remove the one-shot workflow through a protected PR only after the
@@ -903,7 +910,8 @@ argv/output hashes must verify before any new validator key is installed.
    artifacts with their exact sidecar-bound roots, the reviewed six-host
    known-hosts anchor and explicit
    SSH identity, preserved snapshot/WAL, checkpoint, reviewed Caddy
-   2.11.4 binary, community reward probe, and a new private `--stage-root`.
+   2.11.4 binary, community reward probe, the fresh exact macOS pre-tag
+   `--macos-canary-acceptance` receipt, and a new private `--stage-root`.
    The builder copies every semantic input once through no-follow descriptors,
    fsyncs and seals the tree read-only, and only executes, reproduces, archives,
    or deploys those staged bytes. The builder—not a hand-authored
@@ -1019,28 +1027,33 @@ argv/output hashes must verify before any new validator key is installed.
    threshold and continue advancing through restarts and final publication.
 14. In receipt mode, supply `--reward-evidence-output` before plan/preflight.
    Before submitting anything, fsync the six-node-agreed complete all-v3
-   earnings baseline for every worker the sealed coordinator could select.
-   Immediately re-prove that durable history and require the current selectable
-   worker set to be a subset of the sealed set; this same GET-only check runs
-   after a baseline-only crash resume, so a new worker or unrelated receipt
-   aborts before ordinal one.
+   earnings baseline for the exact worker from the hash-bound macOS acceptance
+   receipt. Immediately re-prove that durable history and require that exact
+   worker to remain live, eligible, and model/profile-matched; this same
+   GET-only check runs after a baseline-only crash resume, so an unavailable
+   accepted worker or unrelated receipt aborts before ordinal one.
    Submit one real one-token job, wait (with the bounded rollout poll) until all
    six report the same `mined_success` 0x25 receipt, then submit the second.
    Require distinct transaction hashes, job IDs, block heights, and block
    hashes for the same worker. Each receipt must be exactly 2.5 ARC =
    2,500,000,000 base units. Every baseline block hash, transaction index, and
-   receipt identity must remain,
-   post-canary count must equal baseline + 2, and lifetime gross must equal
-   baseline + 5 ARC with no third new row. Only the empty-baseline case ends at
-   exactly two receipts; there, all six must report null observed rate and null
+   receipt identity must remain. At or before the canonical block/index cutoff
+   defined by the second canary, count must equal baseline + 2 and gross must
+   equal baseline + 5 ARC. Later verification may see legitimate activity: it
+   accepts a larger history only when all six replicas agree on the complete
+   valid history and every extra receipt is strictly after the sealed cutoff.
+   A foreign earlier row, mutation, omission, or replica disagreement fails
+   closed. At an empty-baseline cutoff there are exactly two receipts; all six
+   must report null observed rate and null
    `projected_daily_arc`, with both reasons exactly
    `collecting data: a projection needs at least 3 successful mined reward receipts spanning at least 24 hours, not the initial one or two rollout canaries`. For a nonempty
    baseline, the complete all-v3 timestamp window controls projection truth: a
    window shorter than 24 hours remains null with the canonical short-window
    reason; a valid window must expose the exact observed rate, and any numeric
    projection must equal that rate times 2.5 ARC. The tool then writes the two
-   identities and selected pre-canary baseline as a create-only, mode-0444,
-   rollout-SHA-bound v2 evidence file and checksum. It then restarts all six archive validators one
+   identities, selected pre-canary baseline, and inclusive canonical
+   block-height/hash/index cutoff as a create-only, mode-0444,
+   rollout-SHA-bound v3 evidence file and checksum. It then restarts all six archive validators one
    at a time, requires continued fleet advancement, and re-proves both receipt
    rows from every restarted process. Same-height/different-hash results are a fork,
    not two blocks, and fail closed. Frontend publication may proceed with the
@@ -1085,10 +1098,12 @@ argv/output hashes must verify before any new validator key is installed.
    and attempt before approval. Record the successful artifact's immutable
    numeric ID and `sha256:` server digest.
    Immediately re-prove immutable releases and unchanged `main`, require the
-   exact direct set `FerrumVir` plus `arisarcmarket`, reduce only
-   `arisarcmarket` to `pull`, and re-query the complete set to prove that the
-   sole non-owner is now `read` with no `write`, `maintain`, or `admin`. An
-   unexpected collaborator fails closed without mutation. Require
+   exact direct set `FerrumVir` plus write-capable `arisarcmarket`, and seal that
+   exact collaborator projection create-only. Reduce only `arisarcmarket` to
+   `pull` for the tag/release authority boundary, then re-query the complete set
+   to prove that the sole non-owner is now `read` with no `write`, `maintain`,
+   or `admin`. A first attempt that finds a reduced reviewer without the sealed
+   baseline, or any unexpected collaborator, fails closed without mutation. Require
    zero pending invitations with any of those roles. Re-query active ruleset
    21690216 as the `~ALL` creation gate with only FerrumVir's owner bypass and
    active ruleset 21667203 as the no-bypass `~ALL` update/deletion/
@@ -1115,8 +1130,11 @@ argv/output hashes must verify before any new validator key is installed.
    unique 32-asset digest-bound contract. The exact production commands and
    API checks are in the recovery README.
 18. Only after the immutable release and its independent read-only verification
-   succeed, publish the preserved recovered frontend bytes in one deterministic
-   reviewable commit and create-only branch. Prefer `arisarcmarket`'s exact-head
+   succeed, restore `arisarcmarket` to the exact sealed pre-tag `write` baseline
+   and verify the complete collaborator projection. GitHub counts a required
+   approval only from a write-capable reviewer; any missing baseline or third
+   state stops without mutation. Then publish the preserved recovered frontend
+   bytes in one deterministic reviewable commit and create-only branch. Prefer `arisarcmarket`'s exact-head
    approval. If unavailable, seal the exact main-ruleset policy, temporarily
    relax only approval count and last-push approval under an EXIT/signal restore
    trap, squash merge, and prove the policy snapshot hash was restored. The new
@@ -1124,12 +1142,48 @@ argv/output hashes must verify before any new validator key is installed.
    reviewed tree/config bytes. API-select the exact successful Pages run and
    jobs, bind its successful `github-pages` deployment, compare the CDN config,
    commit marker, and deployed SHA256SUMS, and re-fetch every advertised archive
-   provenance object field-for-field. Finally run a fresh no-service Linux
-   installer plus already-up-to-date canary and the read-only six-node
-   inference/reward verifier; seal `POST-RELEASE-ACCEPTANCE.json` before
-   unmasking package updates. Rollback by reverting only that config commit,
+   provenance object field-for-field. Dispatch the unprivileged
+   `post-release-acceptance.yml` from the immutable tag and bind its exact
+   successful run/attempt plus canonical artifact ID and `sha256:` digest. It
+   downloads by release asset ID, exercises the real published AppImage and
+   macOS/Windows desktop windows, proves fresh/update-only headless Linux, and
+   uses the digest-pinned real v0.7.7 binary offline to preserve legacy state,
+   model, and history into a fresh v0.8 data namespace. Rebuild its canonical
+   receipt and its exact 36-file recursive evidence set locally, including the
+   API-digest-bound `evidence/release/published-evidence.zip`, before running the
+   independent no-service Linux installer canary and preliminary read-only
+   six-node inference/reward verifier. Preserve all of those inputs for the
+   final v2 acceptance builder in step 19. Rollback by reverting only that config commit,
    which restores maintenance without moving v0.8.0 or rolling back or
    renumbering the canonical chain.
+19. Treat the exact protected-main invocation of
+   `scripts/release/build-postrelease-public-truth.py` as the boundary for
+   public live claims. Supply its complete preserved inputs: README, release
+   API; Pages workflow, exact-attempt run and jobs, Pages API, deployment and
+   statuses; deployed config, commit marker, and SHA256SUMS; published-
+   acceptance workflow, exact-attempt run and jobs, artifact metadata and
+   digest-bound ZIP; reward evidence; and final rollout manifest. It rebuilds
+   the published artifact with the exact sibling helper and performs one final
+   read-only live verification with the exact sibling rollout verifier. Its new
+   private mode-0700 directory contains exactly three create-only mode-0400
+   files: `POST-RELEASE-ACCEPTANCE.json` schema
+   `arc.post-release-acceptance.v2`, `README.md`, and
+   `production-status.json` schema `arc.public-production-status.v1`. The
+   status embeds the complete canonical v2 receipt and binds its hash, so the
+   workflow/run/job/artifact and recovery identities remain publicly
+   verifiable. Retain the standalone receipt as a protected audit copy and
+   publish only `README.md` and `shared/frontend/production-status.json` in a
+   second single-parent PR that changes only those two paths, passes all required
+   checks, and has `arisarcmarket` approval for the exact head; public claims
+   have no ruleset-exception merge path. Because a squash merge cannot embed
+   its own future SHA, bind the resulting main commit separately: API-select
+   the exact second `deploy-explorer.yml` run ID and run attempt, require its
+   two named successful jobs and one successful `github-pages` deployment,
+   then cache-bust and byte-compare the deployed config, production status,
+   and `deployed-commit.txt`. Require deployed `SHA256SUMS` to match all three
+   local hashes and seal `PUBLIC-TRUTH-ACCEPTANCE.json`. The fully executable
+   second-PR, exact-attempt, and CDN-byte procedure is in the recovery README;
+   package-update timers remain masked until it finishes.
 
 Each production validator accepts RPC only on its rollout-derived Unix-domain
 socket. The remote unit passes `--rpc-unix` and omits `--rpc`; the manifest's

--- a/scripts/build-public-site.sh
+++ b/scripts/build-public-site.sh
@@ -52,8 +52,10 @@ fi
 for required in \
     dashboard/index.html dashboard/tailwind.css dashboard/app.css dashboard/app.js \
     explorer/index.html explorer/app.js explorer/styles.css \
-    shared/frontend/arc-network.js shared/frontend/arc-network.json; do
-    [ -s "$required" ] || die "required source is missing or empty: $required"
+    shared/frontend/arc-network.js shared/frontend/arc-network.json \
+    shared/frontend/production-status.json; do
+    [ -f "$required" ] && [ ! -L "$required" ] && [ -s "$required" ] \
+        || die "required source is missing, empty, or not a regular file: $required"
 done
 
 OUTPUT_STAGE_DIR="$(mktemp -d "$OUTPUT_PARENT/.${OUTPUT_BASENAME}.arc-public-site-stage.XXXXXX")" \
@@ -107,6 +109,7 @@ if grep -Fq '../explorer/' "$OUTPUT_DIR/app.js"; then
 fi
 cp -- explorer/index.html explorer/app.js explorer/styles.css "$OUTPUT_DIR/explorer/"
 cp -- shared/frontend/arc-network.js shared/frontend/arc-network.json \
+    shared/frontend/production-status.json \
     "$OUTPUT_DIR/shared/frontend/"
 
 # The legacy wallet is deliberately excluded: it stores a private key in

--- a/scripts/recovery/README.md
+++ b/scripts/recovery/README.md
@@ -244,11 +244,13 @@ The orchestrator:
 11. proves reward-policy agreement and, when selected, two sequential,
    successful mined `0x25` receipts with distinct transaction hashes, job IDs,
    block heights, and block hashes. Before the first canary, it fsyncs the
-   six-node-agreed complete all-v3 earnings baseline for every worker the
-   sealed coordinator could select. The final gate retains every baseline row,
-   adds exactly the two 2.5 ARC (2,500,000,000 base-unit) canaries, and requires
-   lifetime gross to increase by exactly 5 ARC. A zero-row baseline therefore
-   ends at exactly two receipts / 5 ARC and must expose the canonical null
+   six-node-agreed complete all-v3 earnings baseline for the exact worker bound
+   by the fresh macOS acceptance receipt. Through the second canary's canonical
+   block/index cutoff, the final gate requires exactly every baseline row plus
+   the two 2.5 ARC (2,500,000,000 base-unit) canaries and exactly a 5 ARC gross
+   increase. Six-replica-agreed receipts strictly after that cutoff are a valid
+   live superset rather than a rollout failure. A zero-row baseline at the
+   cutoff therefore contains exactly two receipts / 5 ARC and must expose the canonical null
    collecting-data state. A nonempty baseline keeps its historical rows and
    uses the full receipt/timestamp window: a numeric rate is valid only with at
    least three receipts spanning 24 hours, and a numeric projection must equal
@@ -305,10 +307,16 @@ The production blocks in this section are one ordered procedure: materialize
 and re-prove the protected pre-tag release, restore the six-key vault, create
 the verified legacy validator-set copy, prepare/freeze/capture, install the six
 keys, export/sign/checkpoint, build the prearchive, and only then archive. Do
-not run a later block before an earlier one has completed. Run the blocks in
-one reviewed root shell so the verified path/hash variables persist; after a
-shell restart, re-establish them from the sealed files and rerun every
-preceding read-only verification instead of copying values from history.
+not run a later block before an earlier one has completed. Keep one reviewed
+root Bash shell open inside the Ubuntu x86_64 Lima operator VM so its verified
+path/hash variables persist. The one block explicitly marked **native macOS
+shell** runs separately as the logged-in canary user; it never replaces or
+inherits the Lima root shell. After its `limactl copy`, return to the still-open
+Lima shell and run the revalidation block before importing anything. If the
+Lima shell was lost, stop: re-establish its values from the sealed files and
+rerun every preceding read-only verification instead of copying values from
+terminal history. Never run a later block in a fresh shell merely because its
+fenced snippet is individually visible.
 
 Materialize the protected pre-tag inputs on the reviewed Ubuntu x86_64 operator
 enclave first. The nine `actions.zip` files are raw GitHub Actions responses,
@@ -333,6 +341,7 @@ or replacement receipt is accepted from the operator.
 
 ```bash
 set -Eeuo pipefail
+set +x
 test "$(uname -s)" = Linux
 test "$(uname -m)" = x86_64
 test "$(id -u)" = 0
@@ -399,6 +408,14 @@ export ARC_RECOVERY_RCLONE_CONFIG=/secure/operator/rclone-arc.conf
 export ARC_RECOVERY_GH_PATH=/secure/operator/tools/gh
 export ARC_RECOVERY_GH_SHA256=c1be595a7357120e28886922c050fed34ad347c36adf37370ad91d4972a416d5
 export ARC_RECOVERY_GITHUB_LOGIN=FerrumVir
+
+# Pass a phase-local token to exactly one gh invocation. The token is never
+# exported into the long-lived operator shell or placed in a URL/argv.
+arc_scoped_gh() {
+  local github_token="$1"
+  shift
+  GH_TOKEN="$github_token" "$ARC_RECOVERY_GH_PATH" "$@"
+}
 
 arc_install_or_reuse_exact() {
   local completed_path="$1"
@@ -561,15 +578,16 @@ printf '%s  %s\n' \
   6707f8b1dbc1f2d37d9a873a7e3d2c870d2b46db36f15a6df5293547680bfd43 \
   /secure/operator/restore.cert.pem | /usr/bin/sha256sum --check --strict
 
-GH_TOKEN="$(
+unset GH_TOKEN GITHUB_TOKEN
+pretag_gh_token="$(
   "$ARC_RECOVERY_GH_PATH" auth token --hostname github.com \
     --user "$ARC_RECOVERY_GITHUB_LOGIN"
 )"
-test -n "$GH_TOKEN"
-export GH_TOKEN
-test "$("$ARC_RECOVERY_GH_PATH" api /user --jq .login)" = \
+test -n "$pretag_gh_token"
+test "$(arc_scoped_gh "$pretag_gh_token" api /user --jq .login)" = \
   "$ARC_RECOVERY_GITHUB_LOGIN"
-test "$("$ARC_RECOVERY_GH_PATH" api repos/FerrumVir/arc-chain/branches/main \
+test "$(arc_scoped_gh "$pretag_gh_token" api \
+  repos/FerrumVir/arc-chain/branches/main \
   --jq .commit.sha)" = "$protected_main_sha"
 
 git_home="$(/usr/bin/mktemp -d /secure/operator/git-home.XXXXXXXX)"
@@ -601,7 +619,8 @@ rewrap_artifacts_json="$rewrap_download_root/ARTIFACTS.json"
 rewrap_raw_zip="$rewrap_download_root/actions.zip"
 (
   set -o noclobber
-  gh api "repos/FerrumVir/arc-chain/actions/runs/$vault_rewrap_run_id" \
+  arc_scoped_gh "$pretag_gh_token" api \
+    "repos/FerrumVir/arc-chain/actions/runs/$vault_rewrap_run_id/attempts/$vault_rewrap_run_attempt" \
     > "$rewrap_run_json"
 )
 jq -e \
@@ -621,7 +640,7 @@ jq -e \
   ' "$rewrap_run_json" >/dev/null
 (
   set -o noclobber
-  gh api --paginate \
+  arc_scoped_gh "$pretag_gh_token" api --paginate \
     "repos/FerrumVir/arc-chain/actions/runs/$vault_rewrap_run_id/artifacts?per_page=100" \
     --jq '.artifacts[]' | jq -s '{artifacts: .}' > "$rewrap_artifacts_json"
 )
@@ -655,7 +674,8 @@ rewrap_artifact_size="$(jq -er '.size_in_bytes' <<<"$rewrap_artifact_json")"
 test "$rewrap_artifact_size" -le 4194304
 (
   set -o noclobber
-  gh api -H 'Accept: application/vnd.github+json' \
+  arc_scoped_gh "$pretag_gh_token" api \
+    -H 'Accept: application/vnd.github+json' \
     "repos/FerrumVir/arc-chain/actions/artifacts/$rewrap_artifact_id/zip" \
     | /usr/bin/head --bytes="$((rewrap_artifact_size + 1))" > "$rewrap_raw_zip"
 )
@@ -791,7 +811,7 @@ install -d -m 0700 "$pretag_raw_root"
 
 (
   set -o noclobber
-  gh api --paginate \
+  arc_scoped_gh "$pretag_gh_token" api --paginate \
     "repos/FerrumVir/arc-chain/actions/runs/$pretag_run_id/artifacts?per_page=100" \
     --jq '.artifacts[]' | jq -s '{artifacts: .}' > "$pretag_api_json"
 )
@@ -810,7 +830,7 @@ pretag_linux_x86_64_artifact_id="$(
   jq -er '.artifacts["linux-x86_64"].headless.id' "$pretag_selection_json"
 )"
 [[ "$pretag_linux_x86_64_artifact_id" =~ ^[1-9][0-9]*$ ]]
-scripts/release/verify-pretag-run-and-artifacts.sh \
+GH_TOKEN="$pretag_gh_token" scripts/release/verify-pretag-run-and-artifacts.sh \
   FerrumVir/arc-chain \
   "$protected_main_sha" \
   "$pretag_run_id" \
@@ -827,7 +847,8 @@ while IFS=$'\t' read -r kind platform artifact_id artifact_digest artifact_size;
   install -d -m 0700 "$group_root"
   (
     set -o noclobber
-    gh api -H 'Accept: application/vnd.github+json' \
+    arc_scoped_gh "$pretag_gh_token" api \
+      -H 'Accept: application/vnd.github+json' \
       "repos/FerrumVir/arc-chain/actions/artifacts/$artifact_id/zip" \
       | /usr/bin/head --bytes="$((artifact_size + 1))" > "$raw_zip"
   )
@@ -894,7 +915,7 @@ done < <(
     ' > "$pretag_input_set"
 )
 chmod 0400 "$pretag_input_set"
-unset GH_TOKEN
+unset pretag_gh_token
 
 pretag_materialized=/secure/operator/pretag-materialized-v0.8.0
 test ! -e "$pretag_materialized"
@@ -1687,7 +1708,7 @@ Ubuntu `unshare` bytes, creates a new network namespace for every ARC signer
 subprocess, proves `/proc/net/dev` exposes only loopback, proves there is no
 IPv4 route or non-loopback IPv6 route, closes every inherited descriptor above
 standard input/output/error, and only then `execve`s the hash-pinned ARC binary
-with a four-variable clean environment. `GH_TOKEN` is removed before
+with a four-variable clean environment. `GH_TOKEN` and `GITHUB_TOKEN` are removed before
 any checkpoint inspection or signature. Five distinct reviewed keyfiles sign
 in sequence; the sixth remains an unused recovery member. Every invocation
 rechecks the exact Linux binary against the protected build-metadata hash,
@@ -1695,10 +1716,39 @@ retains earlier records, adds only that key's signature, and creates a new
 checkpoint path. The final `recovery verify` authenticates both the five
 identities and strict-stake supermajority.
 
+The six validator identities are not six independent human operators. The old
+terminal phrase asking one person to assert that “all six operators” approved
+was neither durable evidence nor an accurate description of the authority in
+use. This emergency cutover instead records one explicit
+`owner_emergency_recovery` decision authenticated by the pinned repository
+owner's GitHub actor and triggering-actor identities. The no-secret, read-only
+`owner-emergency-recovery-approval.yml` workflow must be manually dispatched by
+`FerrumVir` on the exact protected `main` commit with the checkpoint manifest
+hash, public-key manifest hash, and all six public keys. The workflow accepts
+only the exact reviewed confirmation and emits a short-lived
+`arc.recovery.owner-emergency-recovery.v2` artifact; matching text created
+locally is not authorization.
+
+The operator snapshots the matching run set before dispatch, selects exactly
+one new workflow/path/event/branch/SHA/owner run and attempt, waits for that
+attempt, and downloads the workflow, run, exact-attempt jobs, artifact metadata,
+and digest-bound ZIP into a new root-owned mode-0700 attempt directory. Every
+input file becomes root-owned mode 0400. The protected-main helper then verifies
+those API facts and the one-member ZIP, binds H=137145/H+1=137146, recovery
+epoch/set 1/1, all six ordered validator address/public-key/stake identities,
+the exact five signers, the unused recovery member, and the strict-stake
+threshold, checks a maximum age of 900 seconds, and creates the canonical
+mode-0400 receipt plus sidecar. It receives no GitHub token. The wrapper permits
+only root/mode/link checks and explicit receipt/sidecar/directory durability
+syncs after `verify-github-artifact`; the wrapper call is immediately followed
+by the signing loop.
+This is transparent owner emergency authorization; it does not claim six-human
+approval or replace the checkpoint's five-identity cryptographic verification.
+
 ```bash
 set -Eeuo pipefail
 umask 077
-unset GH_TOKEN
+unset GH_TOKEN GITHUB_TOKEN
 signing_unshare=/usr/bin/unshare
 signing_unshare_sha256=a23c8863860669003dc4660039fe642f5795c8c2195898ebc5d01afa1ac3d11c
 test -f "$signing_unshare" && test ! -L "$signing_unshare"
@@ -1763,12 +1813,210 @@ checkpoint_manifest_hash="$(
     | "$ARC_RECOVERY_PYTHON_PATH" -I -c 'import json,sys; print(json.load(sys.stdin)["manifest_hash"])'
 )"
 [[ "$checkpoint_manifest_hash" =~ ^0x[0-9a-f]{64}$ ]]
-checkpoint_approval_phrase="APPROVE CHECKPOINT $checkpoint_manifest_hash"
-printf 'After all six operators compare it out of band, type exactly: %s\n> ' \
-  "$checkpoint_approval_phrase" >/dev/tty
-IFS= read -r checkpoint_approval </dev/tty
-test "$checkpoint_approval" = "$checkpoint_approval_phrase"
-unset checkpoint_approval
+owner_recovery_helper="$PWD/scripts/recovery/owner-emergency-recovery.py"
+test -f "$owner_recovery_helper" && test ! -L "$owner_recovery_helper"
+test "$(arc_git hash-object "$owner_recovery_helper")" = \
+  "$(arc_git rev-parse "$protected_main_sha:scripts/recovery/owner-emergency-recovery.py")"
+owner_recovery_attempt_root="$(
+  /usr/bin/mktemp -d /secure/operator/owner-emergency-recovery.XXXXXXXX
+)"
+test "$(/usr/bin/stat --format='%U:%G:%a' "$owner_recovery_attempt_root")" = root:root:700
+owner_recovery_workflow_json="$owner_recovery_attempt_root/workflow.json"
+owner_recovery_run_json="$owner_recovery_attempt_root/run.json"
+owner_recovery_jobs_json="$owner_recovery_attempt_root/jobs.json"
+owner_recovery_artifact_json="$owner_recovery_attempt_root/artifact.json"
+owner_recovery_artifact_zip="$owner_recovery_attempt_root/artifact.zip"
+owner_recovery_wait_json="$owner_recovery_attempt_root/run-wait.json"
+owner_recovery_receipt="$owner_recovery_attempt_root/OWNER-EMERGENCY-RECOVERY.json"
+owner_recovery_nyc_public_key="$(/usr/bin/jq -er '.[0].public_key' "$validator_public_keys")"
+owner_recovery_lax_public_key="$(/usr/bin/jq -er '.[1].public_key' "$validator_public_keys")"
+owner_recovery_ams_public_key="$(/usr/bin/jq -er '.[2].public_key' "$validator_public_keys")"
+owner_recovery_lhr_public_key="$(/usr/bin/jq -er '.[3].public_key' "$validator_public_keys")"
+owner_recovery_nrt_public_key="$(/usr/bin/jq -er '.[4].public_key' "$validator_public_keys")"
+owner_recovery_sgp_public_key="$(/usr/bin/jq -er '.[5].public_key' "$validator_public_keys")"
+for owner_recovery_public_key in \
+  "$owner_recovery_nyc_public_key" "$owner_recovery_lax_public_key" \
+  "$owner_recovery_ams_public_key" "$owner_recovery_lhr_public_key" \
+  "$owner_recovery_nrt_public_key" "$owner_recovery_sgp_public_key"
+do
+  [[ "$owner_recovery_public_key" =~ ^[0-9a-f]{64}$ ]]
+done
+set +x
+owner_recovery_gh_token="$(
+  "$ARC_RECOVERY_GH_PATH" auth token --hostname github.com \
+    --user "$ARC_RECOVERY_GITHUB_LOGIN"
+)"
+test -n "$owner_recovery_gh_token"
+test "$(arc_scoped_gh "$owner_recovery_gh_token" api /user --jq \
+  '[.login,.id] | @tsv')" = $'FerrumVir\t111036403'
+test "$(arc_scoped_gh "$owner_recovery_gh_token" api \
+  repos/FerrumVir/arc-chain/branches/main --jq .commit.sha)" = \
+  "$protected_main_sha"
+(
+  set -o noclobber
+  arc_scoped_gh "$owner_recovery_gh_token" api \
+    repos/FerrumVir/arc-chain/actions/workflows/owner-emergency-recovery-approval.yml \
+    > "$owner_recovery_workflow_json"
+)
+/usr/bin/chmod 0400 "$owner_recovery_workflow_json"
+owner_recovery_workflow_id="$(/usr/bin/jq -er \
+  'select(.path == ".github/workflows/owner-emergency-recovery-approval.yml"
+    and .state == "active") | .id' "$owner_recovery_workflow_json")"
+[[ "$owner_recovery_workflow_id" =~ ^[1-9][0-9]*$ ]]
+owner_recovery_run_candidates() {
+  arc_scoped_gh "$owner_recovery_gh_token" api --paginate \
+    'repos/FerrumVir/arc-chain/actions/workflows/owner-emergency-recovery-approval.yml/runs?event=workflow_dispatch&branch=main&per_page=100' \
+    --jq '.workflow_runs[]' \
+    | /usr/bin/jq -cs --arg sha "$protected_main_sha" \
+        --arg title "Owner recovery approval for $protected_main_sha at $checkpoint_manifest_hash" \
+        --argjson workflow_id "$owner_recovery_workflow_id" '
+        [.[] | select(.workflow_id == $workflow_id and .head_sha == $sha
+          and .head_branch == "main"
+          and .path == ".github/workflows/owner-emergency-recovery-approval.yml"
+          and .event == "workflow_dispatch" and .display_title == $title
+          and .actor.login == "FerrumVir" and .actor.id == 111036403
+          and .triggering_actor.login == "FerrumVir"
+          and .triggering_actor.id == 111036403)]'
+}
+owner_recovery_runs_before="$(owner_recovery_run_candidates)"
+owner_recovery_run_ids_before="$(printf '%s' "$owner_recovery_runs_before" \
+  | /usr/bin/jq -c '[.[].id]')"
+arc_scoped_gh "$owner_recovery_gh_token" workflow run \
+  owner-emergency-recovery-approval.yml \
+  --repo FerrumVir/arc-chain --ref main \
+  -f expected_main_sha="$protected_main_sha" \
+  -f checkpoint_manifest_hash="$checkpoint_manifest_hash" \
+  -f validator_public_keys_sha256="$validator_public_keys_sha256" \
+  -f nyc_public_key="$owner_recovery_nyc_public_key" \
+  -f lax_public_key="$owner_recovery_lax_public_key" \
+  -f ams_public_key="$owner_recovery_ams_public_key" \
+  -f lhr_public_key="$owner_recovery_lhr_public_key" \
+  -f nrt_public_key="$owner_recovery_nrt_public_key" \
+  -f sgp_public_key="$owner_recovery_sgp_public_key" \
+  -f confirmation="AUTHORIZE ARC OWNER EMERGENCY RECOVERY $protected_main_sha"
+owner_recovery_new_runs='[]'
+for _ in {1..30}; do
+  /usr/bin/sleep 2
+  owner_recovery_new_runs="$(owner_recovery_run_candidates \
+    | /usr/bin/jq -c --argjson before "$owner_recovery_run_ids_before" \
+        '[.[] | .id as $id | select(($before | index($id)) == null)]')"
+  test "$(printf '%s' "$owner_recovery_new_runs" | /usr/bin/jq -er length)" -eq 0 \
+    || break
+done
+test "$(printf '%s' "$owner_recovery_new_runs" | /usr/bin/jq -er length)" -eq 1
+owner_recovery_run_id="$(printf '%s' "$owner_recovery_new_runs" \
+  | /usr/bin/jq -er '.[0].id')"
+owner_recovery_run_attempt="$(printf '%s' "$owner_recovery_new_runs" \
+  | /usr/bin/jq -er '.[0].run_attempt')"
+[[ "$owner_recovery_run_id" =~ ^[1-9][0-9]*$ ]]
+[[ "$owner_recovery_run_attempt" =~ ^[1-9][0-9]*$ ]]
+(
+  set -o noclobber
+  GH_TOKEN="$owner_recovery_gh_token" scripts/release/wait-workflow-attempt.sh \
+    FerrumVir/arc-chain "$owner_recovery_run_id" \
+    "$owner_recovery_run_attempt" success > "$owner_recovery_wait_json"
+)
+/usr/bin/chmod 0400 "$owner_recovery_wait_json"
+(
+  set -o noclobber
+  arc_scoped_gh "$owner_recovery_gh_token" api \
+    "repos/FerrumVir/arc-chain/actions/runs/$owner_recovery_run_id/attempts/$owner_recovery_run_attempt" \
+    > "$owner_recovery_run_json"
+)
+(
+  set -o noclobber
+  arc_scoped_gh "$owner_recovery_gh_token" api \
+    "repos/FerrumVir/arc-chain/actions/runs/$owner_recovery_run_id/attempts/$owner_recovery_run_attempt/jobs?per_page=100" \
+    > "$owner_recovery_jobs_json"
+)
+/usr/bin/chmod 0400 "$owner_recovery_run_json" "$owner_recovery_jobs_json"
+owner_recovery_artifact_name="arc-owner-emergency-recovery-$protected_main_sha-$owner_recovery_run_id-attempt-$owner_recovery_run_attempt"
+owner_recovery_artifact_candidates='[]'
+for _ in {1..30}; do
+  owner_recovery_artifact_candidates="$(
+    arc_scoped_gh "$owner_recovery_gh_token" api \
+      "repos/FerrumVir/arc-chain/actions/runs/$owner_recovery_run_id/artifacts?per_page=100" \
+      | /usr/bin/jq -c --arg name "$owner_recovery_artifact_name" \
+          --arg sha "$protected_main_sha" --argjson run_id "$owner_recovery_run_id" '
+          [.artifacts[] | select(.name == $name and .expired == false
+            and .workflow_run.id == $run_id and .workflow_run.head_sha == $sha)]'
+  )"
+  test "$(printf '%s' "$owner_recovery_artifact_candidates" \
+    | /usr/bin/jq -er length)" -eq 0 || break
+  /usr/bin/sleep 2
+done
+test "$(printf '%s' "$owner_recovery_artifact_candidates" \
+  | /usr/bin/jq -er length)" -eq 1
+owner_recovery_artifact_id="$(printf '%s' "$owner_recovery_artifact_candidates" \
+  | /usr/bin/jq -er '.[0].id')"
+owner_recovery_artifact_digest="$(printf '%s' "$owner_recovery_artifact_candidates" \
+  | /usr/bin/jq -er '.[0].digest')"
+owner_recovery_artifact_size="$(printf '%s' "$owner_recovery_artifact_candidates" \
+  | /usr/bin/jq -er '.[0].size_in_bytes')"
+[[ "$owner_recovery_artifact_id" =~ ^[1-9][0-9]*$ ]]
+[[ "$owner_recovery_artifact_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+[[ "$owner_recovery_artifact_size" =~ ^[1-9][0-9]*$ ]]
+test "$owner_recovery_artifact_size" -le 4194304
+(
+  set -o noclobber
+  arc_scoped_gh "$owner_recovery_gh_token" api \
+    "repos/FerrumVir/arc-chain/actions/artifacts/$owner_recovery_artifact_id" \
+    > "$owner_recovery_artifact_json"
+)
+(
+  set -o noclobber
+  arc_scoped_gh "$owner_recovery_gh_token" api \
+    -H 'Accept: application/vnd.github+json' \
+    "repos/FerrumVir/arc-chain/actions/artifacts/$owner_recovery_artifact_id/zip" \
+    | /usr/bin/head --bytes="$((owner_recovery_artifact_size + 1))" \
+      > "$owner_recovery_artifact_zip"
+)
+/usr/bin/chmod 0400 "$owner_recovery_artifact_json" "$owner_recovery_artifact_zip"
+test "$(/usr/bin/stat --format='%s' "$owner_recovery_artifact_zip")" = \
+  "$owner_recovery_artifact_size"
+for owner_recovery_input in \
+  "$owner_recovery_workflow_json" "$owner_recovery_run_json" \
+  "$owner_recovery_jobs_json" "$owner_recovery_artifact_json" \
+  "$owner_recovery_artifact_zip" "$owner_recovery_wait_json"
+do
+  test -f "$owner_recovery_input" && test ! -L "$owner_recovery_input"
+  test "$(/usr/bin/stat --format='%U:%G:%a:%h' "$owner_recovery_input")" = \
+    root:root:400:1
+done
+unset GH_TOKEN GITHUB_TOKEN
+unset owner_recovery_gh_token
+verify_owner_recovery_authorization() {
+  printf '%s  %s\n' "$ARC_RECOVERY_PYTHON_SHA256" "$ARC_RECOVERY_PYTHON_PATH" \
+    | /usr/bin/sha256sum --check --strict
+  test "$(arc_git hash-object "$owner_recovery_helper")" = \
+    "$(arc_git rev-parse "$protected_main_sha:scripts/recovery/owner-emergency-recovery.py")"
+  "$ARC_RECOVERY_PYTHON_PATH" -I "$owner_recovery_helper" verify-github-artifact \
+    --workflow-json "$owner_recovery_workflow_json" \
+    --run-json "$owner_recovery_run_json" \
+    --jobs-json "$owner_recovery_jobs_json" \
+    --artifact-json "$owner_recovery_artifact_json" \
+    --artifact-zip "$owner_recovery_artifact_zip" \
+    --run-id "$owner_recovery_run_id" \
+    --run-attempt "$owner_recovery_run_attempt" \
+    --artifact-id "$owner_recovery_artifact_id" \
+    --artifact-digest "$owner_recovery_artifact_digest" \
+    --source-main-sha "$protected_main_sha" \
+    --checkpoint-manifest-hash "$checkpoint_manifest_hash" \
+    --validator-public-keys "$validator_public_keys" \
+    --validator-public-keys-sha256 "$validator_public_keys_sha256" \
+    --output "$owner_recovery_receipt" \
+    --max-age-seconds 900
+  for owner_recovery_output in \
+    "$owner_recovery_receipt" "$owner_recovery_receipt.sha256"
+  do
+    test -f "$owner_recovery_output" && test ! -L "$owner_recovery_output"
+    test "$(/usr/bin/stat --format='%U:%G:%a:%h' "$owner_recovery_output")" = \
+      root:root:400:1
+    /usr/bin/sync -f "$owner_recovery_output"
+  done
+  /usr/bin/sync -f "$owner_recovery_attempt_root"
+}
+verify_owner_recovery_authorization
 for index in "${!signing_keys[@]}"; do
   signing_key="${signing_keys[$index]}"
   outgoing_checkpoint="$signing_attempt_root/candidate.signed-$((index + 1)).arcchkpt"
@@ -1810,6 +2058,334 @@ offline_signer "$arc_node_linux" recovery verify \
   --validator-set-id 1
 test "$(arc_sha256 "$recovery_checkpoint")" = \
   "$(arc_sha256 "$incoming_checkpoint")"
+```
+
+On the Apple Silicon canary host, keep the exact installed pre-tag worker
+running and seal its identity only after `start` and `status` pass. This is the
+only **native macOS shell** block in the production procedure. Run it in a
+separate `/bin/bash` terminal as the logged-in non-root canary user; leave the
+Lima root shell open and untouched. The protected checkout is an absolute host
+path. The transfer uses the concrete absolute local-disk convention
+`$HOME/.arc-recovery-transfer/v0.8.0-<protected-main-sha>`: the private parent is
+owned by the logged-in user and mode 0700, and the per-release directory must be
+new. The home directory must be on the FileVault-protected local Mac disk—not a
+Lima shared mount, cloud-synchronized directory, `/tmp`, or removable FAT/exFAT
+volume. Changing the transfer copy to mode 0400 must not change the create-only
+mode-0600 source.
+
+The block creates one guest-native, create-only drop directory and uses
+`limactl copy --backend=scp` for the two bounded files. `ARC_OPERATOR_LIMA_INSTANCE`
+is the exact reviewed instance name shown by `limactl list`; the literal
+placeholder fails its allowlist and cannot accidentally select `default`:
+
+```bash
+# BEGIN NATIVE MACOS CANARY TRANSFER
+set -Eeuo pipefail
+test -n "${BASH_VERSION:-}"
+test "$(/usr/bin/uname -s)" = Darwin
+test "$(/usr/bin/uname -m)" = arm64
+test "$(/usr/bin/id -u)" -ne 0
+umask 077
+
+ARC_MACOS_PROTECTED_MAIN_SHA='<exact 40-character protected-main SHA after merge>'
+ARC_MACOS_PROTECTED_CHECKOUT='<absolute protected-main checkout on the canary Mac>'
+ARC_OPERATOR_LIMA_INSTANCE='<exact reviewed Lima instance name>'
+[[ "$ARC_MACOS_PROTECTED_MAIN_SHA" =~ ^[0-9a-f]{40}$ ]]
+[[ "$ARC_OPERATOR_LIMA_INSTANCE" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$ ]]
+case "$ARC_MACOS_PROTECTED_CHECKOUT" in /*) ;; *) exit 1 ;; esac
+case "$HOME" in /*) ;; *) exit 1 ;; esac
+test -d "$HOME" && test ! -L "$HOME"
+ARC_CANARY_TRANSFER_PARENT="$HOME/.arc-recovery-transfer"
+if [ ! -e "$ARC_CANARY_TRANSFER_PARENT" ]; then
+  /bin/mkdir -m 0700 "$ARC_CANARY_TRANSFER_PARENT"
+fi
+test -d "$ARC_CANARY_TRANSFER_PARENT" \
+  && test ! -L "$ARC_CANARY_TRANSFER_PARENT"
+test "$(/usr/bin/stat -f '%Lp:%l:%u' "$ARC_CANARY_TRANSFER_PARENT")" = \
+  "700:1:$(/usr/bin/id -u)"
+ARC_CANARY_TRANSFER_ROOT="$ARC_CANARY_TRANSFER_PARENT/v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"
+case "$ARC_CANARY_TRANSFER_ROOT" in "$HOME"/*) ;; *) exit 1 ;; esac
+test -d "$ARC_MACOS_PROTECTED_CHECKOUT" \
+  && test ! -L "$ARC_MACOS_PROTECTED_CHECKOUT"
+test "$(/usr/bin/git -C "$ARC_MACOS_PROTECTED_CHECKOUT" rev-parse HEAD)" = \
+  "$ARC_MACOS_PROTECTED_MAIN_SHA"
+/usr/bin/git -C "$ARC_MACOS_PROTECTED_CHECKOUT" diff-index --quiet HEAD --
+test -z "$(/usr/bin/git -C "$ARC_MACOS_PROTECTED_CHECKOUT" \
+  status --porcelain=v1 --untracked-files=all)"
+macos_canary_helper="$ARC_MACOS_PROTECTED_CHECKOUT/scripts/release/macos-community-canary.py"
+test -x "$macos_canary_helper" && test ! -L "$macos_canary_helper"
+test "$(/usr/bin/git -C "$ARC_MACOS_PROTECTED_CHECKOUT" hash-object \
+  "$macos_canary_helper")" = \
+  "$(/usr/bin/git -C "$ARC_MACOS_PROTECTED_CHECKOUT" rev-parse \
+    "$ARC_MACOS_PROTECTED_MAIN_SHA:scripts/release/macos-community-canary.py")"
+
+"$macos_canary_helper" status
+"$macos_canary_helper" accept
+macos_canary_acceptance_source="$HOME/.arc-pretag-community-canary/evidence/ACCEPTED.json"
+macos_canary_acceptance_transfer_root="$ARC_CANARY_TRANSFER_ROOT"
+macos_canary_acceptance_transfer="$macos_canary_acceptance_transfer_root/MACOS-CANARY-ACCEPTANCE.json"
+test -f "$macos_canary_acceptance_source" && test ! -L "$macos_canary_acceptance_source"
+test "$(/usr/bin/stat -f '%Lp:%l:%u' "$macos_canary_acceptance_source")" = \
+  "600:1:$(/usr/bin/id -u)"
+macos_canary_source_identity="$(/usr/bin/stat -f '%d:%i:%z:%m:%c:%Lp:%l:%u' \
+  "$macos_canary_acceptance_source")"
+macos_canary_acceptance_sha256="$(/usr/bin/shasum -a 256 \
+  "$macos_canary_acceptance_source" | /usr/bin/cut -d ' ' -f 1)"
+[[ "$macos_canary_acceptance_sha256" =~ ^[0-9a-f]{64}$ ]]
+test ! -e "$macos_canary_acceptance_transfer_root" \
+  && test ! -L "$macos_canary_acceptance_transfer_root"
+/bin/mkdir -m 0700 "$macos_canary_acceptance_transfer_root"
+test "$(/usr/bin/stat -f '%Lp:%l:%u' "$macos_canary_acceptance_transfer_root")" = \
+  "700:1:$(/usr/bin/id -u)"
+/bin/cp -p "$macos_canary_acceptance_source" "$macos_canary_acceptance_transfer"
+/bin/chmod 0400 "$macos_canary_acceptance_transfer"
+test "$(/usr/bin/shasum -a 256 "$macos_canary_acceptance_transfer" \
+  | /usr/bin/cut -d ' ' -f 1)" = "$macos_canary_acceptance_sha256"
+test "$(/usr/bin/stat -f '%d:%i:%z:%m:%c:%Lp:%l:%u' \
+  "$macos_canary_acceptance_source")" = "$macos_canary_source_identity"
+(
+  set -o noclobber
+  /usr/bin/printf '%s  %s\n' "$macos_canary_acceptance_sha256" \
+    'MACOS-CANARY-ACCEPTANCE.json' \
+    > "$macos_canary_acceptance_transfer.sha256"
+)
+/bin/chmod 0400 "$macos_canary_acceptance_transfer.sha256"
+test "$(/usr/bin/stat -f '%Lp:%l:%u' "$macos_canary_acceptance_transfer")" = \
+  "400:1:$(/usr/bin/id -u)"
+test "$(/usr/bin/stat -f '%Lp:%l:%u' "$macos_canary_acceptance_transfer.sha256")" = \
+  "400:1:$(/usr/bin/id -u)"
+
+ARC_LIMACTL="$(command -v limactl)"
+case "$ARC_LIMACTL" in /*) ;; *) exit 1 ;; esac
+test -x "$ARC_LIMACTL"
+test "$("$ARC_LIMACTL" shell "$ARC_OPERATOR_LIMA_INSTANCE" \
+  /usr/bin/uname -s)" = Linux
+test "$("$ARC_LIMACTL" shell "$ARC_OPERATOR_LIMA_INSTANCE" \
+  /usr/bin/uname -m)" = x86_64
+lima_canary_drop_root=/var/tmp/arc-macos-canary-import-v0.8.0
+"$ARC_LIMACTL" shell "$ARC_OPERATOR_LIMA_INSTANCE" \
+  /usr/bin/test '!' -e "$lima_canary_drop_root"
+"$ARC_LIMACTL" shell "$ARC_OPERATOR_LIMA_INSTANCE" \
+  /usr/bin/install -d -m 0700 "$lima_canary_drop_root"
+"$ARC_LIMACTL" copy --backend=scp \
+  "$macos_canary_acceptance_transfer" \
+  "$macos_canary_acceptance_transfer.sha256" \
+  "$ARC_OPERATOR_LIMA_INSTANCE:$lima_canary_drop_root/"
+/usr/bin/printf 'Copied the canary receipt into %s:%s; return to the open Lima root shell.\n' \
+  "$ARC_OPERATOR_LIMA_INSTANCE" "$lima_canary_drop_root"
+# END NATIVE MACOS CANARY TRANSFER
+```
+
+Return to the already-open **Lima root shell**. Re-arm strict mode and re-prove
+the shell, checkout, package masks, and every transport byte that the following
+builder can use. The `${name:?message}` guards intentionally stop if the Lima
+shell was replaced instead of retained. The import source is the fixed
+guest-native `/var/tmp` drop created above; never substitute a `/Users/...` or
+other host-shared path.
+
+The importer opens the drop directory and both files without following links,
+requires a private single-link file pair, checks the exact Mac sidecar bytes,
+publishes the canonical receipt root-owned and mode 0400 with `O_EXCL`, fsyncs
+it, and re-hashes the stable target. It never chmods or otherwise mutates the
+drop. Build the manifest within six hours of the receipt timestamp and leave
+the Mac canary running through both reward probes:
+
+```bash
+# BEGIN LIMA ROOT SHELL REVALIDATION AND MACOS RECEIPT IMPORT
+set -Eeuo pipefail
+set +x
+test "$(/usr/bin/uname -s)" = Linux
+test "$(/usr/bin/uname -m)" = x86_64
+test "$(/usr/bin/id -u)" = 0
+umask 077
+export PATH=/secure/operator/tools:/usr/bin:/bin
+: "${operator_checkout:?the original Lima root shell was lost}"
+: "${protected_main_sha:?the protected-main identity is unavailable}"
+: "${rclone_config_sha256:?the reviewed rclone identity is unavailable}"
+: "${ARC_RECOVERY_PYTHON_PATH:?the reviewed Python path is unavailable}"
+: "${ARC_RECOVERY_GH_PATH:?the reviewed gh path is unavailable}"
+declare -F arc_sha256 >/dev/null
+declare -F arc_git >/dev/null
+declare -F arc_scoped_gh >/dev/null
+test "$PWD" = "$operator_checkout"
+test "$(arc_git -C "$operator_checkout" rev-parse HEAD)" = "$protected_main_sha"
+arc_git -C "$operator_checkout" diff-index --quiet HEAD --
+test -z "$(arc_git -C "$operator_checkout" status \
+  --porcelain=v1 --untracked-files=all)"
+for unit in "${operator_package_units[@]}"; do
+  test "$(/usr/bin/systemctl show --value --property=LoadState "$unit")" = masked
+  test "$(/usr/bin/systemctl show --value --property=ActiveState "$unit")" = inactive
+  test "$(/usr/bin/systemctl show --value --property=UnitFileState "$unit")" = masked-runtime
+done
+printf '%s  %s\n' "$ARC_RECOVERY_PYTHON_SHA256" "$ARC_RECOVERY_PYTHON_PATH" \
+  | /usr/bin/sha256sum --check --strict
+printf '%s  %s\n' "$ARC_RECOVERY_GH_SHA256" "$ARC_RECOVERY_GH_PATH" \
+  | /usr/bin/sha256sum --check --strict
+printf '%s  %s\n' "$ARC_RECOVERY_SSH_SHA256" /usr/bin/ssh \
+  | /usr/bin/sha256sum --check --strict
+printf '%s  %s\n' "$ARC_RECOVERY_SCP_SHA256" /usr/bin/scp \
+  | /usr/bin/sha256sum --check --strict
+printf '%s  %s\n' "$ARC_RECOVERY_RCLONE_SHA256" "$ARC_RECOVERY_RCLONE_PATH" \
+  | /usr/bin/sha256sum --check --strict
+printf '%s  %s\n' "$ARC_RECOVERY_SSH_KNOWN_HOSTS_SHA256" \
+  "$ARC_RECOVERY_SSH_KNOWN_HOSTS" | /usr/bin/sha256sum --check --strict
+printf '%s  %s\n' "$ARC_RECOVERY_SSH_IDENTITY_SHA256" \
+  "$ARC_RECOVERY_SSH_IDENTITY" | /usr/bin/sha256sum --check --strict
+test "$(arc_sha256 "$ARC_RECOVERY_RCLONE_CONFIG")" = "$rclone_config_sha256"
+unset GH_TOKEN GITHUB_TOKEN
+
+lima_canary_drop_root=/var/tmp/arc-macos-canary-import-v0.8.0
+macos_canary_acceptance_import="$lima_canary_drop_root/MACOS-CANARY-ACCEPTANCE.json"
+macos_canary_acceptance_import_sidecar="$macos_canary_acceptance_import.sha256"
+macos_canary_acceptance=/secure/operator/MACOS-CANARY-ACCEPTANCE.json
+test -d "$lima_canary_drop_root" && test ! -L "$lima_canary_drop_root"
+test "$(/usr/bin/stat --format='%a:%h' "$lima_canary_drop_root")" = 700:1
+test -f "$macos_canary_acceptance_import" \
+  && test ! -L "$macos_canary_acceptance_import"
+test -f "$macos_canary_acceptance_import_sidecar" \
+  && test ! -L "$macos_canary_acceptance_import_sidecar"
+test "$(/usr/bin/stat --format='%a:%h' "$macos_canary_acceptance_import")" = 400:1
+test "$(/usr/bin/stat --format='%a:%h' \
+  "$macos_canary_acceptance_import_sidecar")" = 400:1
+macos_canary_acceptance_sha256="$(
+"$ARC_RECOVERY_PYTHON_PATH" -I - \
+  "$macos_canary_acceptance_import" \
+  "$macos_canary_acceptance_import_sidecar" \
+  "$macos_canary_acceptance" <<'PY'
+import hashlib
+import os
+import pathlib
+import re
+import stat
+import sys
+
+source = pathlib.Path(sys.argv[1])
+sidecar = pathlib.Path(sys.argv[2])
+target = pathlib.Path(sys.argv[3])
+if (
+    not source.is_absolute()
+    or not sidecar.is_absolute()
+    or not target.is_absolute()
+    or source.name != "MACOS-CANARY-ACCEPTANCE.json"
+    or sidecar != pathlib.Path(str(source) + ".sha256")
+):
+    raise SystemExit("Mac canary import paths are not the exact absolute pair")
+
+nofollow = os.O_NOFOLLOW
+directory_flags = os.O_RDONLY | os.O_DIRECTORY | nofollow
+source_parent_fd = os.open(source.parent, directory_flags)
+target_parent_fd = os.open(target.parent, directory_flags)
+
+def read_stable(parent_fd, name, limit, label):
+    descriptor = os.open(name, os.O_RDONLY | nofollow, dir_fd=parent_fd)
+    try:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or stat.S_IMODE(before.st_mode) != 0o400
+            or before.st_nlink != 1
+            or before.st_size < 1
+            or before.st_size > limit
+        ):
+            raise SystemExit(f"{label} is not one bounded mode-0400 regular file")
+        payload = b""
+        while len(payload) < before.st_size:
+            chunk = os.read(descriptor, before.st_size - len(payload))
+            if not chunk:
+                raise SystemExit(f"{label} ended early")
+            payload += chunk
+        after = os.fstat(descriptor)
+        identity = lambda row: (
+            row.st_dev, row.st_ino, row.st_mode, row.st_uid, row.st_gid,
+            row.st_nlink, row.st_size, row.st_mtime_ns, row.st_ctime_ns,
+        )
+        if identity(before) != identity(after):
+            raise SystemExit(f"{label} changed while read")
+        return payload, before
+    finally:
+        os.close(descriptor)
+
+try:
+    source_parent = os.fstat(source_parent_fd)
+    if (
+        not stat.S_ISDIR(source_parent.st_mode)
+        or stat.S_IMODE(source_parent.st_mode) != 0o700
+    ):
+        raise SystemExit("Mac canary drop is not one private mode-0700 directory")
+    target_parent = os.fstat(target_parent_fd)
+    if (
+        not stat.S_ISDIR(target_parent.st_mode)
+        or (target_parent.st_uid, target_parent.st_gid) != (0, 0)
+        or stat.S_IMODE(target_parent.st_mode) & 0o022
+    ):
+        raise SystemExit("canonical Mac canary parent is not protected root storage")
+    payload, source_stat = read_stable(
+        source_parent_fd, source.name, 65536, "Mac canary acceptance import"
+    )
+    sidecar_payload, sidecar_stat = read_stable(
+        source_parent_fd, sidecar.name, 256, "Mac canary acceptance sidecar"
+    )
+    if (source_stat.st_uid, source_stat.st_gid) != (
+        sidecar_stat.st_uid, sidecar_stat.st_gid
+    ):
+        raise SystemExit("Mac canary import pair has different owners")
+    match = re.fullmatch(
+        rb"([0-9a-f]{64})  MACOS-CANARY-ACCEPTANCE[.]json\n", sidecar_payload
+    )
+    if match is None:
+        raise SystemExit("Mac canary sidecar is not the exact canonical line")
+    expected = match.group(1).decode("ascii")
+    if hashlib.sha256(payload).hexdigest() != expected:
+        raise SystemExit("Mac canary acceptance source digest differs")
+    try:
+        target_fd = os.open(
+            target.name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow,
+            0o400,
+            dir_fd=target_parent_fd,
+        )
+    except FileExistsError:
+        existing, existing_stat = read_stable(
+            target_parent_fd, target.name, 65536, "canonical Mac canary acceptance"
+        )
+        if (
+            existing != payload
+            or (existing_stat.st_uid, existing_stat.st_gid) != (0, 0)
+        ):
+            raise SystemExit(
+                "canonical Mac canary acceptance already exists with different identity"
+            )
+    else:
+        try:
+            offset = 0
+            while offset < len(payload):
+                offset += os.write(target_fd, payload[offset:])
+            os.fchmod(target_fd, 0o400)
+            os.fsync(target_fd)
+        finally:
+            os.close(target_fd)
+        os.fsync(target_parent_fd)
+    final_payload, final_stat = read_stable(
+        target_parent_fd, target.name, 65536, "canonical Mac canary acceptance"
+    )
+    if (
+        hashlib.sha256(final_payload).hexdigest() != expected
+        or (final_stat.st_uid, final_stat.st_gid) != (0, 0)
+    ):
+        raise SystemExit("canonical Mac canary acceptance target digest/owner differs")
+    print(expected)
+finally:
+    os.close(source_parent_fd)
+    os.close(target_parent_fd)
+PY
+)"
+[[ "$macos_canary_acceptance_sha256" =~ ^[0-9a-f]{64}$ ]]
+test "$(arc_sha256 "$macos_canary_acceptance_import")" = \
+  "$(arc_sha256 "$macos_canary_acceptance")"
+test "$macos_canary_acceptance_sha256" = \
+  "$(arc_sha256 "$macos_canary_acceptance")"
+test "$(/usr/bin/stat --format='%U:%a:%h' "$macos_canary_acceptance")" = root:400:1
+# END LIMA ROOT SHELL REVALIDATION AND MACOS RECEIPT IMPORT
 ```
 
 Build the prearchive production manifest only from protected-main and sealed
@@ -1857,6 +2433,7 @@ if [ "$prearchive_existing" = 0 ]; then
       --source-wal "$reference_pair/state.wal" \
       --caddy "$caddy_binary" \
       --reward-probe "$PWD/scripts/recovery/community-reward-probe.py" \
+      --macos-canary-acceptance "$macos_canary_acceptance" \
       --stage-root "$production_stage_root" \
       --acme-email tj@arc.ai \
       --output "$prearchive_output"
@@ -2326,17 +2903,37 @@ owner marker.
 
 The rollout generates the archive unit, nginx filter, and Caddy route from the
 sealed node identity; no environment file or hand-edited path is accepted.
-After a successful rollout, these are useful independent diagnostics (replace
-`<generated-unit>`, `<archive-rpc-socket>`, `<sealed-validator-origin>`, and
-`<node>` with the values printed by the plan):
+After a successful rollout, these are useful independent diagnostics. First,
+from the Lima operator VM use the already pinned identity and known-hosts file
+to open a root shell on one selected validator; do not run its `systemctl` or
+Unix-socket checks on the operator VM. On that validator, replace
+`<generated-unit>` and `<archive-rpc-socket>` with the values printed for the
+same node by the plan:
 
 ```bash
-sudo systemctl is-active '<generated-unit>'
-sudo curl --fail --silent --unix-socket '<archive-rpc-socket>' 'http://localhost/provenance' | jq -e \
+# ON THE SELECTED VALIDATOR ROOT SHELL
+/usr/bin/systemctl is-active '<generated-unit>'
+/usr/bin/curl --fail --silent --unix-socket '<archive-rpc-socket>' \
+  'http://localhost/provenance' | /usr/bin/jq -e \
   '.schema == "arc.legacy-archive.query.v1" and .read_only == true and .classification == "valid_noncanonical_fork"'
-test "$(sudo curl --unix-socket '<archive-rpc-socket>' -sS -o /dev/null -w '%{http_code}' -I 'http://localhost/provenance')" = 405
-test "$(sudo curl --unix-socket '<archive-rpc-socket>' -sS -o /dev/null -w '%{http_code}' -X POST 'http://localhost/provenance')" = 405
-curl --fail --silent "https://<sealed-validator-origin>/legacy/<node>/provenance" | jq -e '.read_only == true'
+test "$(/usr/bin/curl --unix-socket '<archive-rpc-socket>' -sS \
+  -o /dev/null -w '%{http_code}' -I 'http://localhost/provenance')" = 405
+test "$(/usr/bin/curl --unix-socket '<archive-rpc-socket>' -sS \
+  -o /dev/null -w '%{http_code}' -X POST 'http://localhost/provenance')" = 405
+```
+
+Exit that validator shell and run the public-vantage request back in the Lima
+operator VM. The origin placeholder is the complete sealed `https://` origin,
+not a bare host to which another scheme should be prepended; `<node>` is the
+matching sealed node name:
+
+```bash
+# BACK IN THE LIMA OPERATOR ROOT SHELL
+sealed_validator_origin='<exact sealed https:// origin printed by the plan>'
+case "$sealed_validator_origin" in https://*) ;; *) exit 1 ;; esac
+/usr/bin/curl --fail --silent \
+  "$sealed_validator_origin/legacy/<node>/provenance" \
+  | /usr/bin/jq -e '.read_only == true'
 ```
 
 The production process has no TCP listener and has no node state, WAL, P2P,
@@ -2437,15 +3034,15 @@ write_once_or_compare() {
 /usr/bin/install -m 0400 "$recovery_checkpoint" \
   "$full_handoff_dir/recovery.arcchkpt"
 
-GH_TOKEN="$(
+release_gh_token="$(
   "$ARC_RECOVERY_GH_PATH" auth token --hostname github.com \
     --user "$ARC_RECOVERY_GITHUB_LOGIN"
 )"
-test -n "$GH_TOKEN"
-test "$(GH_TOKEN="$GH_TOKEN" "$ARC_RECOVERY_GH_PATH" api \
+test -n "$release_gh_token"
+test "$(arc_scoped_gh "$release_gh_token" api \
   repos/FerrumVir/arc-chain/branches/main --jq .commit.sha)" = "$protected_main_sha"
 handoff_receipt="$(
-  GH_TOKEN="$GH_TOKEN" "$ARC_RECOVERY_PYTHON_PATH" -I \
+  GH_TOKEN="$release_gh_token" "$ARC_RECOVERY_PYTHON_PATH" -I \
     scripts/release/create-cutover-handoff-commit.py \
     --repository-root "$operator_checkout" \
     --full-handoff-dir "$full_handoff_dir" \
@@ -2470,11 +3067,11 @@ test "$(arc_git -C "$operator_checkout" rev-list --parents -n 1 \
   "$handoff_commit_sha")" = "$handoff_commit_sha $protected_main_sha"
 test -z "$(arc_git -C "$operator_checkout" status --porcelain=v1 --untracked-files=all)"
 
-handoff_workflow_id="$("$ARC_RECOVERY_GH_PATH" api \
+handoff_workflow_id="$(arc_scoped_gh "$release_gh_token" api \
   repos/FerrumVir/arc-chain/actions/workflows/recovery-release-handoff.yml --jq .id)"
 [[ "$handoff_workflow_id" =~ ^[1-9][0-9]*$ ]]
 handoff_run_candidates() {
-  "$ARC_RECOVERY_GH_PATH" api --paginate \
+  arc_scoped_gh "$release_gh_token" api --paginate \
     'repos/FerrumVir/arc-chain/actions/workflows/recovery-release-handoff.yml/runs?event=workflow_dispatch&branch=main&per_page=100' \
     --jq '.workflow_runs[]' \
   | /usr/bin/jq -cs --arg sha "$protected_main_sha" \
@@ -2489,7 +3086,7 @@ handoff_runs="$(handoff_run_candidates)"
 handoff_run_count="$(printf '%s' "$handoff_runs" | /usr/bin/jq -er length)"
 case "$handoff_run_count" in
   0)
-    GH_TOKEN="$GH_TOKEN" "$ARC_RECOVERY_GH_PATH" workflow run recovery-release-handoff.yml \
+    arc_scoped_gh "$release_gh_token" workflow run recovery-release-handoff.yml \
       --repo FerrumVir/arc-chain \
       --ref main \
       -f handoff_commit_sha="$handoff_commit_sha"
@@ -2524,8 +3121,9 @@ handoff_run_attempt="$(printf '%s' "$handoff_runs" | /usr/bin/jq -er '.[0].run_a
   | write_once_or_compare "$release_control_root/HANDOFF-RUN-SELECTION.json"
 printf 'Approve only handoff run %s attempt %s, then wait here.\n' \
   "$handoff_run_id" "$handoff_run_attempt"
-"$ARC_RECOVERY_GH_PATH" run watch "$handoff_run_id" \
-  --repo FerrumVir/arc-chain --interval 10 --exit-status
+GH_TOKEN="$release_gh_token" scripts/release/wait-workflow-attempt.sh \
+  FerrumVir/arc-chain "$handoff_run_id" "$handoff_run_attempt" success \
+  > "$release_control_root/HANDOFF-RUN-FINAL.json"
 ```
 
 Approve that one exact `release`-environment deployment, wait for the
@@ -2536,8 +3134,8 @@ GitHub server digest; values copied only from a log line are not release
 inputs.
 
 ```bash
-"$ARC_RECOVERY_GH_PATH" api \
-  "repos/FerrumVir/arc-chain/actions/runs/$handoff_run_id" \
+arc_scoped_gh "$release_gh_token" api \
+  "repos/FerrumVir/arc-chain/actions/runs/$handoff_run_id/attempts/$handoff_run_attempt" \
   | /usr/bin/jq -e --arg sha "$protected_main_sha" --argjson id "$handoff_run_id" \
       --argjson attempt "$handoff_run_attempt" --argjson workflow_id "$handoff_workflow_id" \
       '.id == $id and .workflow_id == $workflow_id
@@ -2547,10 +3145,11 @@ inputs.
        and .event == "workflow_dispatch" and .run_attempt == $attempt
        and .status == "completed" and .conclusion == "success"' >/dev/null
 handoff_artifact_json="$(
-  "$ARC_RECOVERY_GH_PATH" api --paginate \
+  arc_scoped_gh "$release_gh_token" api --paginate \
     "repos/FerrumVir/arc-chain/actions/runs/$handoff_run_id/artifacts?per_page=100" \
     --jq '.artifacts[]' \
-  | /usr/bin/jq -cs --arg name "arc-recovery-release-handoff-$protected_main_sha" \
+  | /usr/bin/jq -cs \
+      --arg name "arc-recovery-release-handoff-$protected_main_sha-$handoff_run_id-$handoff_run_attempt" \
       --arg sha "$protected_main_sha" --argjson run_id "$handoff_run_id" \
       '[.[] | select(.name == $name and .expired == false
           and .workflow_run.id == $run_id and .workflow_run.head_sha == $sha
@@ -2567,10 +3166,14 @@ handoff_artifact_digest="$(printf '%s' "$handoff_artifact_json" | /usr/bin/jq -e
 
 Immediately before tag creation, re-prove the owner session and immutable-release
 setting, require the exact direct-collaborator set `FerrumVir` plus
-`arisarcmarket`, and use one bounded owner API call to reduce only
-`arisarcmarket` to `pull`. Then re-query the complete set to prove that the sole
-non-owner retains no `write`, `maintain`, or `admin`. An unexpected collaborator
-fails closed instead of being silently mutated. Also prove unchanged protected `main` and the
+write-capable reviewer `arisarcmarket`, and seal that exact collaborator
+baseline create-only. Use one bounded owner API call to reduce only
+`arisarcmarket` to `pull` for the tag and release authority boundary. Then
+re-query the complete set to prove that the sole non-owner retains no `write`,
+`maintain`, or `admin`. The sealed baseline makes the later restoration exact;
+a first attempt that finds the reviewer already reduced without that receipt,
+or any unexpected collaborator, fails closed instead of guessing or silently
+mutating state. Also prove unchanged protected `main` and the
 remote absence of both the tag and its release. If any check fails, do not
 create the tag. Create the lightweight protected tag with one isolated,
 authenticated Git push to the exact credential-free HTTPS URL. The push clears
@@ -2581,42 +3184,72 @@ the remote ref after every push result instead of treating the Git exit status
 as the final proof.
 
 ```bash
-test "$("$ARC_RECOVERY_GH_PATH" api /user --jq .login)" = FerrumVir
-test "$("$ARC_RECOVERY_GH_PATH" api \
+test "$(arc_scoped_gh "$release_gh_token" api /user --jq .login)" = FerrumVir
+test "$(arc_scoped_gh "$release_gh_token" api \
   repos/FerrumVir/arc-chain/immutable-releases --jq .enabled)" = true
-test "$("$ARC_RECOVERY_GH_PATH" api repos/FerrumVir/arc-chain/branches/main \
+test "$(arc_scoped_gh "$release_gh_token" api \
+  repos/FerrumVir/arc-chain/branches/main \
   --jq .commit.sha)" = "$protected_main_sha"
-direct_collaborators_before="$(
-  "$ARC_RECOVERY_GH_PATH" api --paginate \
+direct_collaborator_projection() {
+  local github_token="$1"
+  arc_scoped_gh "$github_token" api --paginate \
     'repos/FerrumVir/arc-chain/collaborators?affiliation=direct&per_page=100' \
-    --jq '.[]' | /usr/bin/jq -cs 'sort_by(.login)'
+    --jq '.[]' \
+    | /usr/bin/jq -cs \
+        'map({login,id,role_name,permissions}) | sort_by(.login)'
+}
+direct_collaborators_before="$(direct_collaborator_projection "$release_gh_token")"
+pretag_collaborator_baseline_receipt="$release_control_root/PRETAG-COLLABORATOR-BASELINE.json"
+if [ ! -e "$pretag_collaborator_baseline_receipt" ]; then
+  printf '%s' "$direct_collaborators_before" | /usr/bin/jq -e '
+    length == 2 and .[0].login == "FerrumVir" and .[0].permissions.admin == true
+    and .[1].login == "arisarcmarket" and .[1].role_name == "write"
+    and .[1].permissions.pull == true and .[1].permissions.push == true
+    and .[1].permissions.maintain == false and .[1].permissions.admin == false' \
+    >/dev/null
+  printf '%s' "$direct_collaborators_before" \
+    | write_once_or_compare "$pretag_collaborator_baseline_receipt"
+fi
+test -f "$pretag_collaborator_baseline_receipt" \
+  && test ! -L "$pretag_collaborator_baseline_receipt"
+test "$(/usr/bin/stat --format='%a:%h' "$pretag_collaborator_baseline_receipt")" = 400:1
+pretag_collaborator_baseline="$(
+  /usr/bin/jq -cS . "$pretag_collaborator_baseline_receipt"
 )"
-printf '%s' "$direct_collaborators_before" | /usr/bin/jq -e '
+printf '%s' "$pretag_collaborator_baseline" | /usr/bin/jq -e '
   length == 2 and .[0].login == "FerrumVir" and .[0].permissions.admin == true
-  and .[1].login == "arisarcmarket"
-  and (.[1].role_name == "write" or .[1].role_name == "read")' >/dev/null
-"$ARC_RECOVERY_GH_PATH" api --method PUT \
+  and .[1].login == "arisarcmarket" and .[1].role_name == "write"
+  and .[1].permissions.pull == true and .[1].permissions.push == true
+  and .[1].permissions.maintain == false and .[1].permissions.admin == false' \
+  >/dev/null
+pretag_collaborator_reduced="$(printf '%s' "$pretag_collaborator_baseline" \
+  | /usr/bin/jq -cS '
+      .[1].role_name = "read"
+      | .[1].permissions.pull = true
+      | .[1].permissions.push = false
+      | .[1].permissions.maintain = false
+      | .[1].permissions.admin = false')"
+case "$direct_collaborators_before" in
+  "$pretag_collaborator_baseline"|"$pretag_collaborator_reduced") ;;
+  *)
+    printf 'collaborators differ from both sealed baseline and exact reduced state; preserve and stop\n' >&2
+    exit 1
+    ;;
+esac
+arc_scoped_gh "$release_gh_token" api --method PUT \
   repos/FerrumVir/arc-chain/collaborators/arisarcmarket \
   -f permission=pull >/dev/null
-direct_collaborators_after="$(
-  "$ARC_RECOVERY_GH_PATH" api --paginate \
-    'repos/FerrumVir/arc-chain/collaborators?affiliation=direct&per_page=100' \
-    --jq '.[]' | /usr/bin/jq -cs 'sort_by(.login)'
-)"
-printf '%s' "$direct_collaborators_after" | /usr/bin/jq -e '
-  length == 2 and .[0].login == "FerrumVir" and .[0].permissions.admin == true
-  and .[1].login == "arisarcmarket" and .[1].role_name == "read"
-  and .[1].permissions.pull == true and .[1].permissions.push == false
-  and .[1].permissions.maintain == false and .[1].permissions.admin == false' >/dev/null
+direct_collaborators_after="$(direct_collaborator_projection "$release_gh_token")"
+test "$direct_collaborators_after" = "$pretag_collaborator_reduced"
 pending_writer_invitations="$(
-  "$ARC_RECOVERY_GH_PATH" api --paginate \
+  arc_scoped_gh "$release_gh_token" api --paginate \
     'repos/FerrumVir/arc-chain/invitations?per_page=100' --jq '.[]' \
   | /usr/bin/jq -cs \
       '[.[] | select(.permissions == "write" or .permissions == "maintain"
                      or .permissions == "admin")] | length'
 )"
 test "$pending_writer_invitations" = 0
-remote_tag_before="$("$ARC_RECOVERY_GH_PATH" api \
+remote_tag_before="$(arc_scoped_gh "$release_gh_token" api \
   repos/FerrumVir/arc-chain/git/matching-refs/tags/v0.8.0 --jq .)"
 remote_tag_state="$(printf '%s' "$remote_tag_before" | /usr/bin/jq -er \
   --arg sha "$protected_main_sha" '
@@ -2635,12 +3268,12 @@ case "$remote_tag_state" in
   *) exit 1 ;;
 esac
 remote_release_count="$(
-  "$ARC_RECOVERY_GH_PATH" api --paginate \
+  arc_scoped_gh "$release_gh_token" api --paginate \
     'repos/FerrumVir/arc-chain/releases?per_page=100' --jq '.[]' \
   | /usr/bin/jq -cs '[.[] | select(.tag_name == "v0.8.0")] | length'
 )"
 test "$remote_release_count" = 0
-creation_ruleset="$("$ARC_RECOVERY_GH_PATH" api \
+creation_ruleset="$(arc_scoped_gh "$release_gh_token" api \
   repos/FerrumVir/arc-chain/rulesets/21690216)"
 printf '%s' "$creation_ruleset" | /usr/bin/jq -e '
   .id == 21690216 and .name == "Restrict all ARC tag creation"
@@ -2649,7 +3282,7 @@ printf '%s' "$creation_ruleset" | /usr/bin/jq -e '
   and .rules == [{"type":"creation"}]
   and .bypass_actors == [{"actor_id":111036403,"actor_type":"User",
                           "bypass_mode":"always"}]' >/dev/null
-mutation_ruleset="$("$ARC_RECOVERY_GH_PATH" api \
+mutation_ruleset="$(arc_scoped_gh "$release_gh_token" api \
   repos/FerrumVir/arc-chain/rulesets/21667203)"
 printf '%s' "$mutation_ruleset" | /usr/bin/jq -e '
   .id == 21667203 and .name == "Protect all ARC tags from mutation"
@@ -2670,7 +3303,7 @@ if [ "$remote_tag_state" = absent ]; then
     set -o noclobber
     /usr/bin/env -i \
       HOME="$git_home" PATH=/usr/bin:/bin LANG=C LC_ALL=C TZ=UTC \
-      GH_TOKEN="$GH_TOKEN" GH_PROMPT_DISABLED=1 \
+      GH_TOKEN="$release_gh_token" GH_PROMPT_DISABLED=1 \
       GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null \
       GIT_TERMINAL_PROMPT=0 \
       /usr/bin/git -C "$operator_checkout" \
@@ -2689,7 +3322,7 @@ if [ "$remote_tag_state" = absent ]; then
         >"$tag_push_stdout" 2>"$tag_push_stderr"
   ) || tag_ref_push_status=$?
 fi
-remote_tag_after="$("$ARC_RECOVERY_GH_PATH" api \
+remote_tag_after="$(arc_scoped_gh "$release_gh_token" api \
   repos/FerrumVir/arc-chain/git/matching-refs/tags/v0.8.0 --jq .)"
 remote_tag_after_state="$(printf '%s' "$remote_tag_after" | /usr/bin/jq -er \
   --arg sha "$protected_main_sha" '
@@ -2726,11 +3359,11 @@ from the UI. An exact existing selection is resumable; zero or multiple runs
 after the bounded discovery poll stop without moving or re-pushing the tag.
 
 ```bash
-release_workflow_id="$("$ARC_RECOVERY_GH_PATH" api \
+release_workflow_id="$(arc_scoped_gh "$release_gh_token" api \
   repos/FerrumVir/arc-chain/actions/workflows/release.yml --jq .id)"
 [[ "$release_workflow_id" =~ ^[1-9][0-9]*$ ]]
 tag_push_run_candidates() {
-  "$ARC_RECOVERY_GH_PATH" api --paginate \
+  arc_scoped_gh "$release_gh_token" api --paginate \
     'repos/FerrumVir/arc-chain/actions/workflows/release.yml/runs?event=push&branch=v0.8.0&per_page=100' \
     --jq '.workflow_runs[]' \
   | /usr/bin/jq -cs --arg sha "$protected_main_sha" \
@@ -2759,10 +3392,11 @@ tag_push_run_attempt="$(printf '%s' "$tag_push_runs" | /usr/bin/jq -er '.[0].run
     event:"push",head_branch:"v0.8.0",head_sha:$sha,
     run_id:$id,run_attempt:$attempt}' \
   | write_once_or_compare "$release_control_root/TAG-PUSH-RUN-SELECTION.json"
-"$ARC_RECOVERY_GH_PATH" run watch "$tag_push_run_id" \
-  --repo FerrumVir/arc-chain --interval 10
-"$ARC_RECOVERY_GH_PATH" api \
-  "repos/FerrumVir/arc-chain/actions/runs/$tag_push_run_id" \
+GH_TOKEN="$release_gh_token" scripts/release/wait-workflow-attempt.sh \
+  FerrumVir/arc-chain "$tag_push_run_id" "$tag_push_run_attempt" failure \
+  > "$release_control_root/TAG-PUSH-RUN-FINAL.json"
+arc_scoped_gh "$release_gh_token" api \
+  "repos/FerrumVir/arc-chain/actions/runs/$tag_push_run_id/attempts/$tag_push_run_attempt" \
   | /usr/bin/jq -e --arg sha "$protected_main_sha" --argjson id "$tag_push_run_id" \
       --argjson attempt "$tag_push_run_attempt" --argjson workflow_id "$release_workflow_id" \
       '.id == $id and .run_attempt == $attempt and .workflow_id == $workflow_id
@@ -2770,8 +3404,8 @@ tag_push_run_attempt="$(printf '%s' "$tag_push_runs" | /usr/bin/jq -er '.[0].run
        and .head_sha == $sha and .head_branch == "v0.8.0"
        and .path == ".github/workflows/release.yml" and .event == "push"
        and .status == "completed" and .conclusion == "failure"' >/dev/null
-"$ARC_RECOVERY_GH_PATH" api \
-  "repos/FerrumVir/arc-chain/actions/runs/$tag_push_run_id/jobs?filter=all&per_page=100" \
+arc_scoped_gh "$release_gh_token" api \
+  "repos/FerrumVir/arc-chain/actions/runs/$tag_push_run_id/attempts/$tag_push_run_attempt/jobs?per_page=100" \
   | /usr/bin/jq -e '
       ([.jobs[] | select(.name == "Validate release tag and pin commit"
         and .conclusion == "failure")] | length) == 1
@@ -2779,9 +3413,16 @@ tag_push_run_attempt="$(printf '%s' "$tag_push_runs" | /usr/bin/jq -er '.[0].run
         (.name == "Create and upload one isolated release draft"
          or .name == "Publish only the independently verified draft")
         and .conclusion != "skipped")] | length) == 0' >/dev/null
+tag_push_validation_job_id="$(
+  arc_scoped_gh "$release_gh_token" api \
+    "repos/FerrumVir/arc-chain/actions/runs/$tag_push_run_id/attempts/$tag_push_run_attempt/jobs?per_page=100" \
+    --jq '.jobs[] | select(.name == "Validate release tag and pin commit"
+      and .status == "completed" and .conclusion == "failure") | .id'
+)"
+[[ "$tag_push_validation_job_id" =~ ^[1-9][0-9]*$ ]]
 tag_push_failure_log="$(
-  "$ARC_RECOVERY_GH_PATH" run view "$tag_push_run_id" \
-    --repo FerrumVir/arc-chain --log-failed
+  arc_scoped_gh "$release_gh_token" api \
+    "repos/FerrumVir/arc-chain/actions/jobs/$tag_push_validation_job_id/logs"
 )"
 printf '%s\n' "$tag_push_failure_log" | /usr/bin/grep -Fq \
   'Release requires workflow_dispatch with a positive cutover_handoff_artifact_id.'
@@ -2797,11 +3438,11 @@ approval. Approve deployments only when GitHub shows that exact run ID and
 attempt. Do not move, delete, recreate, or re-push the tag.
 
 ```bash
-release_workflow_id="$("$ARC_RECOVERY_GH_PATH" api \
+release_workflow_id="$(arc_scoped_gh "$release_gh_token" api \
   repos/FerrumVir/arc-chain/actions/workflows/release.yml --jq .id)"
 [[ "$release_workflow_id" =~ ^[1-9][0-9]*$ ]]
 release_run_candidates() {
-  "$ARC_RECOVERY_GH_PATH" api --paginate \
+  arc_scoped_gh "$release_gh_token" api --paginate \
     'repos/FerrumVir/arc-chain/actions/workflows/release.yml/runs?event=workflow_dispatch&branch=main&per_page=100' \
     --jq '.workflow_runs[]' \
   | /usr/bin/jq -cs --arg sha "$protected_main_sha" \
@@ -2814,18 +3455,21 @@ release_run_candidates() {
 manual_release_runs="$(release_run_candidates)"
 manual_release_run_count="$(printf '%s' "$manual_release_runs" | /usr/bin/jq -er length)"
 existing_release_count="$(
-  "$ARC_RECOVERY_GH_PATH" api --paginate \
+  arc_scoped_gh "$release_gh_token" api --paginate \
     'repos/FerrumVir/arc-chain/releases?per_page=100' --jq '.[]' \
   | /usr/bin/jq -cs '[.[] | select(.tag_name == "v0.8.0")] | length'
 )"
 case "$manual_release_run_count:$existing_release_count" in
   0:0)
-    "$ARC_RECOVERY_GH_PATH" workflow run release.yml \
+    arc_scoped_gh "$release_gh_token" workflow run release.yml \
       --repo FerrumVir/arc-chain \
       --ref main \
       -f tag=v0.8.0 \
       -f cutover_handoff_artifact_id="$handoff_artifact_id" \
-      -f cutover_handoff_artifact_digest="$handoff_artifact_digest"
+      -f cutover_handoff_artifact_digest="$handoff_artifact_digest" \
+      -f cutover_handoff_run_attempt="$handoff_run_attempt" \
+      -f pretag_run_id="$pretag_run_id" \
+      -f pretag_run_attempt="$pretag_run_attempt"
     for _ in {1..30}; do
       /usr/bin/sleep 2
       manual_release_runs="$(release_run_candidates)"
@@ -2860,8 +3504,9 @@ release_run_attempt="$(printf '%s' "$manual_release_runs" | /usr/bin/jq -er '.[0
   | write_once_or_compare "$release_control_root/RELEASE-RUN-SELECTION.json"
 printf 'Approve only release run %s attempt %s, then wait here.\n' \
   "$release_run_id" "$release_run_attempt"
-"$ARC_RECOVERY_GH_PATH" run watch "$release_run_id" \
-  --repo FerrumVir/arc-chain --interval 10 --exit-status
+GH_TOKEN="$release_gh_token" scripts/release/wait-workflow-attempt.sh \
+  FerrumVir/arc-chain "$release_run_id" "$release_run_attempt" success \
+  > "$release_control_root/RELEASE-RUN-WAIT.json"
 ```
 
 After the watch returns success, re-read the run rather than trusting terminal
@@ -2875,8 +3520,8 @@ stored create-only so a resumed audit must reproduce the same terminal facts.
 release_run_final="$release_control_root/RELEASE-RUN-FINAL.json"
 release_jobs_final="$release_control_root/RELEASE-JOBS-FINAL.json"
 release_api_final="$release_control_root/RELEASE-API-FINAL.json"
-release_run_live="$("$ARC_RECOVERY_GH_PATH" api \
-  "repos/FerrumVir/arc-chain/actions/runs/$release_run_id")"
+release_run_live="$(arc_scoped_gh "$release_gh_token" api \
+  "repos/FerrumVir/arc-chain/actions/runs/$release_run_id/attempts/$release_run_attempt")"
 printf '%s' "$release_run_live" | /usr/bin/jq -e \
   --argjson id "$release_run_id" --argjson attempt "$release_run_attempt" \
   --argjson workflow_id "$release_workflow_id" --arg sha "$protected_main_sha" '
@@ -2919,8 +3564,8 @@ required_release_jobs='[
   "Publish only the independently verified draft",
   "Verify the immutable GitHub release without publication authority"
 ]'
-release_jobs_live="$("$ARC_RECOVERY_GH_PATH" api --paginate \
-  "repos/FerrumVir/arc-chain/actions/runs/$release_run_id/jobs?filter=all&per_page=100" \
+release_jobs_live="$(arc_scoped_gh "$release_gh_token" api --paginate \
+  "repos/FerrumVir/arc-chain/actions/runs/$release_run_id/attempts/$release_run_attempt/jobs?per_page=100" \
   --jq '.jobs[]' | /usr/bin/jq -cs 'sort_by(.name)')"
 printf '%s' "$release_jobs_live" | /usr/bin/jq -e \
   --argjson required "$required_release_jobs" '
@@ -2949,7 +3594,7 @@ expected_release_assets='[
   "arc-legacy-maintenance-boundary.json","arc-recovery-checkpoint-descriptor.json",
   "arc-cutover-policy.json","latest.json","SHA256SUMS","SHA256SUMS.sig"
 ]'
-release_api_live="$("$ARC_RECOVERY_GH_PATH" api \
+release_api_live="$(arc_scoped_gh "$release_gh_token" api \
   repos/FerrumVir/arc-chain/releases/tags/v0.8.0)"
 printf '%s' "$release_api_live" | /usr/bin/jq -e \
   --arg sha "$protected_main_sha" --argjson expected "$expected_release_assets" '
@@ -2972,7 +3617,7 @@ printf '%s' "$release_api_live" | /usr/bin/jq -cS \
     assets:(.assets | map({id,name,size,digest,state,uploader:.uploader.login})
       | sort_by(.name))}' \
   | write_once_or_compare "$release_api_final"
-unset GH_TOKEN
+unset release_gh_token
 ```
 
 A rejected draft
@@ -2996,6 +3641,14 @@ manual local-file handoff and still never mounts or serves Drive.
 
 ### Publish the recovered frontend through one reviewed PR
 
+The tag/release phase reduced `arisarcmarket` only to remove non-owner release
+authority. Now that the release API has independently proved the exact immutable
+release, restore that collaborator to the exact sealed pre-tag `write` baseline
+before asking for reviews. A missing baseline or any state other than the sealed
+baseline and its exact reduced projection stops without mutation. GitHub counts
+required approving reviews only from collaborators with write access, so leaving
+the reviewer at `read` would make the later mandatory public-truth PR impossible.
+
 The output and sidecar are create-only mode `0444`. Derive a deterministic
 single-parent commit that changes only `shared/frontend/arc-network.json`,
 publish its dedicated branch with a create-only lease, and reuse only an exact
@@ -3013,27 +3666,61 @@ source as its sole parent and exactly the reviewed frontend tree and bytes.
 Finally re-prove the protected tag and the canonical ruleset snapshot hash.
 
 ```bash
+frontend_gh_token="$(
+  "$ARC_RECOVERY_GH_PATH" auth token --hostname github.com \
+    --user "$ARC_RECOVERY_GITHUB_LOGIN"
+)"
+test -n "$frontend_gh_token"
+test "$(arc_scoped_gh "$frontend_gh_token" api /user --jq .login)" = FerrumVir
+test "$(arc_scoped_gh "$frontend_gh_token" api \
+  repos/FerrumVir/arc-chain/releases/tags/v0.8.0 \
+  --jq '[.target_commitish,.draft,.prerelease,.immutable] | @tsv')" = \
+  "$protected_main_sha"$'\tfalse\tfalse\ttrue'
+test -f "$pretag_collaborator_baseline_receipt" \
+  && test ! -L "$pretag_collaborator_baseline_receipt"
+test "$(/usr/bin/stat --format='%a:%h' "$pretag_collaborator_baseline_receipt")" = 400:1
+test "$(/usr/bin/jq -cS . "$pretag_collaborator_baseline_receipt")" = \
+  "$pretag_collaborator_baseline"
+frontend_collaborators_current="$(direct_collaborator_projection "$frontend_gh_token")"
+case "$frontend_collaborators_current" in
+  "$pretag_collaborator_baseline") ;;
+  "$pretag_collaborator_reduced")
+    arc_scoped_gh "$frontend_gh_token" api --method PUT \
+      repos/FerrumVir/arc-chain/collaborators/arisarcmarket \
+      -f permission=push >/dev/null
+    ;;
+  *)
+    printf 'collaborators differ from sealed pre-tag states; preserve and stop\n' >&2
+    exit 1
+    ;;
+esac
+test "$(direct_collaborator_projection "$frontend_gh_token")" = \
+  "$pretag_collaborator_baseline"
+
 test "$(arc_sha256 "$frontend_config")" = \
   "$(/usr/bin/awk '{print $1}' "$frontend_config.sha256")"
-test "$("$ARC_RECOVERY_GH_PATH" api repos/FerrumVir/arc-chain/branches/main \
+test "$(arc_scoped_gh "$frontend_gh_token" api \
+  repos/FerrumVir/arc-chain/branches/main \
   --jq .commit.sha)" = "$protected_main_sha"
-test "$("$ARC_RECOVERY_GH_PATH" api \
+test "$(arc_scoped_gh "$frontend_gh_token" api \
   repos/FerrumVir/arc-chain/git/ref/tags/v0.8.0 --jq .object.sha)" = \
   "$protected_main_sha"
 
 repository_ruleset_snapshot() {
+  local github_token="$1"
   local ruleset_ids id
-  ruleset_ids="$("$ARC_RECOVERY_GH_PATH" api --paginate \
+  ruleset_ids="$(arc_scoped_gh "$github_token" api --paginate \
     'repos/FerrumVir/arc-chain/rulesets?includes_parents=true&per_page=100' \
     --jq '.[].id' | /usr/bin/sort -n)"
   while IFS= read -r id; do
     [[ "$id" =~ ^[1-9][0-9]*$ ]]
-    "$ARC_RECOVERY_GH_PATH" api "repos/FerrumVir/arc-chain/rulesets/$id" \
+    arc_scoped_gh "$github_token" api \
+      "repos/FerrumVir/arc-chain/rulesets/$id" \
       | /usr/bin/jq -cS \
           '{id,name,target,source,source_type,enforcement,bypass_actors,conditions,rules}'
   done <<< "$ruleset_ids" | /usr/bin/jq -csS 'sort_by(.id)'
 }
-rulesets_before_frontend="$(repository_ruleset_snapshot)"
+rulesets_before_frontend="$(repository_ruleset_snapshot "$frontend_gh_token")"
 test "$(printf '%s' "$rulesets_before_frontend" | /usr/bin/jq -er length)" -gt 0
 
 frontend_branch='arc-recovery/frontend-v0.8.0'
@@ -3073,7 +3760,7 @@ arc_git -C "$operator_checkout" show \
   "$frontend_commit_sha:shared/frontend/arc-network.json" \
   | /usr/bin/cmp -s - "$frontend_config"
 
-frontend_remote_refs="$("$ARC_RECOVERY_GH_PATH" api \
+frontend_remote_refs="$(arc_scoped_gh "$frontend_gh_token" api \
   'repos/FerrumVir/arc-chain/git/matching-refs/heads/arc-recovery/frontend/v0.8.0' \
   --jq .)"
 frontend_remote_state="$(printf '%s' "$frontend_remote_refs" | /usr/bin/jq -er \
@@ -3085,9 +3772,6 @@ frontend_remote_state="$(printf '%s' "$frontend_remote_refs" | /usr/bin/jq -er \
     else "mismatch" end')"
 case "$frontend_remote_state" in
   absent)
-    frontend_git_token="$("$ARC_RECOVERY_GH_PATH" auth token \
-      --hostname github.com --user "$ARC_RECOVERY_GITHUB_LOGIN")"
-    test -n "$frontend_git_token"
     frontend_push_attempt_root="$(
       /usr/bin/mktemp -d "$release_control_root/frontend-push.XXXXXXXX"
     )"
@@ -3096,7 +3780,7 @@ case "$frontend_remote_state" in
     ( umask 077
       set -o noclobber
       /usr/bin/env -i HOME="$git_home" PATH=/usr/bin:/bin LANG=C LC_ALL=C TZ=UTC \
-        GH_TOKEN="$frontend_git_token" GH_PROMPT_DISABLED=1 \
+        GH_TOKEN="$frontend_gh_token" GH_PROMPT_DISABLED=1 \
         GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_TERMINAL_PROMPT=0 \
         /usr/bin/git -C "$operator_checkout" -c core.hooksPath=/dev/null \
           -c credential.helper= \
@@ -3111,12 +3795,11 @@ case "$frontend_remote_state" in
           >"$frontend_push_attempt_root/STDOUT.txt" \
           2>"$frontend_push_attempt_root/STDERR.txt"
     ) || frontend_push_status=$?
-    unset frontend_git_token
     ;;
   exact) frontend_push_status=0 ;;
   *) printf 'frontend branch exists at another identity; preserve and stop\n' >&2; exit 1 ;;
 esac
-frontend_remote_after="$("$ARC_RECOVERY_GH_PATH" api \
+frontend_remote_after="$(arc_scoped_gh "$frontend_gh_token" api \
   'repos/FerrumVir/arc-chain/git/matching-refs/heads/arc-recovery/frontend/v0.8.0' \
   --jq .)"
 printf '%s' "$frontend_remote_after" | /usr/bin/jq -e \
@@ -3130,7 +3813,7 @@ fi
 
 frontend_pr_title='Publish verified ARC v0.8 recovery frontend'
 frontend_pr_body='Publishes only the create-only, rollout-derived recovered frontend configuration after immutable v0.8.0 verification.'
-frontend_prs="$("$ARC_RECOVERY_GH_PATH" api --method GET \
+frontend_prs="$(arc_scoped_gh "$frontend_gh_token" api --method GET \
   repos/FerrumVir/arc-chain/pulls -f state=all \
   -f head="FerrumVir:$frontend_branch" -f base=main \
   | /usr/bin/jq -c --arg sha "$frontend_commit_sha" \
@@ -3139,16 +3822,18 @@ frontend_prs="$("$ARC_RECOVERY_GH_PATH" api --method GET \
 frontend_pr_count="$(printf '%s' "$frontend_prs" | /usr/bin/jq -er length)"
 case "$frontend_pr_count" in
   0)
-    test "$("$ARC_RECOVERY_GH_PATH" api repos/FerrumVir/arc-chain/branches/main \
+    test "$(arc_scoped_gh "$frontend_gh_token" api \
+      repos/FerrumVir/arc-chain/branches/main \
       --jq .commit.sha)" = "$protected_main_sha"
-    "$ARC_RECOVERY_GH_PATH" api --method POST repos/FerrumVir/arc-chain/pulls \
+    arc_scoped_gh "$frontend_gh_token" api --method POST \
+      repos/FerrumVir/arc-chain/pulls \
       -f title="$frontend_pr_title" -f head="$frontend_branch" -f base=main \
       -f body="$frontend_pr_body" -F draft=false >/dev/null
     ;;
   1) ;;
   *) printf 'frontend pull-request selection is ambiguous; preserve and stop\n' >&2; exit 1 ;;
 esac
-frontend_prs="$("$ARC_RECOVERY_GH_PATH" api --method GET \
+frontend_prs="$(arc_scoped_gh "$frontend_gh_token" api --method GET \
   repos/FerrumVir/arc-chain/pulls -f state=all \
   -f head="FerrumVir:$frontend_branch" -f base=main \
   | /usr/bin/jq -c --arg sha "$frontend_commit_sha" \
@@ -3159,21 +3844,24 @@ frontend_pr_number="$(printf '%s' "$frontend_prs" | /usr/bin/jq -er '.[0].number
 [[ "$frontend_pr_number" =~ ^[1-9][0-9]*$ ]]
 frontend_main_ruleset_id=21689753
 frontend_main_ruleset_policy() {
-  "$ARC_RECOVERY_GH_PATH" api \
+  local github_token="$1"
+  arc_scoped_gh "$github_token" api \
     "repos/FerrumVir/arc-chain/rulesets/$frontend_main_ruleset_id" \
     | /usr/bin/jq -cS \
         '{id,name,target,source,source_type,enforcement,bypass_actors,conditions,rules}'
 }
 frontend_main_ruleset_put() {
-  printf '%s' "$1" | /usr/bin/jq -cS \
+  local github_token="$1"
+  local policy="$2"
+  printf '%s' "$policy" | /usr/bin/jq -cS \
     '{name,target,enforcement,bypass_actors,conditions,rules}' \
-    | "$ARC_RECOVERY_GH_PATH" api --method PUT \
+    | arc_scoped_gh "$github_token" api --method PUT \
         "repos/FerrumVir/arc-chain/rulesets/$frontend_main_ruleset_id" \
         --input - >/dev/null
 }
 frontend_ruleset_baseline_receipt="$release_control_root/FRONTEND-MAIN-RULESET-BASELINE.json"
 if [ ! -e "$frontend_ruleset_baseline_receipt" ]; then
-  frontend_main_ruleset_policy | write_once_or_compare \
+  frontend_main_ruleset_policy "$frontend_gh_token" | write_once_or_compare \
     "$frontend_ruleset_baseline_receipt"
 fi
 test -f "$frontend_ruleset_baseline_receipt" \
@@ -3205,13 +3893,14 @@ frontend_ruleset_exception="$(printf '%s' "$frontend_ruleset_baseline" \
         .parameters.required_approving_review_count = 0
         | .parameters.require_last_push_approval = false
       else . end)')"
-frontend_ruleset_current="$(frontend_main_ruleset_policy)"
+frontend_ruleset_current="$(frontend_main_ruleset_policy "$frontend_gh_token")"
 case "$frontend_ruleset_current" in
   "$frontend_ruleset_baseline") ;;
   "$frontend_ruleset_exception")
     printf 'restoring an exact interrupted frontend ruleset exception before retry\n' >&2
-    frontend_main_ruleset_put "$frontend_ruleset_baseline"
-    test "$(frontend_main_ruleset_policy)" = "$frontend_ruleset_baseline"
+    frontend_main_ruleset_put "$frontend_gh_token" "$frontend_ruleset_baseline"
+    test "$(frontend_main_ruleset_policy "$frontend_gh_token")" = \
+      "$frontend_ruleset_baseline"
     ;;
   *)
     printf 'main ruleset differs from both sealed baseline and exact exception; preserve and stop\n' >&2
@@ -3226,12 +3915,14 @@ frontend_ruleset_baseline_sha="$(arc_sha256 "$frontend_ruleset_baseline_receipt"
 frontend_ruleset_exception_active=false
 restore_frontend_main_ruleset() {
   local current
-  current="$(frontend_main_ruleset_policy)" || return 1
+  current="$(frontend_main_ruleset_policy "$frontend_gh_token")" || return 1
   case "$current" in
     "$frontend_ruleset_baseline") ;;
     "$frontend_ruleset_exception")
-      frontend_main_ruleset_put "$frontend_ruleset_baseline" || return 1
-      test "$(frontend_main_ruleset_policy)" = "$frontend_ruleset_baseline" || return 1
+      frontend_main_ruleset_put "$frontend_gh_token" \
+        "$frontend_ruleset_baseline" || return 1
+      test "$(frontend_main_ruleset_policy "$frontend_gh_token")" = \
+        "$frontend_ruleset_baseline" || return 1
       ;;
     *)
       printf 'main ruleset changed concurrently; refusing to overwrite it during restore\n' >&2
@@ -3255,16 +3946,17 @@ frontend_pr_state="$(printf '%s' "$frontend_prs" | /usr/bin/jq -er '.[0].state')
 frontend_review_authorization="$release_control_root/FRONTEND-REVIEW-AUTHORIZATION.json"
 case "$frontend_pr_state" in
   open)
-    "$ARC_RECOVERY_GH_PATH" pr checks "$frontend_pr_number" \
+    arc_scoped_gh "$frontend_gh_token" pr checks "$frontend_pr_number" \
       --repo FerrumVir/arc-chain --required --watch --interval 10
-    frontend_pr_view="$("$ARC_RECOVERY_GH_PATH" pr view "$frontend_pr_number" \
+    frontend_pr_view="$(arc_scoped_gh "$frontend_gh_token" pr view \
+      "$frontend_pr_number" \
       --repo FerrumVir/arc-chain --json state,headRefOid,baseRefOid,reviewDecision)"
     printf '%s' "$frontend_pr_view" | /usr/bin/jq -e \
       --arg head "$frontend_commit_sha" --arg base "$protected_main_sha" '
       .state == "OPEN" and .headRefOid == $head and .baseRefOid == $base
       and .reviewDecision != "CHANGES_REQUESTED"' >/dev/null
     frontend_aris_approval_count="$(
-      "$ARC_RECOVERY_GH_PATH" api --paginate \
+      arc_scoped_gh "$frontend_gh_token" api --paginate \
         "repos/FerrumVir/arc-chain/pulls/$frontend_pr_number/reviews?per_page=100" \
         --jq '.[]' \
       | /usr/bin/jq -cs --arg head "$frontend_commit_sha" '
@@ -3305,14 +3997,17 @@ case "$frontend_pr_state" in
         ;;
       temporary-ruleset-exception)
         frontend_ruleset_exception_active=true
-        frontend_main_ruleset_put "$frontend_ruleset_exception"
-        test "$(frontend_main_ruleset_policy)" = "$frontend_ruleset_exception"
+        frontend_main_ruleset_put "$frontend_gh_token" \
+          "$frontend_ruleset_exception"
+        test "$(frontend_main_ruleset_policy "$frontend_gh_token")" = \
+          "$frontend_ruleset_exception"
         ;;
       *) exit 1 ;;
     esac
-    test "$("$ARC_RECOVERY_GH_PATH" api repos/FerrumVir/arc-chain/branches/main \
+    test "$(arc_scoped_gh "$frontend_gh_token" api \
+      repos/FerrumVir/arc-chain/branches/main \
       --jq .commit.sha)" = "$protected_main_sha"
-    "$ARC_RECOVERY_GH_PATH" api --method PUT \
+    arc_scoped_gh "$frontend_gh_token" api --method PUT \
       "repos/FerrumVir/arc-chain/pulls/$frontend_pr_number/merge" \
       -f commit_title="$frontend_pr_title" -f merge_method=squash \
       -f sha="$frontend_commit_sha" \
@@ -3337,7 +4032,7 @@ case "$frontend_pr_state" in
 esac
 restore_frontend_main_ruleset
 trap - EXIT HUP INT TERM
-frontend_pr_live="$("$ARC_RECOVERY_GH_PATH" api \
+frontend_pr_live="$(arc_scoped_gh "$frontend_gh_token" api \
   "repos/FerrumVir/arc-chain/pulls/$frontend_pr_number")"
 printf '%s' "$frontend_pr_live" | /usr/bin/jq -e --arg head "$frontend_commit_sha" '
   .state == "closed" and .merged == true and .head.sha == $head
@@ -3353,14 +4048,16 @@ test "$(arc_git -C "$operator_checkout" diff --name-only \
 arc_git -C "$operator_checkout" show \
   "$frontend_main_sha:shared/frontend/arc-network.json" \
   | /usr/bin/cmp -s - "$frontend_config"
-test "$("$ARC_RECOVERY_GH_PATH" api repos/FerrumVir/arc-chain/branches/main \
+test "$(arc_scoped_gh "$frontend_gh_token" api \
+  repos/FerrumVir/arc-chain/branches/main \
   --jq .commit.sha)" = "$frontend_main_sha"
-test "$("$ARC_RECOVERY_GH_PATH" api \
+test "$(arc_scoped_gh "$frontend_gh_token" api \
   repos/FerrumVir/arc-chain/git/ref/tags/v0.8.0 --jq .object.sha)" = \
   "$protected_main_sha"
-rulesets_after_frontend="$(repository_ruleset_snapshot)"
+rulesets_after_frontend="$(repository_ruleset_snapshot "$frontend_gh_token")"
 test "$rulesets_after_frontend" = "$rulesets_before_frontend"
-test "$(frontend_main_ruleset_policy)" = "$frontend_ruleset_baseline"
+test "$(frontend_main_ruleset_policy "$frontend_gh_token")" = \
+  "$frontend_ruleset_baseline"
 frontend_ruleset_exception_used=false
 if [ "$frontend_review_mode" = temporary-ruleset-exception ]; then
   frontend_ruleset_exception_used=true
@@ -3378,6 +4075,7 @@ fi
     main_ruleset_baseline_sha256:$ruleset_baseline_sha,
     config_sha256:$config_sha,changed_paths:["shared/frontend/arc-network.json"]}' \
   | write_once_or_compare "$release_control_root/FRONTEND-MERGE.json"
+unset frontend_gh_token
 ```
 
 Rollback, if a later Pages or live gate fails, is a new reviewed PR that reverts
@@ -3403,11 +4101,33 @@ post_release_attempt_root="$(
   /usr/bin/mktemp -d "$release_control_root/post-release.XXXXXXXX"
 )"
 test "$(/usr/bin/stat --format='%a:%h' "$post_release_attempt_root")" = 700:1
-pages_workflow_id="$("$ARC_RECOVERY_GH_PATH" api \
-  repos/FerrumVir/arc-chain/actions/workflows/deploy-explorer.yml --jq .id)"
+pages_workflow_json="$post_release_attempt_root/pages-workflow.json"
+pages_run_json="$post_release_attempt_root/pages-run.json"
+pages_jobs_json="$post_release_attempt_root/pages-jobs.json"
+pages_api_json="$post_release_attempt_root/pages-api.json"
+pages_deployments_json="$post_release_attempt_root/pages-deployments.json"
+pages_statuses_json="$post_release_attempt_root/pages-statuses.json"
+published_acceptance_workflow_json="$post_release_attempt_root/published-acceptance-workflow.json"
+published_acceptance_run_json="$post_release_attempt_root/published-acceptance-run.json"
+published_acceptance_jobs_json="$post_release_attempt_root/published-acceptance-jobs.json"
+published_acceptance_artifact_json="$post_release_attempt_root/published-acceptance-artifact.json"
+post_release_gh_token="$(
+  "$ARC_RECOVERY_GH_PATH" auth token --hostname github.com \
+    --user "$ARC_RECOVERY_GITHUB_LOGIN"
+)"
+test -n "$post_release_gh_token"
+test "$(arc_scoped_gh "$post_release_gh_token" api /user --jq .login)" = FerrumVir
+pages_workflow_live="$(arc_scoped_gh "$post_release_gh_token" api \
+  repos/FerrumVir/arc-chain/actions/workflows/deploy-explorer.yml)"
+printf '%s' "$pages_workflow_live" | /usr/bin/jq -e '
+  .name == "Deploy ARC public console"
+  and .path == ".github/workflows/deploy-explorer.yml"
+  and .state == "active" and (.id | type == "number" and . > 0)' >/dev/null
+printf '%s' "$pages_workflow_live" | write_once_or_compare "$pages_workflow_json"
+pages_workflow_id="$(printf '%s' "$pages_workflow_live" | /usr/bin/jq -er .id)"
 [[ "$pages_workflow_id" =~ ^[1-9][0-9]*$ ]]
 pages_run_candidates() {
-  "$ARC_RECOVERY_GH_PATH" api --paginate \
+  arc_scoped_gh "$post_release_gh_token" api --paginate \
     'repos/FerrumVir/arc-chain/actions/workflows/deploy-explorer.yml/runs?event=push&branch=main&per_page=100' \
     --jq '.workflow_runs[]' \
   | /usr/bin/jq -cs --arg sha "$frontend_main_sha" \
@@ -3435,10 +4155,11 @@ pages_run_attempt="$(printf '%s' "$pages_runs" | /usr/bin/jq -er '.[0].run_attem
     workflow_id:$workflow_id,workflow_path:".github/workflows/deploy-explorer.yml",
     event:"push",head_branch:"main",head_sha:$sha,run_id:$id,run_attempt:$attempt}' \
   | write_once_or_compare "$release_control_root/PAGES-RUN-SELECTION.json"
-"$ARC_RECOVERY_GH_PATH" run watch "$pages_run_id" \
-  --repo FerrumVir/arc-chain --interval 10 --exit-status
-pages_run_live="$("$ARC_RECOVERY_GH_PATH" api \
-  "repos/FerrumVir/arc-chain/actions/runs/$pages_run_id")"
+GH_TOKEN="$post_release_gh_token" scripts/release/wait-workflow-attempt.sh \
+  FerrumVir/arc-chain "$pages_run_id" "$pages_run_attempt" success \
+  > "$post_release_attempt_root/pages-run-wait.json"
+pages_run_live="$(arc_scoped_gh "$post_release_gh_token" api \
+  "repos/FerrumVir/arc-chain/actions/runs/$pages_run_id/attempts/$pages_run_attempt")"
 printf '%s' "$pages_run_live" | /usr/bin/jq -e \
   --argjson id "$pages_run_id" --argjson attempt "$pages_run_attempt" \
   --argjson workflow_id "$pages_workflow_id" --arg sha "$frontend_main_sha" '
@@ -3447,8 +4168,8 @@ printf '%s' "$pages_run_live" | /usr/bin/jq -e \
   and .head_sha == $sha and .head_branch == "main"
   and .path == ".github/workflows/deploy-explorer.yml" and .event == "push"
   and .status == "completed" and .conclusion == "success"' >/dev/null
-pages_jobs_live="$("$ARC_RECOVERY_GH_PATH" api --paginate \
-  "repos/FerrumVir/arc-chain/actions/runs/$pages_run_id/jobs?filter=all&per_page=100" \
+pages_jobs_live="$(arc_scoped_gh "$post_release_gh_token" api --paginate \
+  "repos/FerrumVir/arc-chain/actions/runs/$pages_run_id/attempts/$pages_run_attempt/jobs?per_page=100" \
   --jq '.jobs[]' | /usr/bin/jq -cs 'sort_by(.name)')"
 printf '%s' "$pages_jobs_live" | /usr/bin/jq -e '
   length == 2
@@ -3456,15 +4177,16 @@ printf '%s' "$pages_jobs_live" | /usr/bin/jq -e '
     and .status == "completed" and .conclusion == "success")] | length) == 1
   and ([.[] | select(.name == "Publish GitHub Pages"
     and .status == "completed" and .conclusion == "success")] | length) == 1' >/dev/null
-printf '%s' "$pages_run_live" > "$post_release_attempt_root/pages-run.json"
-printf '%s' "$pages_jobs_live" > "$post_release_attempt_root/pages-jobs.json"
+printf '%s' "$pages_run_live" | write_once_or_compare "$pages_run_json"
+printf '%s' "$pages_jobs_live" | write_once_or_compare "$pages_jobs_json"
 
-pages_api_live="$("$ARC_RECOVERY_GH_PATH" api repos/FerrumVir/arc-chain/pages)"
+pages_api_live="$(arc_scoped_gh "$post_release_gh_token" api \
+  repos/FerrumVir/arc-chain/pages)"
 printf '%s' "$pages_api_live" | /usr/bin/jq -e '
   .build_type == "workflow"
   and (.html_url | test("^https://[A-Za-z0-9.-]+(?:/[A-Za-z0-9._~/-]*)?/$"))' >/dev/null
 pages_url="$(printf '%s' "$pages_api_live" | /usr/bin/jq -er '.html_url | rtrimstr("/")')"
-pages_deployments="$("$ARC_RECOVERY_GH_PATH" api --method GET \
+pages_deployments="$(arc_scoped_gh "$post_release_gh_token" api --method GET \
   repos/FerrumVir/arc-chain/deployments -f sha="$frontend_main_sha" \
   -f environment=github-pages -f per_page=100 \
   | /usr/bin/jq -c --arg sha "$frontend_main_sha" '
@@ -3473,15 +4195,15 @@ pages_deployments="$("$ARC_RECOVERY_GH_PATH" api --method GET \
 test "$(printf '%s' "$pages_deployments" | /usr/bin/jq -er length)" -eq 1
 pages_deployment_id="$(printf '%s' "$pages_deployments" | /usr/bin/jq -er '.[0].id')"
 [[ "$pages_deployment_id" =~ ^[1-9][0-9]*$ ]]
-pages_deployment_statuses="$("$ARC_RECOVERY_GH_PATH" api \
+pages_deployment_statuses="$(arc_scoped_gh "$post_release_gh_token" api \
   "repos/FerrumVir/arc-chain/deployments/$pages_deployment_id/statuses?per_page=100")"
 printf '%s' "$pages_deployment_statuses" | /usr/bin/jq -e \
   --arg url "$pages_url" '
   [.[] | select(.state == "success" and .environment == "github-pages"
     and ((.environment_url | rtrimstr("/")) == $url))] | length == 1' >/dev/null
-printf '%s' "$pages_api_live" > "$post_release_attempt_root/pages-api.json"
-printf '%s' "$pages_deployments" > "$post_release_attempt_root/pages-deployments.json"
-printf '%s' "$pages_deployment_statuses" > "$post_release_attempt_root/pages-statuses.json"
+printf '%s' "$pages_api_live" | write_once_or_compare "$pages_api_json"
+printf '%s' "$pages_deployments" | write_once_or_compare "$pages_deployments_json"
+printf '%s' "$pages_deployment_statuses" | write_once_or_compare "$pages_statuses_json"
 
 deployed_config="$post_release_attempt_root/arc-network.json"
 deployed_commit="$post_release_attempt_root/deployed-commit.txt"
@@ -3554,6 +4276,360 @@ test "$legacy_provenance_count" = \
     "$deployed_config")"
 ```
 
+### Exercise the exact published packages and seal their acceptance artifact
+
+Dispatch the unprivileged `post-release-acceptance.yml` definition from the
+immutable `v0.8.0` tag, never from moving `main`. The workflow binds the exact
+successful release run and attempt, downloads public assets only by numeric
+release-asset ID, and performs the following on hosted runners: fresh and
+update-only headless Linux installs; a real visible AppImage launch under
+Xvfb; real visible-window launches of both macOS bundles and the MSI-extracted
+Windows app; and a network-disabled migration rehearsal generated by the real,
+digest-pinned v0.7.7 Linux binary. It installs no service and has no release,
+deployment, environment, package, OIDC, or validator authority.
+
+Snapshot the matching run IDs before dispatch so a concurrent or previous run
+cannot be selected as "latest." Seal the newly created run ID and attempt
+create-only, wait for that exact attempt, and require the complete named job
+set. A resume reuses the sealed selection; it never dispatches another run.
+
+```bash
+published_acceptance_workflow_live="$(
+  arc_scoped_gh "$post_release_gh_token" api \
+    repos/FerrumVir/arc-chain/actions/workflows/post-release-acceptance.yml
+)"
+printf '%s' "$published_acceptance_workflow_live" | /usr/bin/jq -e '
+  .name == "Published artifact acceptance"
+  and .path == ".github/workflows/post-release-acceptance.yml"
+  and .state == "active" and (.id | type == "number" and . > 0)' >/dev/null
+printf '%s' "$published_acceptance_workflow_live" \
+  | write_once_or_compare "$published_acceptance_workflow_json"
+published_acceptance_workflow_id="$(printf '%s' \
+  "$published_acceptance_workflow_live" | /usr/bin/jq -er .id)"
+[[ "$published_acceptance_workflow_id" =~ ^[1-9][0-9]*$ ]]
+published_acceptance_run_selection="$release_control_root/PUBLISHED-ARTIFACT-ACCEPTANCE-RUN.json"
+published_acceptance_runs() {
+  arc_scoped_gh "$post_release_gh_token" api --paginate \
+    "repos/FerrumVir/arc-chain/actions/workflows/$published_acceptance_workflow_id/runs?event=workflow_dispatch&per_page=100" \
+    --jq '.workflow_runs[]' \
+  | /usr/bin/jq -cs --arg sha "$protected_main_sha" \
+      --argjson workflow_id "$published_acceptance_workflow_id" '
+      [.[] | select(.workflow_id == $workflow_id and .head_sha == $sha
+        and .path == ".github/workflows/post-release-acceptance.yml"
+        and .event == "workflow_dispatch")]'
+}
+if [ ! -e "$published_acceptance_run_selection" ]; then
+  published_acceptance_before="$(published_acceptance_runs | /usr/bin/jq '[.[].id]')"
+  arc_scoped_gh "$post_release_gh_token" workflow run \
+    post-release-acceptance.yml --repo FerrumVir/arc-chain --ref v0.8.0 \
+    -f tag=v0.8.0 -f release_source_sha="$protected_main_sha" \
+    -f release_run_id="$release_run_id" \
+    -f release_run_attempt="$release_run_attempt"
+  published_acceptance_candidates='[]'
+  for _ in {1..30}; do
+    published_acceptance_candidates="$(published_acceptance_runs \
+      | /usr/bin/jq --argjson before "$published_acceptance_before" '
+          [.[] | .id as $id | select(($before | index($id)) == null)]')"
+    [ "$(printf '%s' "$published_acceptance_candidates" \
+      | /usr/bin/jq -er length)" -eq 0 ] || break
+    /usr/bin/sleep 2
+  done
+  test "$(printf '%s' "$published_acceptance_candidates" \
+    | /usr/bin/jq -er length)" -eq 1
+  published_acceptance_run_id="$(printf '%s' "$published_acceptance_candidates" \
+    | /usr/bin/jq -er '.[0].id')"
+  published_acceptance_run_attempt="$(printf '%s' "$published_acceptance_candidates" \
+    | /usr/bin/jq -er '.[0].run_attempt')"
+  /usr/bin/jq -cnS \
+    --argjson workflow_id "$published_acceptance_workflow_id" \
+    --arg sha "$protected_main_sha" \
+    --argjson run_id "$published_acceptance_run_id" \
+    --argjson run_attempt "$published_acceptance_run_attempt" \
+    --argjson release_run_id "$release_run_id" \
+    --argjson release_run_attempt "$release_run_attempt" '
+    {schema:"arc.published-artifact-acceptance-run-selection.v1",
+     repository:"FerrumVir/arc-chain",workflow_id:$workflow_id,
+     workflow_path:".github/workflows/post-release-acceptance.yml",
+     dispatch_ref:"v0.8.0",head_sha:$sha,run_id:$run_id,
+     run_attempt:$run_attempt,release_run_id:$release_run_id,
+     release_run_attempt:$release_run_attempt}' \
+    | write_once_or_compare "$published_acceptance_run_selection"
+fi
+/usr/bin/jq -e \
+  --argjson workflow_id "$published_acceptance_workflow_id" \
+  --arg sha "$protected_main_sha" \
+  --argjson release_run_id "$release_run_id" \
+  --argjson release_run_attempt "$release_run_attempt" '
+  .schema == "arc.published-artifact-acceptance-run-selection.v1"
+  and .repository == "FerrumVir/arc-chain" and .workflow_id == $workflow_id
+  and .workflow_path == ".github/workflows/post-release-acceptance.yml"
+  and .dispatch_ref == "v0.8.0" and .head_sha == $sha
+  and .release_run_id == $release_run_id
+  and .release_run_attempt == $release_run_attempt
+  and (.run_id | type == "number" and . > 0)
+  and (.run_attempt | type == "number" and . > 0)' \
+  "$published_acceptance_run_selection" >/dev/null
+published_acceptance_run_id="$(/usr/bin/jq -er .run_id \
+  "$published_acceptance_run_selection")"
+published_acceptance_run_attempt="$(/usr/bin/jq -er .run_attempt \
+  "$published_acceptance_run_selection")"
+GH_TOKEN="$post_release_gh_token" scripts/release/wait-workflow-attempt.sh \
+  FerrumVir/arc-chain "$published_acceptance_run_id" \
+  "$published_acceptance_run_attempt" success \
+  > "$post_release_attempt_root/published-acceptance-run-wait.json"
+published_acceptance_run_live="$(
+  arc_scoped_gh "$post_release_gh_token" api \
+    "repos/FerrumVir/arc-chain/actions/runs/$published_acceptance_run_id/attempts/$published_acceptance_run_attempt"
+)"
+printf '%s' "$published_acceptance_run_live" | /usr/bin/jq -e \
+  --argjson id "$published_acceptance_run_id" \
+  --argjson attempt "$published_acceptance_run_attempt" \
+  --argjson workflow_id "$published_acceptance_workflow_id" \
+  --arg sha "$protected_main_sha" '
+  .id == $id and .run_attempt == $attempt and .workflow_id == $workflow_id
+  and .head_repository.full_name == "FerrumVir/arc-chain"
+  and .head_sha == $sha
+  and .path == ".github/workflows/post-release-acceptance.yml"
+  and .event == "workflow_dispatch"
+  and .status == "completed" and .conclusion == "success"' >/dev/null
+published_acceptance_jobs="$(
+  arc_scoped_gh "$post_release_gh_token" api --paginate \
+    "repos/FerrumVir/arc-chain/actions/runs/$published_acceptance_run_id/attempts/$published_acceptance_run_attempt/jobs?per_page=100" \
+    --jq '.jobs[]' | /usr/bin/jq -cs 'sort_by(.name)'
+)"
+printf '%s' "$published_acceptance_jobs" | /usr/bin/jq -e '
+  ([.[].name] | sort) == ([
+    "Bind exact release run, tag, and public assets",
+    "Linux headless, AppImage, and real v0.7.7 migration",
+    "Packaged desktop (macos-arm64)",
+    "Packaged desktop (macos-x86_64)",
+    "Packaged desktop (windows-x86_64)",
+    "Seal canonical published-artifact receipt"
+  ] | sort)
+  and all(.[]; .status == "completed" and .conclusion == "success")' >/dev/null
+printf '%s' "$published_acceptance_run_live" \
+  | write_once_or_compare "$published_acceptance_run_json"
+printf '%s' "$published_acceptance_jobs" \
+  | write_once_or_compare "$published_acceptance_jobs_json"
+```
+
+The final Actions artifact is a second boundary. Select it by the exact
+run/attempt-encoded name, numeric artifact ID, same-run SHA, and server
+`sha256:` digest. Verify the downloaded archive against that digest, extract
+only its nine exact top-level/checksum files plus the exact 36-file recursive
+`evidence/` set, verify its checksum list, and rebuild the canonical receipt
+with the tagged verifier. That evidence includes
+`evidence/release/published-evidence.zip`, whose bytes must equal the release
+publication artifact digest bound inside the evidence manifest. The outer
+numeric artifact ID and digest live outside the acceptance artifact because a
+ZIP cannot safely contain its own hash.
+
+```bash
+published_acceptance_artifact_name="arc-published-artifact-acceptance-v0.8.0-$protected_main_sha-$published_acceptance_run_id-attempt-$published_acceptance_run_attempt"
+published_acceptance_artifacts="$(
+  arc_scoped_gh "$post_release_gh_token" api \
+    "repos/FerrumVir/arc-chain/actions/runs/$published_acceptance_run_id/artifacts?per_page=100"
+)"
+published_acceptance_artifact="$(printf '%s' "$published_acceptance_artifacts" \
+  | /usr/bin/jq -ce --arg name "$published_acceptance_artifact_name" \
+    --argjson run_id "$published_acceptance_run_id" \
+    --arg sha "$protected_main_sha" '
+    [.artifacts[] | select(.name == $name)] as $matches
+    | select(($matches | length) == 1) | $matches[0]
+    | select(.expired == false and (.id | type == "number" and . > 0)
+      and (.size_in_bytes | type == "number" and . > 0 and . <= 805306368)
+      and (.digest | test("^sha256:[0-9a-f]{64}$"))
+      and .workflow_run.id == $run_id and .workflow_run.head_sha == $sha)')"
+test -n "$published_acceptance_artifact"
+published_acceptance_artifact_id="$(printf '%s' "$published_acceptance_artifact" \
+  | /usr/bin/jq -er .id)"
+published_acceptance_artifact_digest="$(printf '%s' "$published_acceptance_artifact" \
+  | /usr/bin/jq -er .digest)"
+published_acceptance_artifact_size="$(printf '%s' "$published_acceptance_artifact" \
+  | /usr/bin/jq -er .size_in_bytes)"
+[[ "$published_acceptance_artifact_id" =~ ^[1-9][0-9]*$ ]]
+[[ "$published_acceptance_artifact_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+[[ "$published_acceptance_artifact_size" =~ ^[1-9][0-9]*$ ]]
+test "$published_acceptance_artifact_size" -le 805306368
+published_acceptance_artifact_live="$(
+  arc_scoped_gh "$post_release_gh_token" api \
+    "repos/FerrumVir/arc-chain/actions/artifacts/$published_acceptance_artifact_id"
+)"
+test "$(printf '%s' "$published_acceptance_artifact_live" | /usr/bin/jq -cS .)" = \
+  "$(printf '%s' "$published_acceptance_artifact" | /usr/bin/jq -cS .)"
+printf '%s' "$published_acceptance_artifact_live" \
+  | write_once_or_compare "$published_acceptance_artifact_json"
+published_acceptance_zip="$post_release_attempt_root/published-acceptance.zip"
+(
+  set -o noclobber
+  arc_scoped_gh "$post_release_gh_token" api \
+    -H 'Accept: application/vnd.github+json' \
+    "repos/FerrumVir/arc-chain/actions/artifacts/$published_acceptance_artifact_id/zip" \
+    | /usr/bin/head --bytes="$((published_acceptance_artifact_size + 1))" \
+      > "$published_acceptance_zip"
+)
+test -f "$published_acceptance_zip" && test ! -L "$published_acceptance_zip"
+test "$(/usr/bin/stat --format='%s' "$published_acceptance_zip")" = \
+  "$published_acceptance_artifact_size"
+test "$(arc_sha256 "$published_acceptance_zip")" = \
+  "${published_acceptance_artifact_digest#sha256:}"
+/usr/bin/chmod 0400 "$published_acceptance_zip"
+published_acceptance_root="$post_release_attempt_root/published-acceptance"
+test ! -e "$published_acceptance_root"
+/usr/bin/mkdir -m 0700 "$published_acceptance_root"
+"$ARC_RECOVERY_PYTHON_PATH" -I - "$published_acceptance_zip" \
+  "$published_acceptance_root" <<'PY'
+import os
+import pathlib
+import stat
+import sys
+import zipfile
+
+archive = pathlib.Path(sys.argv[1])
+root = pathlib.Path(sys.argv[2]).resolve()
+expected_top = {
+    "POST-RELEASE-ARTIFACT-ACCEPTANCE.SHA256SUMS",
+    "POST-RELEASE-ARTIFACT-ACCEPTANCE.json",
+    "EVIDENCE-MANIFEST.json",
+    "component-artifacts.json",
+    "linux-x86_64.json",
+    "macos-arm64.json",
+    "macos-x86_64.json",
+    "release-binding.json",
+    "windows-x86_64.json",
+}
+expected_evidence = {
+    "linux-x86_64/app.stderr",
+    "linux-x86_64/app.stdout",
+    "linux-x86_64/extract.stderr",
+    "linux-x86_64/extract.stdout",
+    "linux-x86_64/headless-install.stderr",
+    "linux-x86_64/headless-install.stdout",
+    "linux-x86_64/headless-update.stderr",
+    "linux-x86_64/headless-update.stdout",
+    "linux-x86_64/legacy-data-after.json",
+    "linux-x86_64/legacy-data-before.json",
+    "linux-x86_64/legacy-home.txt",
+    "linux-x86_64/legacy-migration.stderr",
+    "linux-x86_64/legacy-migration.stdout",
+    "linux-x86_64/legacy-model-before.sha256",
+    "linux-x86_64/legacy-source.json",
+    "linux-x86_64/legacy-update.stderr",
+    "linux-x86_64/legacy-update.stdout",
+    "linux-x86_64/legacy-version.txt",
+    "linux-x86_64/window-geometry.txt",
+    "linux-x86_64/window-pid.txt",
+    "linux-x86_64/window-properties.txt",
+    "linux-x86_64/window.xwd",
+    "macos-arm64/desktop-window.json",
+    "macos-arm64/desktop.stderr",
+    "macos-arm64/desktop.stdout",
+    "macos-x86_64/desktop-window.json",
+    "macos-x86_64/desktop.stderr",
+    "macos-x86_64/desktop.stdout",
+    "release/published-evidence-artifact.json",
+    "release/published-evidence.zip",
+    "release/release-attempt-jobs.json",
+    "release/release-published.json",
+    "windows-x86_64/windows-desktop-window.json",
+    "windows-x86_64/windows-desktop.stderr",
+    "windows-x86_64/windows-desktop.stdout",
+    "windows-x86_64/windows-msi-admin.log",
+}
+if len(expected_evidence) != 36:
+    raise SystemExit("published acceptance evidence contract is not exactly 36 files")
+expected = expected_top | {f"evidence/{name}" for name in expected_evidence}
+with zipfile.ZipFile(archive) as handle:
+    entries = handle.infolist()
+    names = [entry.filename for entry in entries]
+    if len(names) != len(set(names)) or set(names) != expected:
+        raise SystemExit("published acceptance ZIP has a non-canonical file set")
+    if sum(entry.file_size for entry in entries) > 512 * 1024 * 1024:
+        raise SystemExit("published acceptance ZIP expands beyond its bound")
+    for entry in entries:
+        path = pathlib.PurePosixPath(entry.filename)
+        mode_type = (entry.external_attr >> 16) & 0o170000
+        if (
+            path.is_absolute()
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or "\\" in entry.filename
+            or entry.is_dir()
+            or entry.flag_bits & 0x1
+            or mode_type not in (0, stat.S_IFREG)
+        ):
+            raise SystemExit("published acceptance ZIP contains an unsafe path")
+        if (
+            entry.file_size > 256 * 1024 * 1024
+            or (entry.filename in expected_top and entry.file_size < 1)
+        ):
+            raise SystemExit("published acceptance ZIP contains an unsafe entry")
+        target = root.joinpath(*path.parts)
+        target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        with handle.open(entry, "r") as source, target.open("xb") as destination:
+            copied = 0
+            while chunk := source.read(1024 * 1024):
+                copied += len(chunk)
+                if copied > entry.file_size:
+                    raise SystemExit("published acceptance ZIP member exceeds its declared size")
+                destination.write(chunk)
+            destination.flush()
+            os.fsync(destination.fileno())
+        if copied != entry.file_size:
+            raise SystemExit("published acceptance ZIP member is truncated")
+        target.chmod(0o400)
+for directory in sorted(
+    (path for path in root.rglob("*") if path.is_dir()), reverse=True
+) + [root]:
+    directory_fd = os.open(directory, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+PY
+(cd "$published_acceptance_root" && /usr/bin/sha256sum --check --strict \
+  POST-RELEASE-ARTIFACT-ACCEPTANCE.SHA256SUMS)
+test "$(arc_git -C "$operator_checkout" rev-parse HEAD)" = "$protected_main_sha"
+published_acceptance_components="$post_release_attempt_root/published-components"
+/usr/bin/mkdir -m 0700 "$published_acceptance_components"
+for platform in linux-x86_64 macos-arm64 macos-x86_64 windows-x86_64; do
+  /usr/bin/cp -- "$published_acceptance_root/$platform.json" \
+    "$published_acceptance_components/$platform.json"
+done
+published_acceptance_rebuilt="$post_release_attempt_root/published-acceptance-rebuilt.json"
+"$ARC_RECOVERY_PYTHON_PATH" -I \
+  "$operator_checkout/scripts/release/published-artifact-acceptance.py" aggregate \
+  --binding "$published_acceptance_root/release-binding.json" \
+  --component-artifacts "$published_acceptance_root/component-artifacts.json" \
+  --components "$published_acceptance_components" \
+  --evidence-manifest "$published_acceptance_root/EVIDENCE-MANIFEST.json" \
+  --evidence-root "$published_acceptance_root/evidence" \
+  --acceptance-run-id "$published_acceptance_run_id" \
+  --acceptance-run-attempt "$published_acceptance_run_attempt" \
+  --output "$published_acceptance_rebuilt"
+/usr/bin/cmp -s "$published_acceptance_rebuilt" \
+  "$published_acceptance_root/POST-RELEASE-ARTIFACT-ACCEPTANCE.json"
+published_acceptance_receipt_sha="$(arc_sha256 \
+  "$published_acceptance_root/POST-RELEASE-ARTIFACT-ACCEPTANCE.json")"
+published_acceptance_selection="$release_control_root/PUBLISHED-ARTIFACT-ACCEPTANCE-SELECTION.json"
+/usr/bin/jq -cnS \
+  --argjson workflow_id "$published_acceptance_workflow_id" \
+  --argjson run_id "$published_acceptance_run_id" \
+  --argjson run_attempt "$published_acceptance_run_attempt" \
+  --arg head_sha "$protected_main_sha" \
+  --arg artifact_name "$published_acceptance_artifact_name" \
+  --argjson artifact_id "$published_acceptance_artifact_id" \
+  --arg artifact_digest "$published_acceptance_artifact_digest" \
+  --arg receipt_sha "$published_acceptance_receipt_sha" '
+  {schema:"arc.published-artifact-acceptance-selection.v1",
+   repository:"FerrumVir/arc-chain",workflow_id:$workflow_id,
+   workflow_path:".github/workflows/post-release-acceptance.yml",
+   dispatch_ref:"v0.8.0",head_sha:$head_sha,run_id:$run_id,
+   run_attempt:$run_attempt,artifact_name:$artifact_name,
+   artifact_id:$artifact_id,artifact_digest:$artifact_digest,
+   canonical_receipt_sha256:$receipt_sha}' \
+  | write_once_or_compare "$published_acceptance_selection"
+```
+
 ### Run published installer/update and live inference/reward acceptance gates
 
 Use a fresh, no-service install root on the reviewed Linux x86_64 operator.
@@ -3564,13 +4640,15 @@ and reused. The update-only pass must resolve the public channel back to
 v0.8.0 and report equality without replacement. Finally, rerun the rollout's
 read-only live verifier against the immutable two-canary reward evidence. This
 does not issue a third reward: it re-proves all-six convergence, inference
-attestations, the two mined `0x25` receipts, exact 5 ARC delta, and honest
-projection state from the existing evidence.
+attestations, the two mined `0x25` receipts, exact baseline-plus-5-ARC history
+through the sealed cutoff, and honest projection state from the existing
+evidence. Any intervening legitimate receipts pass only as a complete
+six-replica-agreed superset strictly after that cutoff.
 
 ```bash
 installer_canary_root="$release_control_root/installer-canary-linux-x86_64"
 installer_canary_receipt="$installer_canary_root/ACCEPTED.json"
-release_api_canary="$("$ARC_RECOVERY_GH_PATH" api \
+release_api_canary="$(arc_scoped_gh "$post_release_gh_token" api \
   repos/FerrumVir/arc-chain/releases/tags/v0.8.0)"
 printf '%s' "$release_api_canary" | /usr/bin/jq -e \
   --argjson release_id "$release_id" --arg sha "$protected_main_sha" '
@@ -3661,33 +4739,537 @@ test -s "$live_acceptance"
 /usr/bin/chmod 0400 "$live_acceptance"
 (cd /secure/operator && \
   /usr/bin/sha256sum --check --strict recovery-v3.reward-evidence.json.sha256)
+# The public-truth builder below performs the final protected-helper rebuild and
+# live all-six verification, then creates the canonical v2 acceptance receipt.
+unset post_release_gh_token
+```
 
-acceptance_receipt="$post_release_attempt_root/POST-RELEASE-ACCEPTANCE.json"
-/usr/bin/jq -cnS --arg source_sha "$protected_main_sha" \
+### Publish the sealed public truth through a second reviewed PR
+
+The protected-main public-truth helper is the authorization boundary for public
+live claims; the release-source README remains an immutable pre-release
+snapshot. In one create-only invocation it authenticates the preserved Pages
+workflow/run/jobs/deployment/CDN facts and the exact published-acceptance
+workflow/run/jobs/artifact, rebuilds that artifact with the exact sibling
+helper, and performs one final live all-six verification with the exact sibling
+recovery verifier. It creates exactly three root-only local files: the
+canonical `arc.post-release-acceptance.v2` receipt, the replacement README, and
+`arc.public-production-status.v1`, whose receipt hash binds that exact v2
+receipt and whose `acceptance.receipt` embeds the complete canonical receipt for
+public verification. Retain the standalone receipt as the root-only audit copy;
+publish only the README and status paths through a second, single-parent PR.
+This PR requires an exact-head
+`arisarcmarket` approval and every required check; unlike the earlier recovered
+config PR, there is no owner ruleset-exception path for public claims.
+
+The accepted config commit is named inside the generated bytes. The subsequent
+squash-merge SHA cannot safely name itself, so the second Pages deployment is
+bound separately by its exact run/attempt, deployment, `deployed-commit.txt`,
+and CDN byte hashes below.
+
+```bash
+public_truth_gh_token="$(
+  "$ARC_RECOVERY_GH_PATH" auth token --hostname github.com \
+    --user "$ARC_RECOVERY_GITHUB_LOGIN"
+)"
+test -n "$public_truth_gh_token"
+test "$(arc_scoped_gh "$public_truth_gh_token" api /user --jq .login)" = FerrumVir
+test "$(direct_collaborator_projection "$public_truth_gh_token")" = \
+  "$pretag_collaborator_baseline"
+test "$(arc_scoped_gh "$public_truth_gh_token" api \
+  repos/FerrumVir/arc-chain/branches/main \
+  --jq .commit.sha)" = "$frontend_main_sha"
+public_truth_helper="$PWD/scripts/release/build-postrelease-public-truth.py"
+test -f "$public_truth_helper" && test ! -L "$public_truth_helper"
+test "$(arc_git hash-object "$public_truth_helper")" = \
+  "$(arc_git rev-parse \
+    "$protected_main_sha:scripts/release/build-postrelease-public-truth.py")"
+
+public_truth_base_readme="$post_release_attempt_root/README.before-public-truth.md"
+public_truth_release_api="$post_release_attempt_root/public-truth-release-api.json"
+arc_git -C "$operator_checkout" show "$frontend_main_sha:README.md" \
+  | write_once_or_compare "$public_truth_base_readme"
+printf '%s' "$release_api_canary" | /usr/bin/jq -cS . \
+  | write_once_or_compare "$public_truth_release_api"
+public_truth_output="$post_release_attempt_root/public-truth-output"
+test ! -e "$public_truth_output" && test ! -L "$public_truth_output"
+"$ARC_RECOVERY_PYTHON_PATH" -I "$public_truth_helper" \
+  --readme "$public_truth_base_readme" \
+  --release-api "$public_truth_release_api" \
+  --pages-workflow "$pages_workflow_json" \
+  --pages-run "$pages_run_json" \
+  --pages-jobs "$pages_jobs_json" \
+  --pages-api "$pages_api_json" \
+  --pages-deployments "$pages_deployments_json" \
+  --pages-statuses "$pages_statuses_json" \
+  --frontend-config "$deployed_config" \
+  --deployed-commit "$deployed_commit" \
+  --deployed-sha256sums "$deployed_sums" \
+  --published-workflow "$published_acceptance_workflow_json" \
+  --published-run "$published_acceptance_run_json" \
+  --published-jobs "$published_acceptance_jobs_json" \
+  --published-artifact-metadata "$published_acceptance_artifact_json" \
+  --published-artifact-zip "$published_acceptance_zip" \
+  --reward-evidence "$reward_evidence" \
+  --rollout-manifest "$final_manifest" \
+  --output-dir "$public_truth_output"
+public_truth_readme="$public_truth_output/README.md"
+public_truth_status="$public_truth_output/production-status.json"
+acceptance_receipt="$public_truth_output/POST-RELEASE-ACCEPTANCE.json"
+test "$(/usr/bin/stat --format='%U:%G:%a:%h' "$public_truth_output")" = \
+  root:root:700:1
+for public_truth_local_output in \
+  "$public_truth_readme" "$public_truth_status" "$acceptance_receipt"
+do
+  test -f "$public_truth_local_output" && test ! -L "$public_truth_local_output"
+  test "$(/usr/bin/stat --format='%U:%G:%a:%h' "$public_truth_local_output")" = \
+    root:root:400:1
+done
+test "$(/usr/bin/find "$public_truth_output" -mindepth 1 -maxdepth 1 \
+  -type f -printf '%f\n' | /usr/bin/sort)" = \
+  "$(/usr/bin/printf '%s\n' README.md production-status.json \
+    POST-RELEASE-ACCEPTANCE.json | /usr/bin/sort)"
+public_truth_acceptance_sha="$(arc_sha256 "$acceptance_receipt")"
+public_truth_readme_sha="$(arc_sha256 "$public_truth_readme")"
+public_truth_status_sha="$(arc_sha256 "$public_truth_status")"
+/usr/bin/jq -e --arg source "$protected_main_sha" \
+  --argjson release_id "$release_id" \
   --argjson release_run_id "$release_run_id" \
-  --argjson release_run_attempt "$release_run_attempt" --argjson release_id "$release_id" \
-  --arg frontend_commit "$frontend_commit_sha" --argjson frontend_pr "$frontend_pr_number" \
-  --arg frontend_main "$frontend_main_sha" --argjson pages_run_id "$pages_run_id" \
+  --argjson release_run_attempt "$release_run_attempt" \
+  --arg frontend "$frontend_main_sha" \
+  --argjson pages_workflow_id "$pages_workflow_id" \
+  --argjson pages_run_id "$pages_run_id" \
   --argjson pages_run_attempt "$pages_run_attempt" \
   --argjson pages_deployment_id "$pages_deployment_id" \
-  --arg config_sha "$(arc_sha256 "$deployed_config")" \
-  --arg installer_receipt_sha "$(arc_sha256 "$installer_canary_receipt")" \
-  --arg reward_evidence_sha "$(arc_sha256 "$reward_evidence")" \
-  --arg live_verify_sha "$(arc_sha256 "$live_acceptance")" '
-  {schema:"arc.post-release-acceptance.v1",repository:"FerrumVir/arc-chain",
-   release_source_sha:$source_sha,release_run_id:$release_run_id,
-   release_run_attempt:$release_run_attempt,release_id:$release_id,
-   frontend_commit:$frontend_commit,frontend_pull_request:$frontend_pr,
-   frontend_main_sha:$frontend_main,pages_run_id:$pages_run_id,
-   pages_run_attempt:$pages_run_attempt,pages_deployment_id:$pages_deployment_id,
-   deployed_config_sha256:$config_sha,installer_receipt_sha256:$installer_receipt_sha,
-   reward_evidence_sha256:$reward_evidence_sha,live_verify_sha256:$live_verify_sha,
-   release_immutable:true,pages_jobs_succeeded:true,provenance_verified:true,
-   installer_update_verified:true,inference_reward_evidence_verified:true}' \
-  > "$acceptance_receipt"
-/usr/bin/chmod 0400 "$acceptance_receipt"
-/usr/bin/sync -f "$acceptance_receipt"
-/usr/bin/sync -f "$post_release_attempt_root"
+  --argjson published_workflow_id "$published_acceptance_workflow_id" \
+  --argjson published_run_id "$published_acceptance_run_id" \
+  --argjson published_run_attempt "$published_acceptance_run_attempt" \
+  --argjson published_artifact_id "$published_acceptance_artifact_id" \
+  --arg published_artifact_digest "$published_acceptance_artifact_digest" \
+  --arg published_receipt_sha "$published_acceptance_receipt_sha" \
+  --arg manifest_sha "$(arc_sha256 "$final_manifest")" \
+  --arg reward_sha "$(arc_sha256 "$reward_evidence")" '
+  (keys | sort) == (["pages","publishedAcceptance","recovery","release",
+                     "repository","schema"] | sort)
+  and .schema == "arc.post-release-acceptance.v2"
+  and .repository == "FerrumVir/arc-chain"
+  and .release.id == $release_id and .release.tag == "v0.8.0"
+  and .release.sourceCommit == $source
+  and .release.runId == $release_run_id
+  and .release.runAttempt == $release_run_attempt
+  and .pages.acceptedConfigCommit == $frontend
+  and .pages.workflowId == $pages_workflow_id
+  and .pages.runId == $pages_run_id
+  and .pages.runAttempt == $pages_run_attempt
+  and .pages.deploymentId == $pages_deployment_id
+  and .publishedAcceptance.workflowId == $published_workflow_id
+  and .publishedAcceptance.runId == $published_run_id
+  and .publishedAcceptance.runAttempt == $published_run_attempt
+  and .publishedAcceptance.artifactId == $published_artifact_id
+  and .publishedAcceptance.artifactDigest == $published_artifact_digest
+  and .publishedAcceptance.canonicalReceiptSha256 == $published_receipt_sha
+  and .publishedAcceptance.helperPath ==
+    "scripts/release/published-artifact-acceptance.py"
+  and .recovery.manifestSha256 == $manifest_sha
+  and .recovery.rewardEvidenceSha256 == $reward_sha
+  and .recovery.verifierPath == "scripts/recovery/recovery_rollout.py"' \
+  "$acceptance_receipt" >/dev/null
+/usr/bin/jq -cS . "$acceptance_receipt" \
+  | /usr/bin/cmp -s - "$acceptance_receipt"
+/usr/bin/jq -e --slurpfile receipt "$acceptance_receipt" \
+  --arg acceptance_sha "$public_truth_acceptance_sha" \
+  --arg source "$protected_main_sha" --arg accepted_config "$frontend_main_sha" '
+  .schema == "arc.public-production-status.v1" and .state == "recovered"
+  and .acceptance.receiptSha256 == $acceptance_sha
+  and .acceptance.receipt == $receipt[0]
+  and .release.sourceCommit == $source and .release.tag == "v0.8.0"
+  and .release.immutable == true
+  and .pages.acceptedConfigCommit == $accepted_config
+  and .checkpoint.height == 137145 and .checkpoint.recoveryHeight == 137146
+  and (.checkpoint.protocolVersion | test("^3\\.[0-9]+\\.[0-9]+$"))
+  and .fleet.validatorCount == 6 and .fleet.legacyForkCount == 6
+  and .fleet.requiredHealthyValidators == 6
+  and .rewards.canaryReceiptCount == 2
+  and .rewards.rewardPerReceiptBase == 2500000000
+  and .rewards.demonstratedGrossBase == 5000000000
+  and .rewards.stakeZeroEligible == true' "$public_truth_status" >/dev/null
+/usr/bin/jq -cS . "$public_truth_status" \
+  | /usr/bin/cmp -s - "$public_truth_status"
+/usr/bin/jq -cS '.acceptance.receipt' "$public_truth_status" \
+  | /usr/bin/cmp -s - "$acceptance_receipt"
+
+public_truth_branch='arc-recovery/public-truth-v0.8.0'
+public_truth_index="$(/usr/bin/mktemp \
+  "$release_control_root/public-truth-index.XXXXXXXX")"
+/usr/bin/rm -f -- "$public_truth_index"
+arc_public_truth_index_git() {
+  /usr/bin/env -i HOME="$git_home" PATH=/usr/bin:/bin LANG=C LC_ALL=C \
+    GIT_CONFIG_NOSYSTEM=1 GIT_INDEX_FILE="$public_truth_index" \
+    /usr/bin/git -C "$operator_checkout" "$@"
+}
+arc_public_truth_index_git read-tree "$frontend_main_sha^{tree}"
+public_truth_readme_blob="$(arc_git -C "$operator_checkout" \
+  hash-object -w -- "$public_truth_readme")"
+public_truth_status_blob="$(arc_git -C "$operator_checkout" \
+  hash-object -w -- "$public_truth_status")"
+[[ "$public_truth_readme_blob" =~ ^[0-9a-f]{40}$ ]]
+[[ "$public_truth_status_blob" =~ ^[0-9a-f]{40}$ ]]
+arc_public_truth_index_git update-index --add --cacheinfo 100644 \
+  "$public_truth_readme_blob" README.md
+arc_public_truth_index_git update-index --add --cacheinfo 100644 \
+  "$public_truth_status_blob" shared/frontend/production-status.json
+public_truth_tree_sha="$(arc_public_truth_index_git write-tree)"
+public_truth_parent_date="$(arc_git -C "$operator_checkout" show -s \
+  --format=%cI "$frontend_main_sha")"
+public_truth_commit_sha="$(
+  /usr/bin/printf '%s\n' 'Publish sealed ARC v0.8 public truth' \
+  | /usr/bin/env -i HOME="$git_home" PATH=/usr/bin:/bin LANG=C LC_ALL=C TZ=UTC \
+      GIT_CONFIG_NOSYSTEM=1 GIT_AUTHOR_NAME=FerrumVir \
+      GIT_AUTHOR_EMAIL=111036403+FerrumVir@users.noreply.github.com \
+      GIT_AUTHOR_DATE="$public_truth_parent_date" GIT_COMMITTER_NAME=FerrumVir \
+      GIT_COMMITTER_EMAIL=111036403+FerrumVir@users.noreply.github.com \
+      GIT_COMMITTER_DATE="$public_truth_parent_date" \
+      /usr/bin/git -C "$operator_checkout" -c commit.gpgSign=false \
+        commit-tree "$public_truth_tree_sha" -p "$frontend_main_sha"
+)"
+/usr/bin/rm -f -- "$public_truth_index"
+[[ "$public_truth_commit_sha" =~ ^[0-9a-f]{40}$ ]]
+test "$(arc_git -C "$operator_checkout" rev-list --parents -n 1 \
+  "$public_truth_commit_sha")" = "$public_truth_commit_sha $frontend_main_sha"
+test "$(arc_git -C "$operator_checkout" diff-tree --no-commit-id --name-only -r \
+  "$public_truth_commit_sha" | /usr/bin/sort)" = \
+  "$(/usr/bin/printf '%s\n' README.md shared/frontend/production-status.json \
+    | /usr/bin/sort)"
+arc_git -C "$operator_checkout" show "$public_truth_commit_sha:README.md" \
+  | /usr/bin/cmp -s - "$public_truth_readme"
+arc_git -C "$operator_checkout" show \
+  "$public_truth_commit_sha:shared/frontend/production-status.json" \
+  | /usr/bin/cmp -s - "$public_truth_status"
+arc_git -C "$operator_checkout" show \
+  "$public_truth_commit_sha:shared/frontend/arc-network.json" \
+  | /usr/bin/cmp -s - "$frontend_config"
+
+public_truth_remote_refs="$(arc_scoped_gh "$public_truth_gh_token" api \
+  'repos/FerrumVir/arc-chain/git/matching-refs/heads/arc-recovery/public-truth/v0.8.0' \
+  --jq .)"
+public_truth_remote_state="$(printf '%s' "$public_truth_remote_refs" \
+  | /usr/bin/jq -er --arg sha "$public_truth_commit_sha" \
+      --arg ref "refs/heads/$public_truth_branch" '
+      [.[] | select(.ref == $ref)] as $matches
+      | if ($matches | length) == 0 then "absent"
+        elif ($matches | length) == 1 and $matches[0].object.type == "commit"
+          and $matches[0].object.sha == $sha then "exact"
+        else "mismatch" end')"
+case "$public_truth_remote_state" in
+  absent)
+    public_truth_push_root="$(/usr/bin/mktemp -d \
+      "$release_control_root/public-truth-push.XXXXXXXX")"
+    test "$(/usr/bin/stat --format='%a:%h' "$public_truth_push_root")" = 700:1
+    public_truth_push_status=0
+    ( umask 077
+      set -o noclobber
+      /usr/bin/env -i HOME="$git_home" PATH=/usr/bin:/bin LANG=C LC_ALL=C TZ=UTC \
+        GH_TOKEN="$public_truth_gh_token" GH_PROMPT_DISABLED=1 \
+        GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_TERMINAL_PROMPT=0 \
+        /usr/bin/git -C "$operator_checkout" -c core.hooksPath=/dev/null \
+          -c credential.helper= \
+          -c "credential.https://github.com.helper=!$ARC_RECOVERY_GH_PATH auth git-credential" \
+          -c http.extraHeader= -c http.https://github.com/.extraHeader= \
+          -c http.sslVerify=true -c protocol.allow=never \
+          -c protocol.https.allow=always push --porcelain --atomic --no-verify \
+          --force-with-lease="refs/heads/$public_truth_branch:" \
+          -- https://github.com/FerrumVir/arc-chain.git \
+          "$public_truth_commit_sha:refs/heads/$public_truth_branch" \
+          >"$public_truth_push_root/STDOUT.txt" \
+          2>"$public_truth_push_root/STDERR.txt"
+    ) || public_truth_push_status=$?
+    ;;
+  exact) public_truth_push_status=0 ;;
+  *) printf 'public-truth branch has another identity; preserve and stop\n' >&2; exit 1 ;;
+esac
+public_truth_remote_after="$(arc_scoped_gh "$public_truth_gh_token" api \
+  'repos/FerrumVir/arc-chain/git/matching-refs/heads/arc-recovery/public-truth/v0.8.0' \
+  --jq .)"
+printf '%s' "$public_truth_remote_after" | /usr/bin/jq -e \
+  --arg sha "$public_truth_commit_sha" --arg ref "refs/heads/$public_truth_branch" '
+  [.[] | select(.ref == $ref and .object.type == "commit"
+    and .object.sha == $sha)] | length == 1' >/dev/null
+if [ "$public_truth_push_status" -ne 0 ]; then
+  printf 'public-truth push returned %s, but the post-query proved the exact branch\n' \
+    "$public_truth_push_status" >&2
+fi
+
+public_truth_pr_title='Publish sealed ARC v0.8 public truth'
+public_truth_pr_body='Publishes only the evidence-derived README marker block and production status after sealed post-release acceptance.'
+public_truth_prs="$(arc_scoped_gh "$public_truth_gh_token" api --method GET \
+  repos/FerrumVir/arc-chain/pulls -f state=all \
+  -f head="FerrumVir:$public_truth_branch" -f base=main \
+  | /usr/bin/jq -c --arg sha "$public_truth_commit_sha" \
+      '[.[] | select(.head.sha == $sha
+        and .head.ref == "arc-recovery/public-truth-v0.8.0"
+        and .base.ref == "main")]')"
+case "$(printf '%s' "$public_truth_prs" | /usr/bin/jq -er length)" in
+  0)
+    test "$(arc_scoped_gh "$public_truth_gh_token" api \
+      repos/FerrumVir/arc-chain/branches/main \
+      --jq .commit.sha)" = "$frontend_main_sha"
+    arc_scoped_gh "$public_truth_gh_token" api --method POST \
+      repos/FerrumVir/arc-chain/pulls \
+      -f title="$public_truth_pr_title" -f head="$public_truth_branch" -f base=main \
+      -f body="$public_truth_pr_body" -F draft=false >/dev/null
+    ;;
+  1) ;;
+  *) printf 'public-truth PR selection is ambiguous; preserve and stop\n' >&2; exit 1 ;;
+esac
+public_truth_prs="$(arc_scoped_gh "$public_truth_gh_token" api --method GET \
+  repos/FerrumVir/arc-chain/pulls -f state=all \
+  -f head="FerrumVir:$public_truth_branch" -f base=main \
+  | /usr/bin/jq -c --arg sha "$public_truth_commit_sha" \
+      '[.[] | select(.head.sha == $sha
+        and .head.ref == "arc-recovery/public-truth-v0.8.0"
+        and .base.ref == "main")]')"
+test "$(printf '%s' "$public_truth_prs" | /usr/bin/jq -er length)" -eq 1
+public_truth_pr_number="$(printf '%s' "$public_truth_prs" | /usr/bin/jq -er '.[0].number')"
+[[ "$public_truth_pr_number" =~ ^[1-9][0-9]*$ ]]
+public_truth_pr_state="$(printf '%s' "$public_truth_prs" | /usr/bin/jq -er '.[0].state')"
+arc_scoped_gh "$public_truth_gh_token" pr checks "$public_truth_pr_number" \
+  --repo FerrumVir/arc-chain --required --watch --interval 10
+case "$public_truth_pr_state" in
+  open)
+    public_truth_pr_view="$(arc_scoped_gh "$public_truth_gh_token" pr view \
+      "$public_truth_pr_number" \
+      --repo FerrumVir/arc-chain --json state,headRefOid,baseRefOid,reviewDecision)"
+    printf '%s' "$public_truth_pr_view" | /usr/bin/jq -e \
+      --arg head "$public_truth_commit_sha" --arg base "$frontend_main_sha" '
+      .state == "OPEN" and .headRefOid == $head and .baseRefOid == $base
+      and .reviewDecision == "APPROVED"' >/dev/null
+    public_truth_approval_count="$(arc_scoped_gh "$public_truth_gh_token" api --paginate \
+      "repos/FerrumVir/arc-chain/pulls/$public_truth_pr_number/reviews?per_page=100" \
+      --jq '.[]' | /usr/bin/jq -cs --arg head "$public_truth_commit_sha" '
+        [.[] | select(.user.login == "arisarcmarket" and .state == "APPROVED"
+          and .commit_id == $head)] | length')"
+    test "$public_truth_approval_count" -ge 1
+    test "$(frontend_main_ruleset_policy "$public_truth_gh_token")" = \
+      "$frontend_ruleset_baseline"
+    test "$(arc_scoped_gh "$public_truth_gh_token" api \
+      repos/FerrumVir/arc-chain/branches/main \
+      --jq .commit.sha)" = "$frontend_main_sha"
+    arc_scoped_gh "$public_truth_gh_token" api --method PUT \
+      "repos/FerrumVir/arc-chain/pulls/$public_truth_pr_number/merge" \
+      -f commit_title="$public_truth_pr_title" -f merge_method=squash \
+      -f sha="$public_truth_commit_sha" \
+      | /usr/bin/jq -e '.merged == true
+          and (.sha | test("^[0-9a-f]{40}$"))' >/dev/null
+    ;;
+  closed)
+    printf '%s' "$public_truth_prs" \
+      | /usr/bin/jq -e '.[0].merged_at != null' >/dev/null
+    public_truth_approval_count="$(arc_scoped_gh "$public_truth_gh_token" api --paginate \
+      "repos/FerrumVir/arc-chain/pulls/$public_truth_pr_number/reviews?per_page=100" \
+      --jq '.[]' | /usr/bin/jq -cs --arg head "$public_truth_commit_sha" '
+        [.[] | select(.user.login == "arisarcmarket" and .state == "APPROVED"
+          and .commit_id == $head)] | length')"
+    test "$public_truth_approval_count" -ge 1
+    ;;
+  *) exit 1 ;;
+esac
+public_truth_pr_live="$(arc_scoped_gh "$public_truth_gh_token" api \
+  "repos/FerrumVir/arc-chain/pulls/$public_truth_pr_number")"
+printf '%s' "$public_truth_pr_live" | /usr/bin/jq -e \
+  --arg head "$public_truth_commit_sha" '
+  .state == "closed" and .merged == true and .head.sha == $head
+  and .base.ref == "main" and (.merge_commit_sha | test("^[0-9a-f]{40}$"))' \
+  >/dev/null
+public_truth_main_sha="$(printf '%s' "$public_truth_pr_live" \
+  | /usr/bin/jq -er .merge_commit_sha)"
+arc_git -C "$operator_checkout" fetch --no-tags origin "$public_truth_main_sha"
+test "$(arc_git -C "$operator_checkout" rev-list --parents -n 1 \
+  "$public_truth_main_sha")" = "$public_truth_main_sha $frontend_main_sha"
+test "$(arc_git -C "$operator_checkout" rev-parse \
+  "$public_truth_main_sha^{tree}")" = "$public_truth_tree_sha"
+test "$(arc_git -C "$operator_checkout" diff --name-only \
+  "$frontend_main_sha" "$public_truth_main_sha" | /usr/bin/sort)" = \
+  "$(/usr/bin/printf '%s\n' README.md shared/frontend/production-status.json \
+    | /usr/bin/sort)"
+arc_git -C "$operator_checkout" show "$public_truth_main_sha:README.md" \
+  | /usr/bin/cmp -s - "$public_truth_readme"
+arc_git -C "$operator_checkout" show \
+  "$public_truth_main_sha:shared/frontend/production-status.json" \
+  | /usr/bin/cmp -s - "$public_truth_status"
+test "$(arc_scoped_gh "$public_truth_gh_token" api \
+  repos/FerrumVir/arc-chain/branches/main \
+  --jq .commit.sha)" = "$public_truth_main_sha"
+test "$(arc_scoped_gh "$public_truth_gh_token" api \
+  repos/FerrumVir/arc-chain/git/ref/tags/v0.8.0 --jq .object.sha)" = \
+  "$protected_main_sha"
+test "$(repository_ruleset_snapshot "$public_truth_gh_token")" = \
+  "$rulesets_before_frontend"
+test "$(frontend_main_ruleset_policy "$public_truth_gh_token")" = \
+  "$frontend_ruleset_baseline"
+```
+
+### Prove the exact second Pages run and public bytes
+
+Select only the Pages run for the second merge SHA. The cache-busted CDN reads
+must simultaneously match the unchanged accepted network config, generated
+public status, and new deployed commit marker, and the deployed `SHA256SUMS`
+must bind all three byte strings.
+
+```bash
+public_truth_pages_runs='[]'
+for _ in {1..30}; do
+  public_truth_pages_runs="$(arc_scoped_gh "$public_truth_gh_token" api --paginate \
+    'repos/FerrumVir/arc-chain/actions/workflows/deploy-explorer.yml/runs?event=push&branch=main&per_page=100' \
+    --jq '.workflow_runs[]' \
+    | /usr/bin/jq -cs --arg sha "$public_truth_main_sha" \
+        --argjson workflow_id "$pages_workflow_id" '
+        [.[] | select(.workflow_id == $workflow_id and .head_sha == $sha
+          and .head_branch == "main"
+          and .path == ".github/workflows/deploy-explorer.yml"
+          and .event == "push")]')"
+  public_truth_pages_count="$(printf '%s' "$public_truth_pages_runs" \
+    | /usr/bin/jq -er length)"
+  [ "$public_truth_pages_count" -eq 0 ] || break
+  /usr/bin/sleep 2
+done
+test "$public_truth_pages_count" -eq 1
+public_truth_pages_run_id="$(printf '%s' "$public_truth_pages_runs" \
+  | /usr/bin/jq -er '.[0].id')"
+public_truth_pages_run_attempt="$(printf '%s' "$public_truth_pages_runs" \
+  | /usr/bin/jq -er '.[0].run_attempt')"
+[[ "$public_truth_pages_run_id" =~ ^[1-9][0-9]*$ ]]
+[[ "$public_truth_pages_run_attempt" =~ ^[1-9][0-9]*$ ]]
+/usr/bin/jq -cnS --argjson id "$public_truth_pages_run_id" \
+  --argjson attempt "$public_truth_pages_run_attempt" \
+  --arg sha "$public_truth_main_sha" --argjson workflow_id "$pages_workflow_id" \
+  '{schema:"arc.public-truth-pages-run-selection.v1",
+    repository:"FerrumVir/arc-chain",workflow_id:$workflow_id,
+    workflow_path:".github/workflows/deploy-explorer.yml",event:"push",
+    head_branch:"main",head_sha:$sha,run_id:$id,run_attempt:$attempt}' \
+  | write_once_or_compare \
+      "$release_control_root/PUBLIC-TRUTH-PAGES-RUN-SELECTION.json"
+GH_TOKEN="$public_truth_gh_token" scripts/release/wait-workflow-attempt.sh \
+  FerrumVir/arc-chain "$public_truth_pages_run_id" \
+  "$public_truth_pages_run_attempt" success \
+  > "$post_release_attempt_root/public-truth-pages-run-wait.json"
+public_truth_pages_run="$(arc_scoped_gh "$public_truth_gh_token" api \
+  "repos/FerrumVir/arc-chain/actions/runs/$public_truth_pages_run_id/attempts/$public_truth_pages_run_attempt")"
+printf '%s' "$public_truth_pages_run" | /usr/bin/jq -e \
+  --argjson id "$public_truth_pages_run_id" \
+  --argjson attempt "$public_truth_pages_run_attempt" \
+  --argjson workflow_id "$pages_workflow_id" --arg sha "$public_truth_main_sha" '
+  .id == $id and .run_attempt == $attempt and .workflow_id == $workflow_id
+  and .head_repository.full_name == "FerrumVir/arc-chain"
+  and .head_sha == $sha and .head_branch == "main"
+  and .path == ".github/workflows/deploy-explorer.yml" and .event == "push"
+  and .status == "completed" and .conclusion == "success"' >/dev/null
+public_truth_pages_jobs="$(arc_scoped_gh "$public_truth_gh_token" api --paginate \
+  "repos/FerrumVir/arc-chain/actions/runs/$public_truth_pages_run_id/attempts/$public_truth_pages_run_attempt/jobs?per_page=100" \
+  --jq '.jobs[]' | /usr/bin/jq -cs 'sort_by(.name)')"
+printf '%s' "$public_truth_pages_jobs" | /usr/bin/jq -e '
+  length == 2
+  and ([.[] | select(.name == "Verify and assemble public console"
+    and .status == "completed" and .conclusion == "success")] | length) == 1
+  and ([.[] | select(.name == "Publish GitHub Pages"
+    and .status == "completed" and .conclusion == "success")] | length) == 1' \
+  >/dev/null
+printf '%s' "$public_truth_pages_run" \
+  | write_once_or_compare "$post_release_attempt_root/public-truth-pages-run.json"
+printf '%s' "$public_truth_pages_jobs" \
+  | write_once_or_compare "$post_release_attempt_root/public-truth-pages-jobs.json"
+
+public_truth_deployments="$(arc_scoped_gh "$public_truth_gh_token" api --method GET \
+  repos/FerrumVir/arc-chain/deployments -f sha="$public_truth_main_sha" \
+  -f environment=github-pages -f per_page=100 \
+  | /usr/bin/jq -c --arg sha "$public_truth_main_sha" '
+      [.[] | select(.sha == $sha and .ref == "main"
+        and .environment == "github-pages" and .task == "deploy")]')"
+test "$(printf '%s' "$public_truth_deployments" | /usr/bin/jq -er length)" -eq 1
+public_truth_deployment_id="$(printf '%s' "$public_truth_deployments" \
+  | /usr/bin/jq -er '.[0].id')"
+[[ "$public_truth_deployment_id" =~ ^[1-9][0-9]*$ ]]
+public_truth_deployment_statuses="$(arc_scoped_gh "$public_truth_gh_token" api \
+  "repos/FerrumVir/arc-chain/deployments/$public_truth_deployment_id/statuses?per_page=100")"
+printf '%s' "$public_truth_deployment_statuses" | /usr/bin/jq -e \
+  --arg url "$pages_url" '
+  [.[] | select(.state == "success" and .environment == "github-pages"
+    and ((.environment_url | rtrimstr("/")) == $url))] | length == 1' >/dev/null
+printf '%s' "$public_truth_deployments" \
+  | write_once_or_compare "$post_release_attempt_root/public-truth-pages-deployments.json"
+printf '%s' "$public_truth_deployment_statuses" \
+  | write_once_or_compare "$post_release_attempt_root/public-truth-pages-statuses.json"
+
+public_truth_deployed_config="$post_release_attempt_root/public-truth-arc-network.json"
+public_truth_deployed_status="$post_release_attempt_root/public-truth-production-status.json"
+public_truth_deployed_commit="$post_release_attempt_root/public-truth-deployed-commit.txt"
+public_truth_deployed_sums="$post_release_attempt_root/public-truth-SHA256SUMS"
+public_truth_pages_bytes_match=false
+for _ in {1..12}; do
+  /usr/bin/curl --fail --silent --show-error --location \
+    --proto '=https' --proto-redir '=https' --tlsv1.2 --max-time 30 \
+    --max-filesize 4194304 \
+    "$pages_url/shared/frontend/arc-network.json?commit=$public_truth_main_sha" \
+    -o "$public_truth_deployed_config.tmp"
+  /usr/bin/curl --fail --silent --show-error --location \
+    --proto '=https' --proto-redir '=https' --tlsv1.2 --max-time 30 \
+    --max-filesize 4194304 \
+    "$pages_url/shared/frontend/production-status.json?commit=$public_truth_main_sha" \
+    -o "$public_truth_deployed_status.tmp"
+  /usr/bin/curl --fail --silent --show-error --location \
+    --proto '=https' --proto-redir '=https' --tlsv1.2 --max-time 30 \
+    --max-filesize 1024 \
+    "$pages_url/deployed-commit.txt?commit=$public_truth_main_sha" \
+    -o "$public_truth_deployed_commit.tmp"
+  if /usr/bin/cmp -s "$public_truth_deployed_config.tmp" "$frontend_config" \
+      && /usr/bin/cmp -s "$public_truth_deployed_status.tmp" "$public_truth_status" \
+      && test "$(/usr/bin/tr -d '\r\n' \
+        < "$public_truth_deployed_commit.tmp")" = "$public_truth_main_sha"; then
+    /usr/bin/mv -- "$public_truth_deployed_config.tmp" "$public_truth_deployed_config"
+    /usr/bin/mv -- "$public_truth_deployed_status.tmp" "$public_truth_deployed_status"
+    /usr/bin/mv -- "$public_truth_deployed_commit.tmp" "$public_truth_deployed_commit"
+    public_truth_pages_bytes_match=true
+    break
+  fi
+  /usr/bin/rm -f -- "$public_truth_deployed_config.tmp" \
+    "$public_truth_deployed_status.tmp" "$public_truth_deployed_commit.tmp"
+  /usr/bin/sleep 5
+done
+test "$public_truth_pages_bytes_match" = true
+/usr/bin/curl --fail --silent --show-error --location \
+  --proto '=https' --proto-redir '=https' --tlsv1.2 --max-time 30 \
+  --max-filesize 1048576 \
+  "$pages_url/SHA256SUMS?commit=$public_truth_main_sha" \
+  -o "$public_truth_deployed_sums"
+test "$(/usr/bin/awk '$2 == "./shared/frontend/arc-network.json" {print $1}' \
+  "$public_truth_deployed_sums")" = "$(arc_sha256 "$frontend_config")"
+test "$(/usr/bin/awk '$2 == "./shared/frontend/production-status.json" {print $1}' \
+  "$public_truth_deployed_sums")" = "$public_truth_status_sha"
+test "$(/usr/bin/awk '$2 == "./deployed-commit.txt" {print $1}' \
+  "$public_truth_deployed_sums")" = "$(arc_sha256 "$public_truth_deployed_commit")"
+/usr/bin/chmod 0400 "$public_truth_deployed_config" \
+  "$public_truth_deployed_status" "$public_truth_deployed_commit" \
+  "$public_truth_deployed_sums"
+/usr/bin/jq -cnS --arg source "$protected_main_sha" \
+  --arg accepted_config "$frontend_main_sha" --arg commit "$public_truth_commit_sha" \
+  --argjson pr "$public_truth_pr_number" --arg main "$public_truth_main_sha" \
+  --arg acceptance_sha "$public_truth_acceptance_sha" \
+  --arg readme_sha "$public_truth_readme_sha" --arg status_sha "$public_truth_status_sha" \
+  --argjson run_id "$public_truth_pages_run_id" \
+  --argjson run_attempt "$public_truth_pages_run_attempt" \
+  --argjson deployment_id "$public_truth_deployment_id" \
+  --arg sums_sha "$(arc_sha256 "$public_truth_deployed_sums")" '
+  {schema:"arc.post-release-public-truth-acceptance.v1",
+   release_source_sha:$source,accepted_config_main_sha:$accepted_config,
+   public_truth_commit:$commit,public_truth_pull_request:$pr,
+   public_truth_main_sha:$main,post_release_acceptance_sha256:$acceptance_sha,
+   readme_sha256:$readme_sha,production_status_sha256:$status_sha,
+   pages_run_id:$run_id,pages_run_attempt:$run_attempt,
+   pages_deployment_id:$deployment_id,deployed_sums_sha256:$sums_sha,
+   exact_reviewed_paths:true,pages_jobs_succeeded:true,deployed_bytes_verified:true}' \
+  | write_once_or_compare "$release_control_root/PUBLIC-TRUTH-ACCEPTANCE.json"
+test "$(direct_collaborator_projection "$public_truth_gh_token")" = \
+  "$pretag_collaborator_baseline"
+unset public_truth_gh_token
 ```
 
 Only now may the operator restore the normal package-update schedule:
@@ -3728,10 +5310,13 @@ epoch, set, domain, validator-set commitment, and amount agreement.
   invokes ordinal 2. It never submits both at once.
 
 For the production GO gate, the manifest validator requires the staged,
-SHA-pinned repository probe with the exact one-token argv; policy-only mode,
-fixed receipts, a foreign probe path/hash, or a different token count is
-rejected before plan/GO. The probe first requires an issuance-ready validator that sees an eligible
-full-model worker, submits one real one-token `/inference/run`, and refuses to
+SHA-pinned repository probe with the exact one-token argv and
+`--expected-worker` address copied from the hash-bound, at-most-six-hour-old
+macOS canary acceptance receipt; policy-only mode, fixed receipts, a foreign
+probe path/hash, worker, acceptance hash, or token count is rejected before
+plan/GO. The probe first requires an issuance-ready validator that sees that
+exact eligible full-model worker, submits one real one-token `/inference/run`
+targeted to it, and refuses to
 emit evidence unless the response proves community routing, the canonical
 per-row INT8 execution profile, authenticated 2-of-3 verification for every
 range/position, five validator approvals, and a pending `0x25` transaction:
@@ -3748,8 +5333,10 @@ Bind those values into the draft before sealing:
   "mode": "receipt",
   "expect_protocol_active": true,
   "expect_issuance_ready": true,
-  "probe_argv": ["/absolute/path/to/scripts/recovery/community-reward-probe.py"],
+  "probe_argv": ["/absolute/path/to/scripts/recovery/community-reward-probe.py", "--max-tokens", "1", "--expected-worker", "0x<accepted-worker>"],
   "probe_sha256": "<exact 64-character hash above>",
+  "expected_worker": "0x<accepted-worker>",
+  "macos_canary_acceptance_sha256": "<exact staged ACCEPTED.json SHA-256>",
   "expected_reward_base": 2500000000
 }
 ```
@@ -3768,16 +5355,16 @@ The namespaced probe identity is committed as the signed assignment epoch and
 has a consensus replay marker, so a retry rediscovers the same job/transaction
 across client or coordinator restarts and cannot pay through another
 coordinator. Before invoking the probe, the rollout queries all six earnings
-indexes and fsyncs the complete canonical all-v3 history for every potentially
-eligible worker visible to that sealed coordinator (fixed-evidence mode has one
-known worker). The actual worker must belong to that pre-canary set. The
+indexes and fsyncs the complete canonical all-v3 history for the exact accepted
+worker (fixed-evidence mode likewise has one known worker). The probe response,
+settlement, and both receipts must all return that same worker. The
 reserved checksum file is a canonical, fsynced baseline-plus-0/1/2 progress
 journal until final evidence promotion; crashes after the baseline, either receipt, or during
 the earnings/projection-state check therefore re-prove GET-only state without
 issuing another reward. Immediately before ordinal one, including after a
-baseline-only crash resume, the harness re-queries the selectable-worker set
-and all six earnings indexes: a new selectable worker or any changed baseline
-row aborts before the probe can issue a reward.
+baseline-only crash resume, the harness re-queries the accepted worker and all
+six earnings indexes: an unavailable/ineligible accepted worker or any changed
+baseline row aborts before the probe can issue a reward.
 A pending or failed transaction never passes. Both jobs use a real one-token request, but the first must reach
 `mined_success` on all six before the second is submitted. The receipts must
 land at two distinct heights (different hashes at one height are a fork, not
@@ -3785,10 +5372,14 @@ two blocks), each carry at least five approvals, and reconcile on every
 `/worker/earnings/{worker}` response to exactly 2,500,000,000 base units / 2.5
 ARC apiece. Every pre-canary baseline row—including its block hash, transaction
 index, recovery epoch, validator set, and transaction domain—must remain
-byte-for-byte canonical;
-the post-canary count must be baseline count + 2 and gross must be baseline
-gross + 5 ARC, with no third new row. For an empty baseline, exactly two
-immediate receipts are not a rate sample: `attestations_per_day_observed` and
+byte-for-byte canonical. At or before the canonical second-canary block/index
+cutoff, the history must be exactly baseline plus those two receipts and gross
+must be baseline gross + 5 ARC. A later audit accepts a larger history only
+when all six replicas agree on the complete valid history and every extra
+receipt is strictly after the sealed cutoff; a foreign earlier row,
+dropped/mutated baseline row, or replica disagreement fails closed. For an
+empty baseline, exactly two receipts through the cutoff are not a rate sample:
+`attestations_per_day_observed` and
 `projected_daily_arc` must both remain null, and both unavailable reasons must exactly say
 `collecting data: a projection needs at least 3 successful mined reward receipts spanning at least 24 hours, not the initial one or two rollout canaries`. A numeric rate or
 forecast at that boundary fails closed. With a nonempty baseline, the full
@@ -3811,10 +5402,11 @@ preserves this argument:
 
 The rollout writes that file and its `.sha256` sidecar mode `0444` only after
 both receipts and the six-node baseline-retention/delta/projection contract
-pass. Its JSON includes `schema: arc.recovery.reward-evidence.v2`, the exact
-rollout SHA-256, both canary identities, and the selected worker's complete
-pre-canary earnings baseline. It is never reconstructed from chat output and
-is never overwritten.
+pass. Its JSON includes `schema: arc.recovery.reward-evidence.v3`, the exact
+rollout SHA-256, both canary identities, the selected worker's complete
+pre-canary earnings baseline, and the inclusive canonical block-height/hash/
+transaction-index cutoff. It is never reconstructed from chat output and is
+never overwritten.
 
 A later read-only audit can use externally captured evidence:
 

--- a/scripts/recovery/archive-fleet-to-drive.sh
+++ b/scripts/recovery/archive-fleet-to-drive.sh
@@ -8930,6 +8930,7 @@ PY
     fi
     printf 'archive fleet: selected fresh canary-bound live-observation generation %s root=%s\n' \
         "$observation_generation" "$observation_selection_sha"
+    remote_readiness "$capture_id" "$freeze_sha" "$freeze_plan"
     quarantine_generation_ledger_sha="$(run_quarantine_generation_rounds \
         "$freeze_plan" "$freeze_sha" "$capture_id" "$maintenance_input_root" \
         "$log_root" "$quarantine_generation_ledger" "$inspector_binary_sha" \

--- a/scripts/recovery/build-production-manifest.py
+++ b/scripts/recovery/build-production-manifest.py
@@ -28,6 +28,7 @@ import struct
 import subprocess
 import sys
 import tempfile
+import time
 import tomllib
 from pathlib import Path
 from typing import Any, Mapping, NoReturn, Sequence
@@ -107,6 +108,7 @@ PRETAG_WINDOW_SET_SCHEMA = "arc.protected-pretag-artifact-window-set.v1"
 APPROVED_ACME_EMAIL = "tj@arc.ai"
 MAX_OFFLINE_STOP_VERIFICATION_AGE_SECONDS = 300
 MAX_OFFLINE_STOP_VERIFICATION_DURATION_MS = 120_000
+MAX_MACOS_CANARY_ACCEPTANCE_AGE_SECONDS = 6 * 60 * 60
 # The live capture path enforces this wall-clock bound immediately before the
 # authenticated all-writer cross-proof. The post-stop builder re-proves the
 # same bound from the immutable receipt/cross-proof timeline; the six official
@@ -152,6 +154,7 @@ PROTECTED_MAIN_EXECUTION_FILES = (
     SCRIPT_DIR / "community-reward-probe.py",
     SCRIPT_DIR / "legacy-late-fork-interlock.py",
     RELEASE_SCRIPT_DIR / "protected_pretag_artifact.py",
+    RELEASE_SCRIPT_DIR / "macos-community-canary.py",
 )
 
 
@@ -935,6 +938,15 @@ def stage_prearchive_inputs(args: argparse.Namespace) -> tuple[argparse.Namespac
                 True,
                 "root",
             ),
+            (
+                "macos_canary_acceptance",
+                args.macos_canary_acceptance,
+                "MACOS-CANARY-ACCEPTANCE.json",
+                64 * 1024,
+                0o400,
+                False,
+                "root",
+            ),
         )
         for attribute, source, name, maximum, mode, executable, directory in specs:
             destination_parent_fd = root_fd if directory == "root" else child_fds[directory]
@@ -1400,6 +1412,135 @@ def load_pretag_input_set(
             }
         )
     return result, payload, digest
+
+
+def validate_macos_canary_acceptance(
+    path: Path,
+    *,
+    source_main_sha: str,
+    run_id: int,
+    run_attempt: int,
+    verified_pretag_artifacts: Sequence[Mapping[str, Any]],
+) -> tuple[dict[str, Any], bytes, str]:
+    """Authenticate the dedicated pre-tag Mac worker accepted for reward probes."""
+
+    value, payload, digest = load_canonical_json(
+        path,
+        label="macOS pre-tag community canary acceptance",
+        maximum_bytes=64 * 1024,
+        exact_mode=0o400,
+        require_read_only=True,
+    )
+    receipt = require_exact_object(
+        value,
+        {
+            "schema", "accepted", "accepted_at_unix_ns", "canary_schema",
+            "label", "platform", "rust_target", "config_sha256", "worker",
+            "pretag", "runtime", "artifacts", "process",
+        },
+        "macOS pre-tag community canary acceptance",
+    )
+    accepted_at = require_uint(
+        receipt["accepted_at_unix_ns"],
+        "macOS canary accepted_at_unix_ns",
+        positive=True,
+    )
+    now_ns = time.time_ns()
+    if accepted_at > now_ns + 60_000_000_000:
+        fail("macOS canary acceptance timestamp is in the future")
+    if now_ns - accepted_at > MAX_MACOS_CANARY_ACCEPTANCE_AGE_SECONDS * 1_000_000_000:
+        fail(
+            "macOS canary acceptance is older than the six-hour production-manifest window"
+        )
+    exact = {
+        "schema": "arc.macos.pretag-community-canary.acceptance.v1",
+        "accepted": True,
+        "canary_schema": "arc.macos.pretag-community-canary.v1",
+        "label": "network.arc.pretag-community-canary",
+        "platform": "macos-arm64",
+        "rust_target": "aarch64-apple-darwin",
+    }
+    for field, expected in exact.items():
+        if receipt[field] != expected:
+            fail(f"macOS canary acceptance {field} differs")
+    require_hash(receipt["config_sha256"], "macOS canary config sha256")
+    worker = receipt["worker"]
+    if not isinstance(worker, str) or re.fullmatch(r"0x[0-9a-f]{64}", worker) is None:
+        fail("macOS canary acceptance worker must be one 0x-prefixed lowercase address")
+
+    mac_rows = [
+        row
+        for row in verified_pretag_artifacts
+        if (row.get("kind"), row.get("platform")) == ("headless", "macos-arm64")
+    ]
+    if len(mac_rows) != 1:
+        fail("protected pre-tag artifact set lacks one macOS arm64 headless group")
+    proof = mac_rows[0]["provenance"]
+    live = proof["live"]
+    artifact = proof["artifact"]
+    pretag = require_exact_object(
+        receipt["pretag"],
+        {
+            "repository", "commit", "run_id", "run_attempt", "artifact_id",
+            "artifact_digest", "archive_sha256", "metadata_sha256",
+        },
+        "macOS canary acceptance pretag",
+    )
+    expected_pretag = {
+        "repository": REPOSITORY,
+        "commit": source_main_sha,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+        "artifact_id": live["artifact_id"],
+        "artifact_digest": live["artifact_digest"],
+        "archive_sha256": artifact["archive_sha256"],
+        "metadata_sha256": artifact["build_metadata_sha256"],
+    }
+    if pretag != expected_pretag:
+        fail("macOS canary acceptance is bound to a different protected pre-tag artifact")
+
+    runtime = require_exact_object(
+        receipt["runtime"],
+        {
+            "stake", "community_mode", "full_integer_worker", "rpc_loopback_only",
+            "p2p_peers", "p2p_port", "community_rpc_urls", "argv_sha256",
+        },
+        "macOS canary acceptance runtime",
+    )
+    expected_origins = [f"https://{host}" for _name, host in FLEET]
+    if (
+        runtime["stake"] != 0
+        or runtime["community_mode"] is not True
+        or runtime["full_integer_worker"] is not True
+        or runtime["rpc_loopback_only"] is not True
+        or runtime["p2p_peers"] != []
+        or runtime["p2p_port"] != 0
+        or runtime["community_rpc_urls"] != expected_origins
+    ):
+        fail("macOS canary acceptance runtime is not the dedicated stake-zero worker")
+    require_hash(runtime["argv_sha256"], "macOS canary runtime argv sha256")
+
+    artifacts = require_exact_object(
+        receipt["artifacts"],
+        {"node_sha256", "model_sha256", "genesis_sha256"},
+        "macOS canary acceptance artifacts",
+    )
+    expected_artifacts = {
+        "node_sha256": artifact["files"]["arc-node-macos-arm64"],
+        "model_sha256": rollout.CANONICAL_MODEL_SHA256,
+        "genesis_sha256": artifact["files"]["genesis.toml"],
+    }
+    if artifacts != expected_artifacts:
+        fail("macOS canary acceptance artifact hashes differ from protected pre-tag/canonical bytes")
+    process = require_exact_object(
+        receipt["process"],
+        {"pid", "exact_executable_argv_and_listeners_proved"},
+        "macOS canary acceptance process",
+    )
+    require_uint(process["pid"], "macOS canary acceptance pid", positive=True)
+    if process["exact_executable_argv_and_listeners_proved"] is not True:
+        fail("macOS canary acceptance lacks the exact live process proof")
+    return receipt, payload, digest
 
 
 def create_private_seal(path: Path, value: Mapping[str, Any]) -> str:
@@ -5398,6 +5539,17 @@ def prearchive(args: argparse.Namespace) -> str:
     }
     if staged_provenance_set != expected_staged_set:
         fail("staged protected pre-tag provenance set differs from the nine live proof transactions")
+    (
+        macos_canary_acceptance,
+        _macos_canary_acceptance_payload,
+        macos_canary_acceptance_sha,
+    ) = validate_macos_canary_acceptance(
+        args.macos_canary_acceptance,
+        source_main_sha=args.source_main_sha,
+        run_id=args.pretag_run_id,
+        run_attempt=args.pretag_run_attempt,
+        verified_pretag_artifacts=args.pretag_verified_artifacts,
+    )
     metadata, metadata_sha = validate_build_metadata(args)
     freeze, freeze_payload, freeze_sha, freeze_sidecar_sha, freeze_sidecar = validate_freeze_inputs(args)
     (
@@ -5608,6 +5760,10 @@ def prearchive(args: argparse.Namespace) -> str:
         "reward_probe": artifact(
             args.reward_probe, "community reward probe", executable=True
         ),
+        "macos_canary_acceptance": {
+            "path": os.fspath(args.macos_canary_acceptance),
+            "sha256": macos_canary_acceptance_sha,
+        },
         "checkpoint": artifact(args.checkpoint, "signed recovery checkpoint"),
         "legacy_validator_set": artifact(args.legacy_validator_set, "legacy validator set"),
         "source_snapshot": artifact(args.source_snapshot, "canonical source snapshot"),
@@ -5700,8 +5856,16 @@ def prearchive(args: argparse.Namespace) -> str:
                 "mode": "receipt",
                 "expect_protocol_active": True,
                 "expect_issuance_ready": True,
-                "probe_argv": [os.fspath(args.reward_probe), "--max-tokens", "1"],
+                "probe_argv": [
+                    os.fspath(args.reward_probe),
+                    "--max-tokens",
+                    "1",
+                    "--expected-worker",
+                    macos_canary_acceptance["worker"],
+                ],
                 "probe_sha256": artifacts["reward_probe"]["sha256"],
+                "expected_worker": macos_canary_acceptance["worker"],
+                "macos_canary_acceptance_sha256": macos_canary_acceptance_sha,
                 "expected_reward_base": rollout.COMMUNITY_REWARD_BASE,
             },
         },
@@ -5956,6 +6120,23 @@ def prearchive(args: argparse.Namespace) -> str:
             rollout.require_prearchive_manifest(manifest)
         except rollout.RolloutError as error:
             fail(f"final fresh protected-artifact manifest validation failed: {error}")
+        (
+            final_canary_acceptance,
+            final_canary_acceptance_payload,
+            final_canary_acceptance_sha,
+        ) = validate_macos_canary_acceptance(
+            args.macos_canary_acceptance,
+            source_main_sha=args.source_main_sha,
+            run_id=args.pretag_run_id,
+            run_attempt=args.pretag_run_attempt,
+            verified_pretag_artifacts=args.pretag_verified_artifacts,
+        )
+        if (
+            final_canary_acceptance != macos_canary_acceptance
+            or final_canary_acceptance_payload != _macos_canary_acceptance_payload
+            or final_canary_acceptance_sha != macos_canary_acceptance_sha
+        ):
+            fail("macOS canary acceptance changed before prearchive publication")
         recheck_artifact_identities()
         return create_private_seal(args.output, manifest)
 
@@ -6542,6 +6723,11 @@ def validate_archive_evidence(
             "validator_key_install_receipt",
             "VALIDATOR-KEY-INSTALL-RECEIPT.json",
         ),
+        "MACOS-CANARY-ACCEPTANCE.json": _expected_artifact_object(
+            prearchive,
+            "macos_canary_acceptance",
+            "MACOS-CANARY-ACCEPTANCE.json",
+        ),
         "drive-archive-seal-prefreeze.json": (
             "drive-archive-seal-prefreeze.json",
             len(drive_receipt_payload),
@@ -6872,6 +7058,12 @@ def parser() -> argparse.ArgumentParser:
     prepare.add_argument("--source-wal", required=True, type=absolute_path)
     prepare.add_argument("--caddy", required=True, type=absolute_path)
     prepare.add_argument("--reward-probe", required=True, type=absolute_path)
+    prepare.add_argument(
+        "--macos-canary-acceptance",
+        required=True,
+        type=absolute_path,
+        help="canonical ACCEPTED.json from the exact running macOS arm64 pre-tag worker",
+    )
     prepare.add_argument(
         "--stage-root",
         required=True,

--- a/scripts/recovery/community-reward-probe.py
+++ b/scripts/recovery/community-reward-probe.py
@@ -120,7 +120,9 @@ def rpc_origins(cli_origins: list[str]) -> list[str]:
     return origins
 
 
-def eligible_coordinators(origins: list[str], timeout: float) -> list[str]:
+def eligible_coordinators(
+    origins: list[str], timeout: float, expected_worker: str
+) -> list[str]:
     eligible: list[str] = []
     diagnostics: list[str] = []
     for origin in origins:
@@ -133,17 +135,53 @@ def eligible_coordinators(origins: list[str], timeout: float) -> list[str]:
                 diagnostics.append(f"{origin}: reward issuance is not ready")
                 continue
             scoreboard = require_object(
-                request_json(origin, "/workers/scoreboard?limit=1", timeout),
+                request_json(
+                    origin,
+                    f"/workers/scoreboard?limit=1&worker_id={expected_worker}",
+                    timeout,
+                ),
                 f"{origin} worker scoreboard",
             )
-            if require_int(
+            eligible_count = require_int(
                 scoreboard.get("eligible_inference_workers"),
                 f"{origin} eligible_inference_workers",
                 0,
-            ) > 0:
+            )
+            workers = scoreboard.get("workers")
+            if not isinstance(workers, list):
+                fail(f"{origin} worker scoreboard workers must be an array")
+            coordinator_model_id = require_hash(
+                scoreboard.get("coordinator_model_id"),
+                f"{origin} coordinator_model_id",
+            )
+            matching = []
+            for index, row in enumerate(workers):
+                worker = require_object(row, f"{origin} workers[{index}]")
+                worker_id = require_hash(
+                    worker.get("worker_id"), f"{origin} workers[{index}].worker_id"
+                )
+                if worker_id != expected_worker:
+                    continue
+                capabilities = worker.get("capabilities")
+                if (
+                    not isinstance(capabilities, list)
+                    or not all(isinstance(item, str) for item in capabilities)
+                    or "inference" not in capabilities
+                    or worker.get("execution_profile") != CANONICAL_PROFILE
+                    or require_hash(
+                        worker.get("model_id"),
+                        f"{origin} workers[{index}].model_id",
+                    )
+                    != coordinator_model_id
+                ):
+                    fail(f"{origin} accepted worker is not exact-model reward eligible")
+                matching.append(worker)
+            if eligible_count > 0 and len(matching) == 1:
                 eligible.append(origin)
             else:
-                diagnostics.append(f"{origin}: no eligible full-model worker")
+                diagnostics.append(
+                    f"{origin}: accepted worker is absent, duplicated, or not eligible"
+                )
         except ProbeError as error:
             diagnostics.append(str(error))
     if not eligible:
@@ -209,7 +247,7 @@ def require_reward_transaction_state(
 
 
 def evidence_from_inference(
-    value: Any, origin: str, expected_probe_id: str
+    value: Any, origin: str, expected_probe_id: str, expected_worker: str
 ) -> dict[str, str]:
     body = require_object(value, f"{origin} inference response")
     if body.get("success") is not True:
@@ -219,6 +257,8 @@ def evidence_from_inference(
 
     worker = require_object(body.get("worker"), f"{origin} worker evidence")
     worker_id = require_hash(worker.get("worker_id"), "worker.worker_id")
+    if worker_id != expected_worker:
+        fail(f"{origin} routed recovery work to a worker other than the accepted canary")
     routed_via = body.get("routed_via")
     if routed_via != f"community:{worker.get('worker_id')}":
         fail(f"{origin} did not route through the evidenced community worker")
@@ -269,6 +309,7 @@ def evidence_from_replay(
     value: Any,
     origin: str,
     expected_probe_id: str,
+    expected_worker: str,
     timeout: float,
 ) -> dict[str, str]:
     body = require_object(value, f"{origin} recovery replay response")
@@ -298,6 +339,8 @@ def evidence_from_replay(
                 settlement_worker = require_hash(
                     settlement.get("worker"), "settlement.worker"
                 )
+                if settlement_worker != expected_worker:
+                    fail("replay settlement belongs to a worker other than the accepted canary")
                 body_worker = body.get("worker")
                 if body_worker is not None:
                     routed_worker = require_hash(
@@ -341,6 +384,11 @@ def parse_args() -> argparse.Namespace:
         help="distinct receipt in the required two-receipt rollout proof",
     )
     parser.add_argument(
+        "--expected-worker",
+        required=True,
+        help="exact 32-byte worker identity from the macOS canary acceptance receipt",
+    )
+    parser.add_argument(
         "--recovery-probe-id",
         default=None,
         help="optional exact derived identity; any mismatch is rejected",
@@ -362,6 +410,7 @@ def main() -> int:
     checkpoint = os.environ.get("ARC_RECOVERY_CHECKPOINT_MANIFEST_HASH", "")
     if not re.fullmatch(r"[0-9a-f]{64}", checkpoint):
         fail("ARC_RECOVERY_CHECKPOINT_MANIFEST_HASH is missing or invalid")
+    expected_worker = require_hash(args.expected_worker, "--expected-worker")
     probe_id = recovery_probe_id(manifest, args.probe_ordinal)
     if args.recovery_probe_id is not None:
         supplied = require_hash(args.recovery_probe_id, "--recovery-probe-id")
@@ -373,7 +422,9 @@ def main() -> int:
         fail("probe input must be 1..512 UTF-8 bytes without NUL")
 
     origin = sealed_coordinator(origins, manifest)
-    eligible_coordinators([origin], min(args.http_timeout_seconds, 30.0))
+    eligible_coordinators(
+        [origin], min(args.http_timeout_seconds, 30.0), expected_worker
+    )
     response = request_json(
         origin,
         "/inference/run",
@@ -382,13 +433,20 @@ def main() -> int:
             "input": prompt,
             "max_tokens": args.max_tokens,
             "recovery_probe_id": probe_id,
+            "expected_worker": expected_worker,
         },
     )
     body = require_object(response, f"{origin} inference response")
     evidence = (
-        evidence_from_replay(response, origin, probe_id, args.http_timeout_seconds)
+        evidence_from_replay(
+            response,
+            origin,
+            probe_id,
+            expected_worker,
+            args.http_timeout_seconds,
+        )
         if body.get("idempotent_replay") is True
-        else evidence_from_inference(response, origin, probe_id)
+        else evidence_from_inference(response, origin, probe_id, expected_worker)
     )
     sys.stdout.write(json.dumps(evidence, sort_keys=True, separators=(",", ":")) + "\n")
     return 0

--- a/scripts/recovery/owner-emergency-recovery.py
+++ b/scripts/recovery/owner-emergency-recovery.py
@@ -1,0 +1,864 @@
+#!/usr/bin/env python3
+"""Verify one GitHub-owner-authenticated ARC emergency-recovery approval.
+
+This helper deliberately handles public recovery identities and hashes only. It
+never opens a validator key, seed, checkpoint payload, OAuth configuration, or
+other secret-bearing input. The repository owner dispatches a no-secret
+protected-main workflow; this helper authenticates that exact successful run
+attempt and its GitHub artifact, then materializes a create-only mode-0400
+receipt immediately before the offline signer is invoked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import io
+import json
+import os
+import re
+import stat
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any, NoReturn, Sequence
+
+
+RECEIPT_SCHEMA = "arc.recovery.owner-emergency-recovery.v2"
+REPOSITORY = "FerrumVir/arc-chain"
+PROTECTED_BRANCH = "main"
+WORKFLOW_PATH = ".github/workflows/owner-emergency-recovery-approval.yml"
+ARTIFACT_MEMBER = "OWNER-EMERGENCY-RECOVERY.json"
+OWNER_LOGIN = "FerrumVir"
+OWNER_USER_ID = 111036403
+AUTHORIZATION_KIND = "owner_emergency_recovery"
+AUTHORITY_BASIS = (
+    "repository-owner emergency authorization authenticated by an exact GitHub "
+    "Actions run; not approval by six independent humans"
+)
+REASON_CODE = "legacy_fleet_divergence_history_preserving_v080_cutover"
+REASON = (
+    "The divergent public validator fleet requires the reviewed, "
+    "history-preserving ARC v0.8 emergency cutover."
+)
+RISK_ACKNOWLEDGEMENT = (
+    "I authorize five reviewed ARC validator identities to sign the recovery "
+    "checkpoint rooted at preserved source block 137145 and transition block "
+    "137146. I understand that the six legacy forks remain preserved read-only, "
+    "that rollback cannot rewrite signed history, and that this receipt does not "
+    "represent approval by six independent humans."
+)
+SOURCE_HEIGHT = 137_145
+TRANSITION_HEIGHT = 137_146
+RECOVERY_EPOCH = 1
+VALIDATOR_SET_ID = 1
+SIGNATURES_REQUIRED = 5
+TOTAL_STAKE = 40_000_000
+MINIMUM_SIGNED_STAKE = TOTAL_STAKE * 2 // 3 + 1
+MAX_JSON_BYTES = 256 * 1024
+DEFAULT_MAX_AGE_SECONDS = 900
+FUTURE_TOLERANCE_SECONDS = 30
+HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+UTC_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+SAFE_PATH_COMPONENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+# The order is the checked-in recovered genesis order and the physical signing
+# order.  SGP remains the unused recovery member for this five-signature pass.
+PRODUCTION_VALIDATORS: tuple[tuple[str, str, int], ...] = (
+    ("NYC", "adf4ff16f997c871c16f3897e67881311d08f975f28ebdcf79e86ea9e3b99d0f", 6_666_667),
+    ("LAX", "44d20543df6e76696da2ebbbd79e4243cd41729fa5b890e2618991e489314780", 6_666_667),
+    ("AMS", "5772741c93d8a4b04ec39007cb568a31e13ffba0d3e786596d1900d30e529f21", 6_666_667),
+    ("LHR", "228787281308d6c1a560848c2c168814bde1b6153e9e65a286d7211f04628fdd", 6_666_667),
+    ("NRT", "f03cbab49cf553a05541ddebc09b32a4c5507efb157d354b6d7f8c6682c32f5f", 6_666_666),
+    ("SGP", "f521309b041da7aefc742548bdc002c31b47183aacfbbbf245ded09845d0415b", 6_666_666),
+)
+AUTHORIZED_SIGNER_ORDER = tuple(row[0] for row in PRODUCTION_VALIDATORS[:SIGNATURES_REQUIRED])
+UNUSED_RECOVERY_MEMBER = PRODUCTION_VALIDATORS[-1][0]
+
+
+class ApprovalError(ValueError):
+    """The proposed or sealed owner authorization is unsafe or inconsistent."""
+
+
+def fail(message: str) -> NoReturn:
+    raise ApprovalError(message)
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    try:
+        encoded = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as error:
+        fail(f"value cannot be represented as canonical JSON: {error}")
+    return (encoded + "\n").encode("utf-8")
+
+
+def _reject_duplicate_pairs(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, child in pairs:
+        if key in value:
+            fail(f"duplicate JSON key is forbidden: {key}")
+        value[key] = child
+    return value
+
+
+def _reject_nonfinite(value: str) -> NoReturn:
+    fail(f"non-finite JSON number is forbidden: {value}")
+
+
+def parse_canonical_json(raw: bytes, label: str) -> Any:
+    try:
+        value = json.loads(
+            raw.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=_reject_nonfinite,
+        )
+    except ApprovalError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"{label} is not valid UTF-8 JSON: {error}")
+    if canonical_json_bytes(value) != raw:
+        fail(f"{label} is not canonical JSON")
+    return value
+
+
+def sha256_bytes(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+
+
+def parse_utc(value: object, label: str) -> dt.datetime:
+    if not isinstance(value, str) or UTC_RE.fullmatch(value) is None:
+        fail(f"{label} must be canonical UTC seconds")
+    try:
+        return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=dt.timezone.utc
+        )
+    except ValueError as error:
+        fail(f"{label} is invalid: {error}")
+
+
+def require_hash(value: object, label: str) -> str:
+    if not isinstance(value, str) or HASH_RE.fullmatch(value) is None:
+        fail(f"{label} must be 64 lowercase hexadecimal characters")
+    return value
+
+
+def require_checkpoint_hash(value: object, label: str) -> str:
+    if not isinstance(value, str):
+        fail(f"{label} must be a checkpoint manifest hash")
+    bare = value[2:] if value.startswith("0x") else value
+    return "0x" + require_hash(bare, label)
+
+
+def require_commit(value: object, label: str) -> str:
+    if not isinstance(value, str) or COMMIT_RE.fullmatch(value) is None:
+        fail(f"{label} must be one full lowercase Git commit")
+    return value
+
+
+def require_positive_int(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        fail(f"{label} must be a positive integer")
+    return value
+
+
+def exact_object(value: object, fields: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != fields:
+        fail(f"{label} has missing, unknown, or unsupported fields")
+    return value
+
+
+def _path_parts(path: Path) -> tuple[str, ...]:
+    if not path.is_absolute() or path.name in {"", ".", ".."}:
+        fail(f"secure path must be absolute and name one file: {path}")
+    if any(part in {"", ".", ".."} for part in path.parts[1:]):
+        fail(f"secure path traversal is forbidden: {path}")
+    if any(SAFE_PATH_COMPONENT_RE.fullmatch(part) is None for part in path.parts[1:]):
+        fail(f"secure path contains an unsafe component: {path}")
+    return path.parts[1:]
+
+
+def _open_parent(path: Path) -> tuple[int, str]:
+    parts = _path_parts(path)
+    if not hasattr(os, "O_NOFOLLOW"):
+        fail("O_NOFOLLOW is unavailable; refusing unsafe operator path")
+    flags = (
+        os.O_RDONLY
+        | os.O_NOFOLLOW
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    descriptor = os.open("/", flags)
+    operator_uid = os.geteuid()
+    try:
+        for component in parts[:-1]:
+            try:
+                child = os.open(component, flags, dir_fd=descriptor)
+            except OSError as error:
+                fail(f"cannot securely open path component {component}: {error}")
+            try:
+                details = os.fstat(child)
+            except Exception:
+                os.close(child)
+                raise
+            if not stat.S_ISDIR(details.st_mode):
+                os.close(child)
+                fail(f"secure path component is not a directory: {component}")
+            if details.st_uid not in {0, operator_uid}:
+                os.close(child)
+                fail(f"secure path component is not root/operator owned: {component}")
+            mode = stat.S_IMODE(details.st_mode)
+            sticky_root_scratch = (
+                details.st_uid == 0
+                and bool(mode & stat.S_ISVTX)
+                and bool(mode & 0o022)
+            )
+            if mode & 0o022 and not sticky_root_scratch:
+                os.close(child)
+                fail(f"secure path component has unsafe group/world write access: {component}")
+            os.close(descriptor)
+            descriptor = child
+        parent = os.fstat(descriptor)
+        if parent.st_uid != operator_uid:
+            fail("secure output/input parent must be owned by the executing operator")
+        if stat.S_IMODE(parent.st_mode) != 0o700:
+            fail("secure output/input parent must have exact mode 0700")
+        return descriptor, parts[-1]
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def read_secure_file(
+    path: Path,
+    *,
+    label: str,
+    exact_modes: set[int],
+    maximum_bytes: int = MAX_JSON_BYTES,
+) -> bytes:
+    parent_fd, name = _open_parent(path)
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            name,
+            os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+            dir_fd=parent_fd,
+        )
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+            fail(f"{label} must be a singly linked regular file")
+        if before.st_uid != os.geteuid():
+            fail(f"{label} must be owned by the executing operator")
+        mode = stat.S_IMODE(before.st_mode)
+        if mode not in exact_modes:
+            expected = "/".join(f"{item:04o}" for item in sorted(exact_modes))
+            fail(f"{label} mode must be {expected}, got {mode:04o}")
+        chunks: list[bytes] = []
+        size = 0
+        while True:
+            chunk = os.read(descriptor, min(64 * 1024, maximum_bytes + 1 - size))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            size += len(chunk)
+            if size > maximum_bytes:
+                fail(f"{label} exceeds {maximum_bytes} bytes")
+        after = os.fstat(descriptor)
+        identity = lambda item: (
+            item.st_dev,
+            item.st_ino,
+            item.st_size,
+            item.st_mtime_ns,
+            item.st_ctime_ns,
+            item.st_nlink,
+        )
+        if identity(before) != identity(after):
+            fail(f"{label} changed while it was read")
+        return b"".join(chunks)
+    except OSError as error:
+        fail(f"cannot securely read {label}: {error}")
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        os.close(parent_fd)
+
+
+def _entry_absent(parent_fd: int, name: str, label: str) -> None:
+    try:
+        os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    except OSError as error:
+        fail(f"cannot check create-only {label}: {error}")
+    fail(f"create-only {label} already exists")
+
+
+def _create_at(parent_fd: int, name: str, raw: bytes, mode: int, label: str) -> None:
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | os.O_NOFOLLOW
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    descriptor = -1
+    try:
+        descriptor = os.open(name, flags, mode, dir_fd=parent_fd)
+        os.fchmod(descriptor, mode)
+        offset = 0
+        while offset < len(raw):
+            written = os.write(descriptor, raw[offset:])
+            if written <= 0:
+                fail(f"short write while creating {label}")
+            offset += written
+        os.fsync(descriptor)
+        details = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(details.st_mode)
+            or details.st_nlink != 1
+            or details.st_uid != os.geteuid()
+            or stat.S_IMODE(details.st_mode) != mode
+            or details.st_size != len(raw)
+        ):
+            fail(f"create-only {label} failed its owner/mode/type/size check")
+    except FileExistsError:
+        fail(f"create-only {label} already exists")
+    except OSError as error:
+        fail(f"cannot create {label}: {error}")
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def create_one(path: Path, raw: bytes, mode: int, label: str) -> None:
+    parent_fd, name = _open_parent(path)
+    try:
+        _entry_absent(parent_fd, name, label)
+        _create_at(parent_fd, name, raw, mode, label)
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+
+
+def create_receipt_pair(path: Path, raw: bytes) -> str:
+    parent_fd, name = _open_parent(path)
+    sidecar_name = name + ".sha256"
+    digest = sha256_bytes(raw)
+    sidecar = f"{digest}  {name}\n".encode("ascii")
+    try:
+        _entry_absent(parent_fd, name, "owner emergency-recovery receipt")
+        _entry_absent(parent_fd, sidecar_name, "owner emergency-recovery receipt sidecar")
+        # The sidecar is staged first and the receipt is the completion marker.
+        # A crash or race leaves evidence behind and never permits overwrite.
+        _create_at(
+            parent_fd,
+            sidecar_name,
+            sidecar,
+            0o400,
+            "owner emergency-recovery receipt sidecar",
+        )
+        os.fsync(parent_fd)
+        _create_at(parent_fd, name, raw, 0o400, "owner emergency-recovery receipt")
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+    return digest
+
+
+def load_validator_public_keys(path: Path, expected_sha256: str) -> tuple[list[dict[str, Any]], str]:
+    expected = require_hash(expected_sha256, "validator public-key manifest SHA-256")
+    raw = read_secure_file(
+        path,
+        label="validator public-key manifest",
+        exact_modes={0o400, 0o444},
+    )
+    if sha256_bytes(raw) != expected:
+        fail("validator public-key manifest differs from its explicit SHA-256")
+    value = parse_canonical_json(raw, "validator public-key manifest")
+    if not isinstance(value, list) or len(value) != len(PRODUCTION_VALIDATORS):
+        fail("validator public-key manifest must contain the reviewed six identities")
+    result: list[dict[str, Any]] = []
+    seen_public_keys: set[str] = set()
+    for ordinal, (expected_row, candidate) in enumerate(
+        zip(PRODUCTION_VALIDATORS, value), start=1
+    ):
+        node, address, stake = expected_row
+        row = exact_object(candidate, {"address", "public_key", "stake"}, f"validator {ordinal}")
+        public_key = require_hash(row["public_key"], f"validator {ordinal} public key")
+        if row["address"] != address or row["stake"] != stake:
+            fail("validator public-key manifest differs from recovered genesis order/stake")
+        if public_key in seen_public_keys:
+            fail("validator public-key manifest contains duplicate public keys")
+        seen_public_keys.add(public_key)
+        result.append(
+            {
+                "address": address,
+                "node": node,
+                "ordinal": ordinal,
+                "public_key": public_key,
+                "stake": stake,
+            }
+        )
+    return result, expected
+
+
+def signing_policy(validators: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "authorized_signer_order": list(AUTHORIZED_SIGNER_ORDER),
+        "minimum_signed_stake": MINIMUM_SIGNED_STAKE,
+        "ordered_validators": validators,
+        "signatures_required": SIGNATURES_REQUIRED,
+        "strict_stake_supermajority_required": True,
+        "total_stake": TOTAL_STAKE,
+        "unused_recovery_member": UNUSED_RECOVERY_MEMBER,
+        "validator_count": len(PRODUCTION_VALIDATORS),
+    }
+
+
+def validate_signing_policy(value: object) -> dict[str, Any]:
+    policy = exact_object(
+        value,
+        {
+            "authorized_signer_order",
+            "minimum_signed_stake",
+            "ordered_validators",
+            "signatures_required",
+            "strict_stake_supermajority_required",
+            "total_stake",
+            "unused_recovery_member",
+            "validator_count",
+        },
+        "signing policy",
+    )
+    if (
+        policy["authorized_signer_order"] != list(AUTHORIZED_SIGNER_ORDER)
+        or policy["minimum_signed_stake"] != MINIMUM_SIGNED_STAKE
+        or policy["signatures_required"] != SIGNATURES_REQUIRED
+        or policy["strict_stake_supermajority_required"] is not True
+        or policy["total_stake"] != TOTAL_STAKE
+        or policy["unused_recovery_member"] != UNUSED_RECOVERY_MEMBER
+        or policy["validator_count"] != len(PRODUCTION_VALIDATORS)
+    ):
+        fail("signing policy differs from the reviewed five-of-six strict-stake threshold")
+    validators = policy["ordered_validators"]
+    if not isinstance(validators, list) or len(validators) != len(PRODUCTION_VALIDATORS):
+        fail("signing policy must contain exactly six ordered validators")
+    public_keys: set[str] = set()
+    for ordinal, (expected, candidate) in enumerate(
+        zip(PRODUCTION_VALIDATORS, validators), start=1
+    ):
+        node, address, stake = expected
+        row = exact_object(
+            candidate,
+            {"address", "node", "ordinal", "public_key", "stake"},
+            f"receipt validator {ordinal}",
+        )
+        if (
+            row["node"] != node
+            or row["address"] != address
+            or row["stake"] != stake
+            or row["ordinal"] != ordinal
+        ):
+            fail("receipt validator order/identity/stake differs from recovered genesis")
+        public_key = require_hash(row["public_key"], f"receipt validator {ordinal} public key")
+        if public_key in public_keys:
+            fail("receipt validators contain duplicate public keys")
+        public_keys.add(public_key)
+    selected_stake = sum(row[2] for row in PRODUCTION_VALIDATORS[:SIGNATURES_REQUIRED])
+    if selected_stake < MINIMUM_SIGNED_STAKE:
+        fail("authorized signer order does not satisfy strict stake supermajority")
+    return policy
+
+
+def scope_value(
+    source_main_sha: str,
+    checkpoint_manifest_hash: str,
+    validator_public_keys_sha256: str,
+) -> dict[str, Any]:
+    return {
+        "checkpoint_manifest_hash": require_checkpoint_hash(
+            checkpoint_manifest_hash, "checkpoint manifest hash"
+        ),
+        "protected_branch": PROTECTED_BRANCH,
+        "recovery_epoch": RECOVERY_EPOCH,
+        "repository": REPOSITORY,
+        "source_height": SOURCE_HEIGHT,
+        "source_main_sha": require_commit(source_main_sha, "protected-main commit"),
+        "transition_height": TRANSITION_HEIGHT,
+        "validator_public_keys_sha256": require_hash(
+            validator_public_keys_sha256, "validator public-key manifest SHA-256"
+        ),
+        "validator_set_id": VALIDATOR_SET_ID,
+    }
+
+
+def validate_scope(value: object) -> dict[str, Any]:
+    scope = exact_object(
+        value,
+        {
+            "checkpoint_manifest_hash",
+            "protected_branch",
+            "recovery_epoch",
+            "repository",
+            "source_height",
+            "source_main_sha",
+            "transition_height",
+            "validator_public_keys_sha256",
+            "validator_set_id",
+        },
+        "authorization scope",
+    )
+    if (
+        scope["repository"] != REPOSITORY
+        or scope["protected_branch"] != PROTECTED_BRANCH
+        or scope["source_height"] != SOURCE_HEIGHT
+        or scope["transition_height"] != TRANSITION_HEIGHT
+        or scope["recovery_epoch"] != RECOVERY_EPOCH
+        or scope["validator_set_id"] != VALIDATOR_SET_ID
+    ):
+        fail("authorization scope differs from the reviewed ARC v0.8 recovery boundary")
+    require_commit(scope["source_main_sha"], "authorization protected-main commit")
+    normalized_checkpoint = require_checkpoint_hash(
+        scope["checkpoint_manifest_hash"], "authorization checkpoint hash"
+    )
+    if scope["checkpoint_manifest_hash"] != normalized_checkpoint:
+        fail("authorization checkpoint hash must use canonical lowercase 0x encoding")
+    require_hash(
+        scope["validator_public_keys_sha256"],
+        "authorization validator public-key manifest SHA-256",
+    )
+    return scope
+
+
+def validate_decision(value: object) -> dict[str, Any]:
+    decision = exact_object(
+        value,
+        {
+            "approver",
+            "approved_at",
+            "authority_basis",
+            "authorization_kind",
+            "reason",
+            "reason_code",
+            "risk_acknowledgement",
+        },
+        "owner decision",
+    )
+    approver = exact_object(
+        decision["approver"],
+        {"github_login", "github_user_id", "repository_role"},
+        "owner approver",
+    )
+    if approver != {
+        "github_login": OWNER_LOGIN,
+        "github_user_id": OWNER_USER_ID,
+        "repository_role": "owner",
+    }:
+        fail("approver identity is not the pinned ARC repository owner")
+    if (
+        decision["authority_basis"] != AUTHORITY_BASIS
+        or decision["authorization_kind"] != AUTHORIZATION_KIND
+        or decision["reason"] != REASON
+        or decision["reason_code"] != REASON_CODE
+        or decision["risk_acknowledgement"] != RISK_ACKNOWLEDGEMENT
+    ):
+        fail("owner decision changes the emergency authority or risk acknowledgement")
+    parse_utc(decision["approved_at"], "owner approval time")
+    return decision
+
+
+def validate_receipt(value: object) -> dict[str, Any]:
+    receipt = exact_object(
+        value,
+        {"decision", "github_authentication", "schema", "scope", "signing_policy"},
+        "owner emergency-recovery receipt",
+    )
+    if receipt["schema"] != RECEIPT_SCHEMA:
+        fail("owner emergency-recovery receipt schema is unsupported")
+    validate_decision(receipt["decision"])
+    validate_scope(receipt["scope"])
+    validate_signing_policy(receipt["signing_policy"])
+    authentication = exact_object(
+        receipt["github_authentication"],
+        {
+            "actor",
+            "event",
+            "head_branch",
+            "head_sha",
+            "repository",
+            "run_attempt",
+            "run_id",
+            "triggering_actor",
+            "workflow_path",
+        },
+        "GitHub authentication",
+    )
+    if (
+        authentication["repository"] != REPOSITORY
+        or authentication["workflow_path"] != WORKFLOW_PATH
+        or authentication["event"] != "workflow_dispatch"
+        or authentication["head_branch"] != PROTECTED_BRANCH
+    ):
+        fail("receipt GitHub authentication does not name the protected owner workflow")
+    require_commit(authentication["head_sha"], "GitHub authentication head SHA")
+    require_positive_int(authentication["run_id"], "GitHub authentication run ID")
+    require_positive_int(authentication["run_attempt"], "GitHub authentication run attempt")
+    expected_actor = {"login": OWNER_LOGIN, "user_id": OWNER_USER_ID}
+    for field in ("actor", "triggering_actor"):
+        actor = exact_object(authentication[field], {"login", "user_id"}, field)
+        if actor != expected_actor:
+            fail(f"receipt {field} is not the pinned repository owner")
+    return receipt
+
+
+def parse_api_json(raw: bytes, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            raw.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=_reject_nonfinite,
+        )
+    except ApprovalError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"{label} is not valid JSON: {error}")
+    if not isinstance(value, dict):
+        fail(f"{label} must be a JSON object")
+    return value
+
+
+def artifact_receipt(zip_raw: bytes) -> bytes:
+    try:
+        with zipfile.ZipFile(io.BytesIO(zip_raw), "r") as archive:
+            members = archive.infolist()
+            if len(members) != 1 or members[0].filename != ARTIFACT_MEMBER:
+                fail(f"approval artifact must contain only {ARTIFACT_MEMBER}")
+            member = members[0]
+            if member.is_dir() or member.flag_bits & 0x1:
+                fail("approval artifact member is a directory or encrypted")
+            if member.file_size <= 0 or member.file_size > MAX_JSON_BYTES:
+                fail("approval artifact receipt has an unsupported size")
+            if member.compress_size <= 0 or member.file_size > member.compress_size * 200 + 4096:
+                fail("approval artifact receipt has an unsafe compression ratio")
+            raw = archive.read(member)
+            if len(raw) != member.file_size:
+                fail("approval artifact receipt was not read completely")
+            return raw
+    except (OSError, zipfile.BadZipFile, RuntimeError) as error:
+        fail(f"approval artifact is not a safe ZIP: {error}")
+
+
+def _github_actor(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        fail(f"{label} must be a GitHub actor object")
+    actor = {"login": value.get("login"), "id": value.get("id")}
+    if actor != {"login": OWNER_LOGIN, "id": OWNER_USER_ID}:
+        fail(f"{label} is not the pinned repository owner")
+    return actor
+
+
+def verify_github_artifact(args: argparse.Namespace) -> str:
+    run_id = require_positive_int(args.run_id, "approval run ID")
+    run_attempt = require_positive_int(args.run_attempt, "approval run attempt")
+    artifact_id = require_positive_int(args.artifact_id, "approval artifact ID")
+    digest_value = args.artifact_digest
+    if not isinstance(digest_value, str) or not digest_value.startswith("sha256:"):
+        fail("approval artifact digest must have one sha256: prefix")
+    artifact_digest = require_hash(digest_value[7:], "approval artifact digest")
+    workflow = parse_api_json(
+        read_secure_file(args.workflow_json, label="approval workflow API JSON", exact_modes={0o400}),
+        "approval workflow API JSON",
+    )
+    run = parse_api_json(
+        read_secure_file(args.run_json, label="approval run API JSON", exact_modes={0o400}),
+        "approval run API JSON",
+    )
+    jobs = parse_api_json(
+        read_secure_file(
+            args.jobs_json,
+            label="approval exact-attempt jobs API JSON",
+            exact_modes={0o400},
+        ),
+        "approval exact-attempt jobs API JSON",
+    )
+    artifact = parse_api_json(
+        read_secure_file(args.artifact_json, label="approval artifact API JSON", exact_modes={0o400}),
+        "approval artifact API JSON",
+    )
+    zip_raw = read_secure_file(
+        args.artifact_zip,
+        label="approval artifact ZIP",
+        exact_modes={0o400},
+        maximum_bytes=4 * 1024 * 1024,
+    )
+    workflow_id = require_positive_int(workflow.get("id"), "approval workflow ID")
+    if workflow.get("path") != WORKFLOW_PATH:
+        fail("approval workflow API object has another path")
+    if (
+        run.get("id") != run_id
+        or run.get("run_attempt") != run_attempt
+        or run.get("workflow_id") != workflow_id
+        or run.get("path") != WORKFLOW_PATH
+        or run.get("event") != "workflow_dispatch"
+        or run.get("head_branch") != PROTECTED_BRANCH
+        or run.get("head_sha") != args.source_main_sha
+        or not isinstance(run.get("head_repository"), dict)
+        or run["head_repository"].get("full_name") != REPOSITORY
+        or run.get("status") != "completed"
+        or run.get("conclusion") != "success"
+    ):
+        fail("approval run is not the successful exact protected-main workflow attempt")
+    _github_actor(run.get("actor"), "approval run actor")
+    _github_actor(run.get("triggering_actor"), "approval run triggering actor")
+    job_rows = jobs.get("jobs")
+    if jobs.get("total_count") != 1 or not isinstance(job_rows, list) or len(job_rows) != 1:
+        fail("approval exact-attempt jobs do not contain exactly one authorization job")
+    job = job_rows[0]
+    if not isinstance(job, dict):
+        fail("approval exact-attempt job is not a JSON object")
+    if (
+        job.get("run_id") != run_id
+        or job.get("run_attempt") != run_attempt
+        or job.get("head_sha") != args.source_main_sha
+        or job.get("name") != "authenticate owner and seal exact recovery decision"
+        or job.get("status") != "completed"
+        or job.get("conclusion") != "success"
+        or job.get("started_at") is None
+        or job.get("completed_at") is None
+    ):
+        fail("approval authorization job is not the successful exact workflow attempt")
+    expected_artifact_name = (
+        f"arc-owner-emergency-recovery-{args.source_main_sha}-{run_id}-attempt-{run_attempt}"
+    )
+    workflow_run = artifact.get("workflow_run")
+    if (
+        artifact.get("id") != artifact_id
+        or artifact.get("name") != expected_artifact_name
+        or artifact.get("digest") != digest_value
+        or artifact.get("expired") is not False
+        or isinstance(artifact.get("size_in_bytes"), bool)
+        or not isinstance(artifact.get("size_in_bytes"), int)
+        or artifact["size_in_bytes"] <= 0
+        or artifact["size_in_bytes"] > 4 * 1024 * 1024
+        or artifact["size_in_bytes"] != len(zip_raw)
+        or not isinstance(workflow_run, dict)
+        or workflow_run.get("id") != run_id
+        or workflow_run.get("head_sha") != args.source_main_sha
+    ):
+        fail("approval artifact API identity differs from the exact run attempt")
+    if sha256_bytes(zip_raw) != artifact_digest:
+        fail("downloaded approval artifact differs from the GitHub server digest")
+    receipt_raw = artifact_receipt(zip_raw)
+    receipt = validate_receipt(
+        parse_canonical_json(receipt_raw, "owner emergency-recovery receipt")
+    )
+    expected_scope = scope_value(
+        args.source_main_sha,
+        args.checkpoint_manifest_hash,
+        args.validator_public_keys_sha256,
+    )
+    if receipt["scope"] != expected_scope:
+        fail("owner emergency-recovery receipt does not authorize these exact signing inputs")
+    validators, public_digest = load_validator_public_keys(
+        args.validator_public_keys, args.validator_public_keys_sha256
+    )
+    if public_digest != receipt["scope"]["validator_public_keys_sha256"]:
+        fail("receipt validator public-key digest differs from the signing input")
+    if receipt["signing_policy"] != signing_policy(validators):
+        fail("receipt validator identities/order differ from the signing input")
+    authentication = receipt["github_authentication"]
+    if authentication != {
+        "actor": {"login": OWNER_LOGIN, "user_id": OWNER_USER_ID},
+        "event": "workflow_dispatch",
+        "head_branch": PROTECTED_BRANCH,
+        "head_sha": args.source_main_sha,
+        "repository": REPOSITORY,
+        "run_attempt": run_attempt,
+        "run_id": run_id,
+        "triggering_actor": {"login": OWNER_LOGIN, "user_id": OWNER_USER_ID},
+        "workflow_path": WORKFLOW_PATH,
+    }:
+        fail("receipt is not bound to the selected owner-authenticated run attempt")
+    max_age = require_positive_int(args.max_age_seconds, "maximum receipt age")
+    now = utc_now()
+    approved_at = parse_utc(receipt["decision"]["approved_at"], "owner approval time")
+    age = (now - approved_at).total_seconds()
+    if age < -FUTURE_TOLERANCE_SECONDS:
+        fail("owner approval time is unreasonably in the future")
+    if age > max_age:
+        fail("owner emergency-recovery receipt is stale; create and review a fresh receipt")
+    started_at = parse_utc(run.get("run_started_at"), "approval run start time")
+    updated_at = parse_utc(run.get("updated_at"), "approval run update time")
+    job_started_at = parse_utc(job.get("started_at"), "approval job start time")
+    job_completed_at = parse_utc(job.get("completed_at"), "approval job completion time")
+    if job_started_at < started_at - dt.timedelta(seconds=FUTURE_TOLERANCE_SECONDS):
+        fail("approval job predates the authenticated workflow attempt")
+    if job_completed_at > updated_at + dt.timedelta(seconds=FUTURE_TOLERANCE_SECONDS):
+        fail("approval job completion postdates the authenticated workflow attempt")
+    if job_completed_at < job_started_at:
+        fail("approval job completion predates its start")
+    if approved_at < started_at - dt.timedelta(seconds=FUTURE_TOLERANCE_SECONDS):
+        fail("owner approval predates the authenticated workflow attempt")
+    if approved_at > updated_at + dt.timedelta(seconds=FUTURE_TOLERANCE_SECONDS):
+        fail("owner approval postdates the authenticated workflow attempt")
+    receipt_digest = sha256_bytes(receipt_raw)
+    create_receipt_pair(args.output, receipt_raw)
+    return receipt_digest
+
+
+def parser() -> argparse.ArgumentParser:
+    command = argparse.ArgumentParser(
+        description="Verify and materialize a GitHub-owner-authenticated ARC recovery receipt"
+    )
+    subcommands = command.add_subparsers(dest="command", required=True)
+    verifier = subcommands.add_parser(
+        "verify-github-artifact",
+        help="verify one exact GitHub owner workflow artifact immediately before signing",
+    )
+    verifier.add_argument("--workflow-json", required=True, type=Path)
+    verifier.add_argument("--run-json", required=True, type=Path)
+    verifier.add_argument("--jobs-json", required=True, type=Path)
+    verifier.add_argument("--artifact-json", required=True, type=Path)
+    verifier.add_argument("--artifact-zip", required=True, type=Path)
+    verifier.add_argument("--run-id", required=True, type=int)
+    verifier.add_argument("--run-attempt", required=True, type=int)
+    verifier.add_argument("--artifact-id", required=True, type=int)
+    verifier.add_argument("--artifact-digest", required=True)
+    verifier.add_argument("--source-main-sha", required=True)
+    verifier.add_argument("--checkpoint-manifest-hash", required=True)
+    verifier.add_argument("--validator-public-keys", required=True, type=Path)
+    verifier.add_argument("--validator-public-keys-sha256", required=True)
+    verifier.add_argument("--output", required=True, type=Path)
+    verifier.add_argument(
+        "--max-age-seconds", type=int, default=DEFAULT_MAX_AGE_SECONDS
+    )
+    verifier.set_defaults(handler=verify_github_artifact)
+    return command
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        digest = args.handler(args)
+    except ApprovalError as error:
+        print(f"owner-emergency-recovery: ERROR: {error}", file=sys.stderr)
+        return 1
+    status = "VERIFIED_GITHUB_OWNER_EMERGENCY_RECOVERY"
+    print(canonical_json_bytes({"sha256": digest, "status": status}).decode("ascii"), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/recovery/owner-emergency-recovery.schema.json
+++ b/scripts/recovery/owner-emergency-recovery.schema.json
@@ -1,0 +1,279 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/FerrumVir/arc-chain/blob/main/scripts/recovery/owner-emergency-recovery.schema.json",
+  "title": "ARC GitHub-owner-authenticated emergency-recovery approval receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "decision",
+    "github_authentication",
+    "schema",
+    "scope",
+    "signing_policy"
+  ],
+  "properties": {
+    "schema": {
+      "const": "arc.recovery.owner-emergency-recovery.v2"
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "approver",
+        "approved_at",
+        "authority_basis",
+        "authorization_kind",
+        "reason",
+        "reason_code",
+        "risk_acknowledgement"
+      ],
+      "properties": {
+        "authorization_kind": {
+          "const": "owner_emergency_recovery"
+        },
+        "authority_basis": {
+          "const": "repository-owner emergency authorization authenticated by an exact GitHub Actions run; not approval by six independent humans"
+        },
+        "approver": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "github_login",
+            "github_user_id",
+            "repository_role"
+          ],
+          "properties": {
+            "github_login": {
+              "const": "FerrumVir"
+            },
+            "github_user_id": {
+              "const": 111036403
+            },
+            "repository_role": {
+              "const": "owner"
+            }
+          }
+        },
+        "approved_at": {
+          "$ref": "#/$defs/utcSeconds"
+        },
+        "reason": {
+          "const": "The divergent public validator fleet requires the reviewed, history-preserving ARC v0.8 emergency cutover."
+        },
+        "reason_code": {
+          "const": "legacy_fleet_divergence_history_preserving_v080_cutover"
+        },
+        "risk_acknowledgement": {
+          "const": "I authorize five reviewed ARC validator identities to sign the recovery checkpoint rooted at preserved source block 137145 and transition block 137146. I understand that the six legacy forks remain preserved read-only, that rollback cannot rewrite signed history, and that this receipt does not represent approval by six independent humans."
+        }
+      }
+    },
+    "github_authentication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "actor",
+        "event",
+        "head_branch",
+        "head_sha",
+        "repository",
+        "run_attempt",
+        "run_id",
+        "triggering_actor",
+        "workflow_path"
+      ],
+      "properties": {
+        "repository": {
+          "const": "FerrumVir/arc-chain"
+        },
+        "workflow_path": {
+          "const": ".github/workflows/owner-emergency-recovery-approval.yml"
+        },
+        "event": {
+          "const": "workflow_dispatch"
+        },
+        "head_branch": {
+          "const": "main"
+        },
+        "head_sha": {
+          "$ref": "#/$defs/commit"
+        },
+        "run_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "run_attempt": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "actor": {
+          "$ref": "#/$defs/ownerActor"
+        },
+        "triggering_actor": {
+          "$ref": "#/$defs/ownerActor"
+        }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "checkpoint_manifest_hash",
+        "protected_branch",
+        "recovery_epoch",
+        "repository",
+        "source_height",
+        "source_main_sha",
+        "transition_height",
+        "validator_public_keys_sha256",
+        "validator_set_id"
+      ],
+      "properties": {
+        "repository": {
+          "const": "FerrumVir/arc-chain"
+        },
+        "protected_branch": {
+          "const": "main"
+        },
+        "source_main_sha": {
+          "$ref": "#/$defs/commit"
+        },
+        "checkpoint_manifest_hash": {
+          "type": "string",
+          "pattern": "^0x[0-9a-f]{64}$"
+        },
+        "source_height": {
+          "const": 137145
+        },
+        "transition_height": {
+          "const": 137146
+        },
+        "recovery_epoch": {
+          "const": 1
+        },
+        "validator_set_id": {
+          "const": 1
+        },
+        "validator_public_keys_sha256": {
+          "$ref": "#/$defs/hash"
+        }
+      }
+    },
+    "signing_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authorized_signer_order",
+        "minimum_signed_stake",
+        "ordered_validators",
+        "signatures_required",
+        "strict_stake_supermajority_required",
+        "total_stake",
+        "unused_recovery_member",
+        "validator_count"
+      ],
+      "properties": {
+        "authorized_signer_order": {
+          "const": [
+            "NYC",
+            "LAX",
+            "AMS",
+            "LHR",
+            "NRT"
+          ]
+        },
+        "minimum_signed_stake": {
+          "const": 26666667
+        },
+        "signatures_required": {
+          "const": 5
+        },
+        "strict_stake_supermajority_required": {
+          "const": true
+        },
+        "total_stake": {
+          "const": 40000000
+        },
+        "unused_recovery_member": {
+          "const": "SGP"
+        },
+        "validator_count": {
+          "const": 6
+        },
+        "ordered_validators": {
+          "type": "array",
+          "minItems": 6,
+          "maxItems": 6,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "address",
+              "node",
+              "ordinal",
+              "public_key",
+              "stake"
+            ],
+            "properties": {
+              "address": {
+                "$ref": "#/$defs/hash"
+              },
+              "node": {
+                "enum": [
+                  "NYC",
+                  "LAX",
+                  "AMS",
+                  "LHR",
+                  "NRT",
+                  "SGP"
+                ]
+              },
+              "ordinal": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 6
+              },
+              "public_key": {
+                "$ref": "#/$defs/hash"
+              },
+              "stake": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "ownerActor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "login",
+        "user_id"
+      ],
+      "properties": {
+        "login": {
+          "const": "FerrumVir"
+        },
+        "user_id": {
+          "const": 111036403
+        }
+      }
+    },
+    "utcSeconds": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    }
+  }
+}

--- a/scripts/recovery/recovery-manifest.schema.json
+++ b/scripts/recovery/recovery-manifest.schema.json
@@ -50,14 +50,14 @@
               "legacy_late_fork_source_set", "legacy_late_fork_source_set_sidecar",
               "legacy_late_fork_interlock_tool",
               "offline_stop_evidence", "offline_stop_evidence_sidecar",
-              "ssh_known_hosts", "reward_probe", "checkpoint", "legacy_validator_set",
+              "ssh_known_hosts", "reward_probe", "macos_canary_acceptance", "checkpoint", "legacy_validator_set",
               "source_snapshot", "source_wal", "caddy"
             ]
           },
           "checks": {
             "properties": {
               "reward": {
-                "required": ["probe_argv", "probe_sha256", "expected_reward_base"],
+                "required": ["probe_argv", "probe_sha256", "expected_worker", "macos_canary_acceptance_sha256", "expected_reward_base"],
                 "properties": {
                   "mode": { "const": "receipt" },
                   "expect_protocol_active": { "const": true },
@@ -339,6 +339,7 @@
         "offline_stop_evidence_sidecar": { "$ref": "#/$defs/artifact" },
         "ssh_known_hosts": { "$ref": "#/$defs/artifact" },
         "reward_probe": { "$ref": "#/$defs/artifact" },
+        "macos_canary_acceptance": { "$ref": "#/$defs/artifact" },
         "checkpoint": { "$ref": "#/$defs/artifact" },
         "legacy_validator_set": { "$ref": "#/$defs/artifact" },
         "source_snapshot": { "$ref": "#/$defs/artifact" },
@@ -379,6 +380,8 @@
               "items": { "type": "string", "minLength": 1 }
             },
             "probe_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+            "expected_worker": { "type": "string", "pattern": "^0x[0-9a-f]{64}$" },
+            "macos_canary_acceptance_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
             "receipts": {
               "type": "array",
               "minItems": 2,

--- a/scripts/recovery/recovery_rollout.py
+++ b/scripts/recovery/recovery_rollout.py
@@ -875,6 +875,128 @@ def validate_protected_pretag_window_set(
     return groups
 
 
+def verify_macos_canary_acceptance(
+    manifest: Mapping[str, Any], stage_payloads: Mapping[str, bytes]
+) -> dict[str, Any]:
+    """Bind the reward gate to the one live-tested pre-tag macOS worker."""
+
+    payload = stage_payloads.get("macos_canary_acceptance")
+    if payload is None:
+        fail("production stage omitted the macOS canary acceptance receipt")
+    try:
+        value = json.loads(payload)
+    except (UnicodeError, json.JSONDecodeError) as error:
+        fail(f"macOS canary acceptance receipt is invalid JSON: {error}")
+    if not isinstance(value, dict) or payload != canonical_bytes(value):
+        fail("macOS canary acceptance receipt is not canonical JSON")
+    receipt = require_keys(
+        value,
+        "macOS canary acceptance receipt",
+        (
+            "schema", "accepted", "accepted_at_unix_ns", "canary_schema",
+            "label", "platform", "rust_target", "config_sha256", "worker",
+            "pretag", "runtime", "artifacts", "process",
+        ),
+    )
+    if (
+        receipt["schema"] != "arc.macos.pretag-community-canary.acceptance.v1"
+        or receipt["accepted"] is not True
+        or receipt["canary_schema"] != "arc.macos.pretag-community-canary.v1"
+        or receipt["label"] != "network.arc.pretag-community-canary"
+        or receipt["platform"] != "macos-arm64"
+        or receipt["rust_target"] != "aarch64-apple-darwin"
+    ):
+        fail("macOS canary acceptance receipt identity is unsupported")
+    required_int(
+        receipt["accepted_at_unix_ns"],
+        "macOS canary acceptance accepted_at_unix_ns",
+        minimum=1,
+    )
+    bare_hash(receipt["config_sha256"], "macOS canary acceptance config_sha256")
+    worker = "0x" + bare_hash(receipt["worker"], "macOS canary acceptance worker")
+
+    provenance = manifest["provenance"]
+    mac_group = provenance["protected_pretag_artifact"]["groups"][2]
+    if (mac_group.get("kind"), mac_group.get("platform")) != (
+        "headless",
+        "macos-arm64",
+    ):
+        fail("protected pre-tag window has no ordered macOS arm64 headless proof")
+    proof = mac_group["initial"]
+    live = proof["live"]
+    artifact = proof["artifact"]
+    pretag = require_keys(
+        receipt["pretag"],
+        "macOS canary acceptance pretag",
+        (
+            "repository", "commit", "run_id", "run_attempt", "artifact_id",
+            "artifact_digest", "archive_sha256", "metadata_sha256",
+        ),
+    )
+    expected_pretag = {
+        "repository": "FerrumVir/arc-chain",
+        "commit": provenance["source_main_commit"],
+        "run_id": provenance["pretag_workflow_run_id"],
+        "run_attempt": provenance["pretag_workflow_run_attempt"],
+        "artifact_id": live["artifact_id"],
+        "artifact_digest": live["artifact_digest"],
+        "archive_sha256": artifact["archive_sha256"],
+        "metadata_sha256": artifact["build_metadata_sha256"],
+    }
+    if pretag != expected_pretag:
+        fail("macOS canary acceptance differs from protected pre-tag provenance")
+    runtime = require_keys(
+        receipt["runtime"],
+        "macOS canary acceptance runtime",
+        (
+            "stake", "community_mode", "full_integer_worker", "rpc_loopback_only",
+            "p2p_peers", "p2p_port", "community_rpc_urls", "argv_sha256",
+        ),
+    )
+    if (
+        runtime["stake"] != 0
+        or runtime["community_mode"] is not True
+        or runtime["full_integer_worker"] is not True
+        or runtime["rpc_loopback_only"] is not True
+        or runtime["p2p_peers"] != []
+        or runtime["p2p_port"] != 0
+        or runtime["community_rpc_urls"]
+        != [f"https://{host}" for _name, host in PRODUCTION_FLEET]
+    ):
+        fail("macOS canary acceptance runtime is not the dedicated stake-zero worker")
+    bare_hash(runtime["argv_sha256"], "macOS canary acceptance argv_sha256")
+    artifacts = require_keys(
+        receipt["artifacts"],
+        "macOS canary acceptance artifacts",
+        ("node_sha256", "model_sha256", "genesis_sha256"),
+    )
+    if artifacts != {
+        "node_sha256": artifact["files"]["arc-node-macos-arm64"],
+        "model_sha256": CANONICAL_MODEL_SHA256,
+        "genesis_sha256": artifact["files"]["genesis.toml"],
+    }:
+        fail("macOS canary acceptance artifact hashes differ")
+    process = require_keys(
+        receipt["process"],
+        "macOS canary acceptance process",
+        ("pid", "exact_executable_argv_and_listeners_proved"),
+    )
+    required_int(process["pid"], "macOS canary acceptance process.pid", minimum=1)
+    if process["exact_executable_argv_and_listeners_proved"] is not True:
+        fail("macOS canary acceptance lacks exact executable/argv/listener proof")
+    reward = manifest["checks"]["reward"]
+    if worker != "0x" + bare_hash(
+        reward.get("expected_worker"), "manifest reward expected worker"
+    ):
+        fail("macOS canary acceptance worker differs from the reward probe worker")
+    if sha256_bytes(payload) != bare_hash(
+        reward.get("macos_canary_acceptance_sha256"),
+        "manifest reward macOS acceptance sha256",
+    ):
+        fail("macOS canary acceptance bytes differ from the reward binding")
+    return receipt
+
+
 def parse_listen(value: Any, field: str) -> tuple[str, int]:
     raw = required_string(value, field)
     if raw.count(":") != 1:
@@ -1314,6 +1436,7 @@ def validate_manifest(
                 "offline_stop_evidence_sidecar",
                 "ssh_known_hosts",
                 "reward_probe",
+                "macos_canary_acceptance",
                 "source_snapshot",
                 "source_wal",
                 "caddy",
@@ -1393,7 +1516,10 @@ def validate_manifest(
         checks["reward"],
         "manifest.checks.reward",
         ("mode", "expect_protocol_active", "expect_issuance_ready"),
-        ("probe_argv", "probe_sha256", "receipts", "expected_reward_base"),
+        (
+            "probe_argv", "probe_sha256", "receipts", "expected_reward_base",
+            "expected_worker", "macos_canary_acceptance_sha256",
+        ),
     )
     if reward["mode"] not in {"policy", "receipt"}:
         fail("manifest.checks.reward.mode must be policy or receipt")
@@ -1434,12 +1560,14 @@ def validate_manifest(
                 f"{COMMUNITY_REWARD_BASE} base units (2.5 ARC)"
             )
     else:
-        forbidden = set(reward) & {"probe_argv", "probe_sha256", "receipts", "expected_reward_base"}
+        forbidden = set(reward) & {
+            "probe_argv", "probe_sha256", "receipts", "expected_reward_base",
+            "expected_worker", "macos_canary_acceptance_sha256",
+        }
         if forbidden:
             fail(f"policy reward mode cannot contain: {', '.join(sorted(forbidden))}")
     if mode == "production":
         expected_probe = artifacts["reward_probe"]
-        expected_probe_argv = [expected_probe["path"], "--max-tokens", "1"]
         if reward["mode"] != "receipt":
             fail(
                 "production requires receipt reward mode with the sealed real-inference probe"
@@ -1448,6 +1576,23 @@ def validate_manifest(
             fail(
                 "production requires the sealed real-inference probe, not fixed reward receipts"
             )
+        expected_worker = "0x" + bare_hash(
+            reward.get("expected_worker"),
+            "manifest.checks.reward.expected_worker",
+        )
+        acceptance_sha = bare_hash(
+            reward.get("macos_canary_acceptance_sha256"),
+            "manifest.checks.reward.macos_canary_acceptance_sha256",
+        )
+        if acceptance_sha != artifacts["macos_canary_acceptance"]["sha256"]:
+            fail("production reward worker binding differs from the staged macOS acceptance")
+        expected_probe_argv = [
+            expected_probe["path"],
+            "--max-tokens",
+            "1",
+            "--expected-worker",
+            expected_worker,
+        ]
         if reward["probe_argv"] != expected_probe_argv:
             fail(
                 "production reward probe argv must exactly bind the staged probe and one-token canary"
@@ -1685,6 +1830,7 @@ def verify_artifacts(manifest: Mapping[str, Any]) -> None:
         stage_rows, stage_payloads = verify_production_input_stage(manifest)
         verify_legacy_maintenance_stage_payloads(manifest, stage_rows, stage_payloads)
         verify_protected_pretag_stage_payloads(manifest, stage_payloads)
+        verify_macos_canary_acceptance(manifest, stage_payloads)
 
 
 def verify_production_input_stage(
@@ -1834,6 +1980,7 @@ def verify_production_input_stage(
         "pretag_artifact_input_set", "pretag_initial_live_provenance_set",
         "build_metadata", "validator_vault_restore_receipt",
         "validator_key_install_receipt", "ssh_identity", "validator_public_keys",
+        "macos_canary_acceptance",
     }
     for raw in rows:
         row = require_keys(
@@ -4787,6 +4934,58 @@ class RewardProgressState:
 class RewardEvidenceBundle:
     earnings_baseline: RewardEarningsBaseline
     receipts: tuple[ReceiptEvidence, ...]
+    canonical_cutoff: "CanonicalRewardCutoff"
+
+
+@dataclass(frozen=True, order=True)
+class CanonicalRewardCutoff:
+    """Inclusive canonical transaction position covered by rollout acceptance."""
+
+    block_height: int
+    index: int
+    block_hash: str
+
+    @classmethod
+    def from_value(cls, value: Any) -> "CanonicalRewardCutoff":
+        body = require_keys(
+            value,
+            "reward evidence canonical cutoff",
+            ("block_height", "block_hash", "index"),
+        )
+        cutoff = cls(
+            required_int(body["block_height"], "reward cutoff.block_height", minimum=1),
+            required_int(body["index"], "reward cutoff.index"),
+            "0x" + bare_hash(body["block_hash"], "reward cutoff.block_hash"),
+        )
+        if cutoff.to_value() != body:
+            fail("reward evidence canonical cutoff is not normalized")
+        return cutoff
+
+    @classmethod
+    def from_receipt_blocks(
+        cls, receipt_blocks: Sequence[tuple[int, str, int]]
+    ) -> "CanonicalRewardCutoff":
+        locations = [
+            cls(
+                required_int(height, "reward receipt cutoff height", minimum=1),
+                required_int(index, "reward receipt cutoff index"),
+                "0x" + bare_hash(block_hash, "reward receipt cutoff block hash"),
+            )
+            for height, block_hash, index in receipt_blocks
+        ]
+        if not locations:
+            fail("cannot derive a reward cutoff without mined receipt blocks")
+        return max(locations, key=lambda item: (item.block_height, item.index))
+
+    def contains(self, receipt: CanonicalEarningsReceipt) -> bool:
+        return (receipt.block_height, receipt.index) <= (self.block_height, self.index)
+
+    def to_value(self) -> dict[str, Any]:
+        return {
+            "block_height": self.block_height,
+            "block_hash": self.block_hash,
+            "index": self.index,
+        }
 
 
 def reward_progress_payload(
@@ -4892,11 +5091,14 @@ def parse_reward_evidence_payload(
         body = require_keys(
             json.loads(payload.decode("utf-8")),
             "reward evidence file",
-            ("schema", "rollout_sha256", "earnings_baseline", "receipts"),
+            (
+                "schema", "rollout_sha256", "earnings_baseline", "receipts",
+                "canonical_cutoff",
+            ),
         )
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
         fail(f"cannot read reward evidence: {error}")
-    if body["schema"] != "arc.recovery.reward-evidence.v2":
+    if body["schema"] != "arc.recovery.reward-evidence.v3":
         fail("reward evidence file schema is unsupported")
     if body["rollout_sha256"] != expected_rollout_sha256:
         fail("reward evidence file is bound to a different rollout")
@@ -4906,11 +5108,12 @@ def parse_reward_evidence_payload(
     evidence = [ReceiptEvidence.from_value(row) for row in rows]
     validate_distinct_receipt_evidence(evidence)
     baseline = RewardEarningsBaseline.from_value(body["earnings_baseline"])
+    cutoff = CanonicalRewardCutoff.from_value(body["canonical_cutoff"])
     if baseline.worker != evidence[0].worker:
         fail("reward evidence baseline belongs to a different worker")
     expected = canonical_bytes(
         {
-            "schema": "arc.recovery.reward-evidence.v2",
+            "schema": "arc.recovery.reward-evidence.v3",
             "rollout_sha256": expected_rollout_sha256,
             "earnings_baseline": baseline.to_value(),
             "receipts": [
@@ -4921,11 +5124,12 @@ def parse_reward_evidence_payload(
                 }
                 for item in evidence
             ],
+            "canonical_cutoff": cutoff.to_value(),
         }
     )
     if payload != expected:
         fail("reward evidence file is not canonical")
-    return RewardEvidenceBundle(baseline, tuple(evidence))
+    return RewardEvidenceBundle(baseline, tuple(evidence), cutoff)
 
 
 class RecoveryRollout:
@@ -4959,6 +5163,7 @@ class RecoveryRollout:
         self.final_reward_evidence_sha256: str | None = None
         self.reward_earnings_baselines: dict[str, RewardEarningsBaseline] = {}
         self.reward_earnings_baseline: RewardEarningsBaseline | None = None
+        self.reward_evidence_cutoff: CanonicalRewardCutoff | None = None
         self.rollback_journal = rollback_journal
         self.rollback_journal_reserved = False
         self.rollback_journal_state = "unreserved"
@@ -5277,6 +5482,7 @@ class RecoveryRollout:
         self.reward_earnings_baselines = {
             bundle.earnings_baseline.worker: bundle.earnings_baseline
         }
+        self.reward_evidence_cutoff = bundle.canonical_cutoff
         self.final_reward_evidence_sha256 = digest
         return digest
 
@@ -7831,12 +8037,24 @@ test "$(sha256sum /proc/self/fd/8 | cut -d' ' -f1)" = "$python_sha"
             body = json.loads(result.stdout)
         except json.JSONDecodeError as error:
             fail(f"reward probe did not emit one JSON evidence object: {error}")
-        return ReceiptEvidence.from_value(body)
+        evidence = ReceiptEvidence.from_value(body)
+        expected_worker = reward.get("expected_worker")
+        if expected_worker is not None and evidence.worker != "0x" + bare_hash(
+            expected_worker, "manifest reward expected worker"
+        ):
+            fail("reward probe returned a worker other than the accepted macOS canary")
+        return evidence
 
     def _reward_baseline_candidate_workers(self) -> list[str]:
         reward = self.checks["reward"]
         if "probe_argv" not in reward:
             return [ReceiptEvidence.from_value(reward["receipts"][0]).worker]
+
+        expected_worker = reward.get("expected_worker")
+        if expected_worker is not None:
+            expected_worker = "0x" + bare_hash(
+                expected_worker, "manifest reward expected worker"
+            )
 
         coordinator_digest = hashlib.sha256(
             RECOVERY_PROBE_COORDINATOR_DOMAIN + bytes.fromhex(self.digest)
@@ -7844,7 +8062,12 @@ test "$(sha256sum /proc/self/fd/8 | cut -d' ' -f1)" = "$python_sha"
         coordinator = self.validators[
             int.from_bytes(coordinator_digest[:8], "big") % len(self.validators)
         ]
-        scoreboard = self._http_json(coordinator, "/workers/scoreboard?limit=500")
+        scoreboard_path = (
+            f"/workers/scoreboard?limit=1&worker_id={expected_worker}"
+            if expected_worker is not None
+            else "/workers/scoreboard?limit=500"
+        )
+        scoreboard = self._http_json(coordinator, scoreboard_path)
         if not isinstance(scoreboard, dict):
             fail(f"{coordinator['name']} worker scoreboard is not an object")
         eligible = required_int(
@@ -7895,13 +8118,20 @@ test "$(sha256sum /proc/self/fd/8 | cut -d' ' -f1)" = "$python_sha"
                             f"{coordinator_name} scoreboard worker_id",
                         )
                     )
-        if len(candidates) < eligible:
+        if expected_worker is None and len(candidates) < eligible:
             fail(
                 f"{coordinator['name']} scoreboard hides an eligible inference worker; "
                 "cannot seal every possible pre-canary earnings baseline"
             )
         if not candidates:
             fail(f"{coordinator['name']} has no pre-canary reward worker candidate")
+        if expected_worker is not None:
+            if expected_worker not in candidates:
+                fail(
+                    f"{coordinator['name']} does not expose the accepted macOS canary "
+                    "as an eligible exact-model worker"
+                )
+            return [expected_worker]
         return sorted(candidates)
 
     def capture_reward_earnings_baselines(self) -> None:
@@ -8252,11 +8482,19 @@ test "$(sha256sum /proc/self/fd/8 | cut -d' ' -f1)" = "$python_sha"
         ):
             fail("the two reward receipts must be mined in two distinct blocks")
         baseline = self._select_reward_earnings_baseline(evidence)
+        observed_cutoff = CanonicalRewardCutoff.from_receipt_blocks(receipt_blocks)
+        if self.reward_evidence_cutoff is None:
+            self.reward_evidence_cutoff = observed_cutoff
+        elif self.reward_evidence_cutoff != observed_cutoff:
+            fail("mined rollout receipts differ from the sealed canonical reward cutoff")
+        cutoff = self.reward_evidence_cutoff
         expected_base = self.checks["reward"]["expected_reward_base"]
-        expected_count = baseline.confirmed_receipt_count + 2
-        expected_gross_base = baseline.confirmed_gross_earnings_base + 2 * expected_base
+        expected_cutoff_count = baseline.confirmed_receipt_count + 2
+        expected_cutoff_gross_base = (
+            baseline.confirmed_gross_earnings_base + 2 * expected_base
+        )
         expected_reward_arc = expected_base / 1_000_000_000
-        expected_gross_arc = expected_gross_base / 1_000_000_000
+        expected_cutoff_gross_arc = expected_cutoff_gross_base / 1_000_000_000
         agreed_post_history: RewardEarningsBaseline | None = None
         for node in self.validators:
             earnings = self._http_json(node, f"/worker/earnings/{evidence[0].worker}")
@@ -8270,16 +8508,6 @@ test "$(sha256sum /proc/self/fd/8 | cut -d' ' -f1)" = "$python_sha"
                 agreed_post_history = current
             elif current != agreed_post_history:
                 fail("validators disagree on the canonical post-canary all-v3 earnings history")
-            if current.confirmed_receipt_count != expected_count:
-                fail(
-                    f"{node['name']} earnings must retain the baseline plus exactly two new rollout canaries"
-                )
-            if current.confirmed_gross_earnings_base != expected_gross_base:
-                fail(
-                    f"{node['name']} earnings gross must equal the preserved baseline plus exactly 5 ARC"
-                )
-            if expected_gross_arc != current.confirmed_gross_earnings_base / 1_000_000_000:
-                fail(f"{node['name']} earnings ARC gross does not equal the exact base-unit total")
             current_rows = set(current.confirmed_receipts)
             baseline_rows = set(baseline.confirmed_receipts)
             if not baseline_rows.issubset(current_rows):
@@ -8308,8 +8536,25 @@ test "$(sha256sum /proc/self/fd/8 | cut -d' ' -f1)" = "$python_sha"
                 canary_rows.append(row)
             if baseline_rows & set(canary_rows):
                 fail(f"{node['name']} rollout canary was already present in the pre-canary baseline")
-            if current_rows != baseline_rows | set(canary_rows):
-                fail(f"{node['name']} earnings contains a non-baseline, non-canary receipt")
+            expected_cutoff_rows = baseline_rows | set(canary_rows)
+            actual_cutoff_rows = {row for row in current_rows if cutoff.contains(row)}
+            if actual_cutoff_rows != expected_cutoff_rows:
+                fail(
+                    f"{node['name']} earnings contains a foreign, missing, or mutated "
+                    "receipt at or before the sealed reward cutoff"
+                )
+            if len(actual_cutoff_rows) != expected_cutoff_count:
+                fail(f"{node['name']} reward cutoff does not contain baseline plus two canaries")
+            cutoff_gross_base = sum(row.reward_base for row in actual_cutoff_rows)
+            if cutoff_gross_base != expected_cutoff_gross_base:
+                fail(
+                    f"{node['name']} reward cutoff gross does not equal baseline plus exactly 5 ARC"
+                )
+            if expected_cutoff_gross_arc != cutoff_gross_base / 1_000_000_000:
+                fail(f"{node['name']} reward cutoff ARC gross differs from exact base units")
+            extra_rows = current_rows - actual_cutoff_rows
+            if any(cutoff.contains(row) for row in extra_rows):
+                fail(f"{node['name']} reward superset includes an extra receipt before the cutoff")
 
             if not isinstance(earnings, dict):
                 fail(f"{node['name']} worker earnings is not an object")
@@ -8317,7 +8562,8 @@ test "$(sha256sum /proc/self/fd/8 | cut -d' ' -f1)" = "$python_sha"
             rate_reason = earnings.get("attestations_per_day_unavailable_reason")
             projection = earnings.get("projected_daily_arc")
             projection_reason = earnings.get("projected_daily_unavailable_reason")
-            if expected_count < 3:
+            current_count = current.confirmed_receipt_count
+            if current_count < 3:
                 if rate is not None or projection is not None:
                     fail(f"{node['name']} invents a rate or projection from fewer than three receipts")
                 if rate_reason != PROJECTION_COLLECTING_REASON:
@@ -8345,7 +8591,7 @@ test "$(sha256sum /proc/self/fd/8 | cut -d' ' -f1)" = "$python_sha"
                     or rate_reason is not None
                 ):
                     fail(f"{node['name']} does not expose the receipt-derived observed rate")
-                exact_rate = (expected_count - 1) * 86_400_000 / (
+                exact_rate = (current_count - 1) * 86_400_000 / (
                     last_timestamp - first_timestamp
                 )
                 if not math.isclose(float(rate), exact_rate, rel_tol=1e-12, abs_tol=1e-12):
@@ -8376,8 +8622,9 @@ test "$(sha256sum /proc/self/fd/8 | cut -d' ' -f1)" = "$python_sha"
             elif not isinstance(projection_reason, str) or not projection_reason.strip():
                 fail(f"{node['name']} null projected_daily_arc lacks an unavailable reason")
         self.say(
-            "PASS all six validators retained the exact all-v3 earnings baseline plus two "
-            "distinct 2.5 ARC receipts; gross increased by exactly 5 ARC and projection state is truthful"
+            "PASS all six validators retained the exact baseline plus two 2.5 ARC receipts "
+            "through the sealed canonical cutoff; any agreed superset is strictly later and "
+            "projection state is truthful"
         )
 
     def prove_two_reward_receipts(self) -> list[ReceiptEvidence]:
@@ -8441,9 +8688,11 @@ test "$(sha256sum /proc/self/fd/8 | cut -d' ' -f1)" = "$python_sha"
         if self.reward_evidence_output is None:
             fail("receipt-mode execution requires --reward-evidence-output")
         baseline = self._select_reward_earnings_baseline(evidence)
+        if self.reward_evidence_cutoff is None:
+            fail("reward evidence cannot be finalized before the canonical cutoff is proved")
         payload = canonical_bytes(
             {
-                "schema": "arc.recovery.reward-evidence.v2",
+                "schema": "arc.recovery.reward-evidence.v3",
                 "rollout_sha256": self.digest,
                 "earnings_baseline": baseline.to_value(),
                 "receipts": [
@@ -8454,6 +8703,7 @@ test "$(sha256sum /proc/self/fd/8 | cut -d' ' -f1)" = "$python_sha"
                     }
                     for item in evidence
                 ],
+                "canonical_cutoff": self.reward_evidence_cutoff.to_value(),
             }
         )
         digest = sha256_bytes(payload)
@@ -8885,6 +9135,7 @@ test "$(sha256sum /proc/self/fd/8 | cut -d' ' -f1)" = "$python_sha"
             self.reward_earnings_baselines = {
                 bundle.earnings_baseline.worker: bundle.earnings_baseline
             }
+            self.reward_evidence_cutoff = bundle.canonical_cutoff
             expected_payload, digest, expected_sidecar = (
                 self._reward_evidence_payload(evidence)
             )
@@ -14052,6 +14303,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     evidence_bundle.earnings_baseline.worker:
                     evidence_bundle.earnings_baseline
                 }
+                rollout.reward_evidence_cutoff = evidence_bundle.canonical_cutoff
             evidence = (
                 list(evidence_bundle.receipts)
                 if evidence_bundle is not None
@@ -14105,6 +14357,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     evidence_bundle.earnings_baseline.worker:
                     evidence_bundle.earnings_baseline
                 }
+                rollout.reward_evidence_cutoff = evidence_bundle.canonical_cutoff
             evidence = (
                 list(evidence_bundle.receipts)
                 if evidence_bundle is not None

--- a/scripts/recovery/test_build_production_manifest.py
+++ b/scripts/recovery/test_build_production_manifest.py
@@ -363,6 +363,56 @@ print(json.dumps(value,sort_keys=True))
         self.caddy = root / "caddy"
         write(self.caddy, b"reviewed-caddy", 0o555)
         self.reward_probe = SCRIPT_DIR / "community-reward-probe.py"
+        mac_proof = self.make_provenance("headless", "macos-arm64")
+        self.macos_canary_acceptance = root / "MACOS-CANARY-ACCEPTANCE.json"
+        write(
+            self.macos_canary_acceptance,
+            canonical(
+                {
+                    "schema": "arc.macos.pretag-community-canary.acceptance.v1",
+                    "accepted": True,
+                    "accepted_at_unix_ns": self.proof_now * 1_000_000_000,
+                    "canary_schema": "arc.macos.pretag-community-canary.v1",
+                    "label": "network.arc.pretag-community-canary",
+                    "platform": "macos-arm64",
+                    "rust_target": "aarch64-apple-darwin",
+                    "config_sha256": "a" * 64,
+                    "worker": "0x" + "b" * 64,
+                    "pretag": {
+                        "repository": builder.REPOSITORY,
+                        "commit": self.commit,
+                        "run_id": self.run_id,
+                        "run_attempt": self.run_attempt,
+                        "artifact_id": mac_proof["live"]["artifact_id"],
+                        "artifact_digest": mac_proof["live"]["artifact_digest"],
+                        "archive_sha256": mac_proof["artifact"]["archive_sha256"],
+                        "metadata_sha256": mac_proof["artifact"]["build_metadata_sha256"],
+                    },
+                    "runtime": {
+                        "stake": 0,
+                        "community_mode": True,
+                        "full_integer_worker": True,
+                        "rpc_loopback_only": True,
+                        "p2p_peers": [],
+                        "p2p_port": 0,
+                        "community_rpc_urls": [
+                            f"https://{host}" for _name, host in builder.FLEET
+                        ],
+                        "argv_sha256": "c" * 64,
+                    },
+                    "artifacts": {
+                        "node_sha256": mac_proof["artifact"]["files"]["arc-node-macos-arm64"],
+                        "model_sha256": builder.rollout.CANONICAL_MODEL_SHA256,
+                        "genesis_sha256": mac_proof["artifact"]["files"]["genesis.toml"],
+                    },
+                    "process": {
+                        "pid": 4242,
+                        "exact_executable_argv_and_listeners_proved": True,
+                    },
+                }
+            ),
+            0o400,
+        )
         self.freeze = root / "freeze.json"
         self.freeze_sha = self.write_freeze()
         self.height = root / "legacy-height.json"
@@ -2495,6 +2545,7 @@ print(json.dumps(value,sort_keys=True))
             source_wal=self.wal,
             caddy=self.caddy,
             reward_probe=self.reward_probe,
+            macos_canary_acceptance=self.macos_canary_acceptance,
             stage_root=self.last_stage_root,
             acme_email=builder.APPROVED_ACME_EMAIL,
             output=output or self.output,
@@ -2821,6 +2872,9 @@ print(json.dumps(value,sort_keys=True))
             "recovery.arcchkpt": art("checkpoint", "recovery.arcchkpt"),
             "caddy": art("caddy", "caddy"),
             "community-reward-probe.py": art("reward_probe", "community-reward-probe.py"),
+            "MACOS-CANARY-ACCEPTANCE.json": art(
+                "macos_canary_acceptance", "MACOS-CANARY-ACCEPTANCE.json"
+            ),
             "PRETAG-ARTIFACT-INPUT-SET.json": art(
                 "pretag_artifact_input_set", "PRETAG-ARTIFACT-INPUT-SET.json"
             ),
@@ -3190,6 +3244,18 @@ class ProductionManifestBuilderTests(unittest.TestCase):
         self.assertEqual(value["validators"][0]["host"], builder.FLEET[0][1])
         self.assertEqual(value["validators"][0]["shard_ranges"], builder.SHARDS["nyc"])
         self.assertEqual(value["archive"]["complete_sha256"], builder.ZERO_HASH)
+        self.assertEqual(
+            value["checks"]["reward"]["expected_worker"],
+            "0x" + "b" * 64,
+        )
+        self.assertEqual(
+            value["checks"]["reward"]["macos_canary_acceptance_sha256"],
+            value["artifacts"]["macos_canary_acceptance"]["sha256"],
+        )
+        self.assertEqual(
+            value["checks"]["reward"]["probe_argv"][-2:],
+            ["--expected-worker", "0x" + "b" * 64],
+        )
         assert self.fixture.last_stage_root is not None
         stage_root = self.fixture.last_stage_root
         self.assertEqual(stat.S_IMODE(stage_root.stat().st_mode), 0o500)
@@ -3776,14 +3842,39 @@ class ProductionManifestBuilderTests(unittest.TestCase):
         finally:
             builder.execute_installed_key_verifier.side_effect = original_side_effect
 
-    def test_prearchive_rejects_tampered_duplicate_symlink_and_wrong_commit(self) -> None:
+    def test_prearchive_rejects_wrong_build_metadata_commit(self) -> None:
         metadata = json.loads(self.fixture.build_metadata.read_text())
         metadata["commit"] = "7" * 40
         write(self.fixture.build_metadata, canonical(metadata), 0o444)
         with self.assertRaisesRegex(builder.BuilderError, "metadata commit differs"):
             builder.prearchive(self.fixture.args())
 
+    def test_prearchive_rejects_stale_or_rebound_macos_canary_acceptance(self) -> None:
+        receipt = json.loads(self.fixture.macos_canary_acceptance.read_text())
+        receipt["accepted_at_unix_ns"] = (
+            self.fixture.proof_now
+            - builder.MAX_MACOS_CANARY_ACCEPTANCE_AGE_SECONDS
+            - 1
+        ) * 1_000_000_000
+        write(self.fixture.macos_canary_acceptance, canonical(receipt), 0o400)
+        with self.assertRaisesRegex(builder.BuilderError, "older than the six-hour"):
+            builder.prearchive(self.fixture.args())
+
         self.tearDown(); self.setUp()
+        receipt = json.loads(self.fixture.macos_canary_acceptance.read_text())
+        receipt["pretag"]["artifact_id"] += 1
+        write(self.fixture.macos_canary_acceptance, canonical(receipt), 0o400)
+        with self.assertRaisesRegex(builder.BuilderError, "different protected pre-tag"):
+            builder.prearchive(self.fixture.args())
+
+        self.tearDown(); self.setUp()
+        receipt = json.loads(self.fixture.macos_canary_acceptance.read_text())
+        receipt["worker"] = "0x" + "B" * 64
+        write(self.fixture.macos_canary_acceptance, canonical(receipt), 0o400)
+        with self.assertRaisesRegex(builder.BuilderError, "lowercase address"):
+            builder.prearchive(self.fixture.args())
+
+    def test_prearchive_rejects_duplicate_symlink_and_tampered_stop(self) -> None:
         payload = self.fixture.public_keys.read_text()
         self.fixture.public_keys.chmod(0o600)
         self.fixture.public_keys.write_text(payload.replace('"address":', '"address":"0","address":', 1))

--- a/scripts/recovery/test_community_reward_probe.py
+++ b/scripts/recovery/test_community_reward_probe.py
@@ -29,6 +29,7 @@ class ProbeHandler(BaseHTTPRequestHandler):
     replay_mined = False
     settlement_patch: dict[str, Any] = {}
     settlement_drop: set[str] = set()
+    scoreboard_worker = WORKER
     post_requests: list[dict[str, Any]] = []
 
     def log_message(self, _format: str, *_args: Any) -> None:
@@ -45,8 +46,21 @@ class ProbeHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         if self.path == "/community/reward_policy":
             self.send_json({"issuance_ready": True})
-        elif self.path == "/workers/scoreboard?limit=1":
-            self.send_json({"eligible_inference_workers": 1})
+        elif self.path == f"/workers/scoreboard?limit=1&worker_id={WORKER}":
+            self.send_json(
+                {
+                    "eligible_inference_workers": 1,
+                    "coordinator_model_id": MODEL_HASH,
+                    "workers": [
+                        {
+                            "worker_id": self.scoreboard_worker,
+                            "capabilities": ["inference"],
+                            "model_id": MODEL_HASH,
+                            "execution_profile": CANONICAL_PROFILE,
+                        }
+                    ],
+                }
+            )
         else:
             self.send_error(404)
 
@@ -156,6 +170,7 @@ class CommunityRewardProbeTests(unittest.TestCase):
         ProbeHandler.replay_mined = False
         ProbeHandler.settlement_patch = {}
         ProbeHandler.settlement_drop = set()
+        ProbeHandler.scoreboard_worker = WORKER
         ProbeHandler.post_requests = []
 
     def run_probe(self, *extra_args: str) -> subprocess.CompletedProcess[str]:
@@ -175,6 +190,8 @@ class CommunityRewardProbeTests(unittest.TestCase):
                 str(probe),
                 "--http-timeout-seconds",
                 "5",
+                "--expected-worker",
+                WORKER,
                 *extra_args,
             ],
             text=True,
@@ -198,6 +215,7 @@ class CommunityRewardProbeTests(unittest.TestCase):
                 "0x" + b"ARC-RCV-PROBE1\0\0".hex()
             )
         )
+        self.assertEqual(ProbeHandler.post_requests[0]["expected_worker"], WORKER)
 
     def test_retry_discovers_same_job_without_creating_another(self) -> None:
         ProbeHandler.replay = True
@@ -271,6 +289,19 @@ class CommunityRewardProbeTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertEqual(result.stdout, "")
         self.assertIn("differs from", result.stderr)
+
+    def test_accepted_worker_must_be_visible_and_must_receive_the_job(self) -> None:
+        ProbeHandler.scoreboard_worker = "0x" + "9" * 64
+        result = self.run_probe()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("accepted worker", result.stderr)
+        self.assertEqual(ProbeHandler.post_requests, [])
+
+        ProbeHandler.scoreboard_worker = WORKER
+        ProbeHandler.settlement_patch = {"worker": "0x" + "9" * 64}
+        result = self.run_probe()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("settlement.worker differs", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/recovery/test_owner_emergency_recovery.py
+++ b/scripts/recovery/test_owner_emergency_recovery.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import datetime as dt
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("owner-emergency-recovery.py")
+SPEC = importlib.util.spec_from_file_location("arc_owner_emergency_recovery", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+APPROVAL = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(APPROVAL)
+
+
+def digest(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def utc(value: dt.datetime) -> str:
+    return value.astimezone(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class Fixture:
+    def __init__(self, root: Path) -> None:
+        self.root = root.resolve()
+        self.root.mkdir(parents=True, exist_ok=True)
+        os.chmod(self.root, 0o700)
+        self.public_keys = self.root / "validator-public-keys.json"
+        self.public_rows = [
+            {
+                "address": address,
+                "public_key": f"{ordinal:064x}",
+                "stake": stake,
+            }
+            for ordinal, (_node, address, stake) in enumerate(
+                APPROVAL.PRODUCTION_VALIDATORS, start=1
+            )
+        ]
+        self.public_raw = APPROVAL.canonical_json_bytes(self.public_rows)
+        self._write_secure(self.public_keys, self.public_raw)
+        self.public_sha = digest(self.public_raw)
+        self.commit = "a" * 40
+        self.checkpoint = "0x" + "b" * 64
+        self.run_id = 987654321
+        self.run_attempt = 2
+        self.workflow_id = 445566
+        self.artifact_id = 778899
+        self.output = self.root / "OWNER-EMERGENCY-RECOVERY.json"
+        now = APPROVAL.utc_now()
+        self.started = now - dt.timedelta(seconds=30)
+        self.approved = now - dt.timedelta(seconds=20)
+        self.completed = now - dt.timedelta(seconds=10)
+
+        validators, _ = APPROVAL.load_validator_public_keys(
+            self.public_keys, self.public_sha
+        )
+        self.receipt_value = {
+            "decision": {
+                "approver": {
+                    "github_login": APPROVAL.OWNER_LOGIN,
+                    "github_user_id": APPROVAL.OWNER_USER_ID,
+                    "repository_role": "owner",
+                },
+                "approved_at": utc(self.approved),
+                "authority_basis": APPROVAL.AUTHORITY_BASIS,
+                "authorization_kind": APPROVAL.AUTHORIZATION_KIND,
+                "reason": APPROVAL.REASON,
+                "reason_code": APPROVAL.REASON_CODE,
+                "risk_acknowledgement": APPROVAL.RISK_ACKNOWLEDGEMENT,
+            },
+            "github_authentication": {
+                "actor": {
+                    "login": APPROVAL.OWNER_LOGIN,
+                    "user_id": APPROVAL.OWNER_USER_ID,
+                },
+                "event": "workflow_dispatch",
+                "head_branch": APPROVAL.PROTECTED_BRANCH,
+                "head_sha": self.commit,
+                "repository": APPROVAL.REPOSITORY,
+                "run_attempt": self.run_attempt,
+                "run_id": self.run_id,
+                "triggering_actor": {
+                    "login": APPROVAL.OWNER_LOGIN,
+                    "user_id": APPROVAL.OWNER_USER_ID,
+                },
+                "workflow_path": APPROVAL.WORKFLOW_PATH,
+            },
+            "schema": APPROVAL.RECEIPT_SCHEMA,
+            "scope": APPROVAL.scope_value(
+                self.commit, self.checkpoint, self.public_sha
+            ),
+            "signing_policy": APPROVAL.signing_policy(validators),
+        }
+        self._materialize_inputs()
+
+    def _write_secure(self, path: Path, raw: bytes) -> None:
+        if path.exists():
+            os.chmod(path, 0o600)
+        path.write_bytes(raw)
+        os.chmod(path, 0o400)
+
+    def _json_file(self, name: str, value: object) -> Path:
+        path = self.root / name
+        self._write_secure(path, json.dumps(value, separators=(",", ":")).encode())
+        return path
+
+    def _zip_receipt(self, raw: bytes) -> bytes:
+        stream = io.BytesIO()
+        with zipfile.ZipFile(stream, "w", zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr(APPROVAL.ARTIFACT_MEMBER, raw)
+        return stream.getvalue()
+
+    def _materialize_inputs(self) -> None:
+        receipt_raw = APPROVAL.canonical_json_bytes(self.receipt_value)
+        zip_raw = self._zip_receipt(receipt_raw)
+        self.artifact_digest = "sha256:" + digest(zip_raw)
+        self.workflow = self._json_file(
+            "workflow.json", {"id": self.workflow_id, "path": APPROVAL.WORKFLOW_PATH}
+        )
+        owner = {"login": APPROVAL.OWNER_LOGIN, "id": APPROVAL.OWNER_USER_ID}
+        self.run_value = {
+            "actor": owner,
+            "conclusion": "success",
+            "event": "workflow_dispatch",
+            "head_branch": APPROVAL.PROTECTED_BRANCH,
+            "head_repository": {"full_name": APPROVAL.REPOSITORY},
+            "head_sha": self.commit,
+            "id": self.run_id,
+            "path": APPROVAL.WORKFLOW_PATH,
+            "run_attempt": self.run_attempt,
+            "run_started_at": utc(self.started),
+            "status": "completed",
+            "triggering_actor": owner,
+            "updated_at": utc(self.completed),
+            "workflow_id": self.workflow_id,
+        }
+        self.run = self._json_file("run.json", self.run_value)
+        self.jobs_value = {
+            "jobs": [
+                {
+                    "completed_at": utc(self.completed),
+                    "conclusion": "success",
+                    "head_sha": self.commit,
+                    "name": "authenticate owner and seal exact recovery decision",
+                    "run_attempt": self.run_attempt,
+                    "run_id": self.run_id,
+                    "started_at": utc(self.started),
+                    "status": "completed",
+                }
+            ],
+            "total_count": 1,
+        }
+        self.jobs = self._json_file("jobs.json", self.jobs_value)
+        artifact_name = (
+            f"arc-owner-emergency-recovery-{self.commit}-{self.run_id}"
+            f"-attempt-{self.run_attempt}"
+        )
+        self.artifact_value = {
+            "digest": self.artifact_digest,
+            "expired": False,
+            "id": self.artifact_id,
+            "name": artifact_name,
+            "size_in_bytes": len(zip_raw),
+            "workflow_run": {"head_sha": self.commit, "id": self.run_id},
+        }
+        self.artifact = self._json_file("artifact.json", self.artifact_value)
+        self.artifact_zip = self.root / "artifact.zip"
+        self._write_secure(self.artifact_zip, zip_raw)
+
+    def rewrite_json(self, path: Path, value: object) -> None:
+        os.chmod(path, 0o600)
+        path.write_bytes(json.dumps(value, separators=(",", ":")).encode())
+        os.chmod(path, 0o400)
+
+    def args(self, **overrides: object) -> argparse.Namespace:
+        values: dict[str, object] = {
+            "artifact_digest": self.artifact_digest,
+            "artifact_id": self.artifact_id,
+            "artifact_json": self.artifact,
+            "artifact_zip": self.artifact_zip,
+            "checkpoint_manifest_hash": self.checkpoint,
+            "jobs_json": self.jobs,
+            "max_age_seconds": 900,
+            "output": self.output,
+            "run_attempt": self.run_attempt,
+            "run_id": self.run_id,
+            "run_json": self.run,
+            "source_main_sha": self.commit,
+            "validator_public_keys": self.public_keys,
+            "validator_public_keys_sha256": self.public_sha,
+            "workflow_json": self.workflow,
+        }
+        values.update(overrides)
+        return argparse.Namespace(**values)
+
+
+class OwnerEmergencyRecoveryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.fixture = Fixture(Path(self.temporary.name))
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_cli_verifies_exact_owner_attempt_and_materializes_create_only_pair(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(MODULE_PATH),
+                "verify-github-artifact",
+                "--workflow-json",
+                str(self.fixture.workflow),
+                "--run-json",
+                str(self.fixture.run),
+                "--jobs-json",
+                str(self.fixture.jobs),
+                "--artifact-json",
+                str(self.fixture.artifact),
+                "--artifact-zip",
+                str(self.fixture.artifact_zip),
+                "--run-id",
+                str(self.fixture.run_id),
+                "--run-attempt",
+                str(self.fixture.run_attempt),
+                "--artifact-id",
+                str(self.fixture.artifact_id),
+                "--artifact-digest",
+                self.fixture.artifact_digest,
+                "--source-main-sha",
+                self.fixture.commit,
+                "--checkpoint-manifest-hash",
+                self.fixture.checkpoint,
+                "--validator-public-keys",
+                str(self.fixture.public_keys),
+                "--validator-public-keys-sha256",
+                self.fixture.public_sha,
+                "--output",
+                str(self.fixture.output),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        status = json.loads(result.stdout)
+        self.assertEqual(status["status"], "VERIFIED_GITHUB_OWNER_EMERGENCY_RECOVERY")
+        self.assertEqual(
+            status["sha256"], digest(self.fixture.output.read_bytes())
+        )
+        self.assertEqual(stat.S_IMODE(self.fixture.output.stat().st_mode), 0o400)
+        sidecar = self.fixture.output.with_name(self.fixture.output.name + ".sha256")
+        self.assertEqual(stat.S_IMODE(sidecar.stat().st_mode), 0o400)
+        self.assertEqual(
+            sidecar.read_text(encoding="ascii"),
+            f"{status['sha256']}  {self.fixture.output.name}\n",
+        )
+
+    def test_exact_run_actor_triggering_actor_attempt_and_job_are_required(self) -> None:
+        mutations = (
+            ("run", "actor", {"login": "operator", "id": 1}, "pinned repository owner"),
+            ("run", "triggering_actor", {"login": "operator", "id": 1}, "pinned repository owner"),
+            ("run", "run_attempt", 1, "exact protected-main workflow attempt"),
+            ("jobs", "total_count", 2, "exactly one authorization job"),
+        )
+        for source, field, value, message in mutations:
+            with self.subTest(source=source, field=field):
+                fixture = Fixture(self.fixture.root / f"case-{source}-{field}")
+                target = fixture.run if source == "run" else fixture.jobs
+                document = copy.deepcopy(
+                    fixture.run_value if source == "run" else fixture.jobs_value
+                )
+                document[field] = value
+                fixture.rewrite_json(target, document)
+                with self.assertRaisesRegex(APPROVAL.ApprovalError, message):
+                    APPROVAL.verify_github_artifact(fixture.args())
+
+        fixture = Fixture(self.fixture.root / "case-job-attempt")
+        document = copy.deepcopy(fixture.jobs_value)
+        document["jobs"][0]["run_attempt"] = 1
+        fixture.rewrite_json(fixture.jobs, document)
+        with self.assertRaisesRegex(APPROVAL.ApprovalError, "exact workflow attempt"):
+            APPROVAL.verify_github_artifact(fixture.args())
+
+    def test_receipt_and_artifact_are_bound_to_exact_public_inputs(self) -> None:
+        for override in (
+            {"source_main_sha": "c" * 40},
+            {"checkpoint_manifest_hash": "0x" + "d" * 64},
+            {"validator_public_keys_sha256": "e" * 64},
+            {"artifact_id": self.fixture.artifact_id + 1},
+            {"artifact_digest": "sha256:" + "f" * 64},
+        ):
+            with self.subTest(override=override):
+                with self.assertRaises(APPROVAL.ApprovalError):
+                    APPROVAL.verify_github_artifact(self.fixture.args(**override))
+
+    def test_tampered_zip_duplicate_member_and_unsafe_modes_fail_closed(self) -> None:
+        os.chmod(self.fixture.artifact_zip, 0o600)
+        with self.assertRaisesRegex(APPROVAL.ApprovalError, "mode must be"):
+            APPROVAL.verify_github_artifact(self.fixture.args())
+        os.chmod(self.fixture.artifact_zip, 0o400)
+
+        fixture = Fixture(self.fixture.root / "duplicate")
+        receipt_raw = APPROVAL.canonical_json_bytes(fixture.receipt_value)
+        stream = io.BytesIO()
+        with zipfile.ZipFile(stream, "w", zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr(APPROVAL.ARTIFACT_MEMBER, receipt_raw)
+            archive.writestr("unexpected.json", b"{}\n")
+        duplicate_raw = stream.getvalue()
+        os.chmod(fixture.artifact_zip, 0o600)
+        fixture.artifact_zip.write_bytes(duplicate_raw)
+        os.chmod(fixture.artifact_zip, 0o400)
+        fixture.artifact_digest = "sha256:" + digest(duplicate_raw)
+        artifact = copy.deepcopy(fixture.artifact_value)
+        artifact["digest"] = fixture.artifact_digest
+        artifact["size_in_bytes"] = len(duplicate_raw)
+        fixture.rewrite_json(fixture.artifact, artifact)
+        with self.assertRaisesRegex(APPROVAL.ApprovalError, "must contain only"):
+            APPROVAL.verify_github_artifact(fixture.args())
+
+    def test_stale_future_or_outside_attempt_approval_fails(self) -> None:
+        stale = Fixture(self.fixture.root / "stale")
+        stale.receipt_value["decision"]["approved_at"] = utc(
+            APPROVAL.utc_now() - dt.timedelta(hours=2)
+        )
+        stale._materialize_inputs()
+        with self.assertRaisesRegex(APPROVAL.ApprovalError, "stale"):
+            APPROVAL.verify_github_artifact(stale.args())
+
+        outside = Fixture(self.fixture.root / "outside")
+        outside.receipt_value["decision"]["approved_at"] = utc(
+            outside.started - dt.timedelta(minutes=2)
+        )
+        outside._materialize_inputs()
+        with self.assertRaisesRegex(APPROVAL.ApprovalError, "predates"):
+            APPROVAL.verify_github_artifact(outside.args())
+
+    def test_create_only_refuses_existing_receipt_or_sidecar(self) -> None:
+        receipt_sha = APPROVAL.verify_github_artifact(self.fixture.args())
+        with self.assertRaisesRegex(APPROVAL.ApprovalError, "already exists"):
+            APPROVAL.verify_github_artifact(self.fixture.args())
+        second = Fixture(self.fixture.root / "sidecar-case")
+        sidecar = second.output.with_name(second.output.name + ".sha256")
+        sidecar.write_text(f"{receipt_sha}  {second.output.name}\n", encoding="ascii")
+        os.chmod(sidecar, 0o400)
+        with self.assertRaisesRegex(APPROVAL.ApprovalError, "sidecar already exists"):
+            APPROVAL.verify_github_artifact(second.args())
+        self.assertFalse(second.output.exists())
+
+    def test_schema_pins_authenticated_owner_and_recovery_boundary(self) -> None:
+        schema_path = Path(__file__).with_name("owner-emergency-recovery.schema.json")
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        properties = schema["properties"]
+        self.assertEqual(properties["schema"]["const"], APPROVAL.RECEIPT_SCHEMA)
+        self.assertEqual(
+            properties["github_authentication"]["properties"]["workflow_path"]["const"],
+            APPROVAL.WORKFLOW_PATH,
+        )
+        self.assertEqual(
+            schema["$defs"]["ownerActor"]["properties"]["user_id"]["const"],
+            APPROVAL.OWNER_USER_ID,
+        )
+        self.assertEqual(
+            properties["decision"]["properties"]["authority_basis"]["const"],
+            APPROVAL.AUTHORITY_BASIS,
+        )
+        self.assertEqual(properties["scope"]["properties"]["source_height"]["const"], 137145)
+        self.assertEqual(properties["scope"]["properties"]["transition_height"]["const"], 137146)
+        self.assertEqual(
+            properties["signing_policy"]["properties"]["signatures_required"]["const"],
+            5,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/recovery/test_recovery_rollout.py
+++ b/scripts/recovery/test_recovery_rollout.py
@@ -57,6 +57,7 @@ class ManifestFixture:
                 "offline_stop_evidence_sidecar",
                 "ssh_known_hosts",
                 "reward_probe",
+                "macos_canary_acceptance",
                 "source_snapshot",
                 "source_wal",
                 "caddy",
@@ -326,6 +327,67 @@ class ManifestFixture:
                 "schema": "arc.protected-pretag-artifact-window-set.v1",
                 "groups": groups,
             }
+            mac_proof = groups[2]["initial"]
+            mac_acceptance = {
+                "schema": "arc.macos.pretag-community-canary.acceptance.v1",
+                "accepted": True,
+                "accepted_at_unix_ns": 1_800_000_001_000_000_000,
+                "canary_schema": "arc.macos.pretag-community-canary.v1",
+                "label": "network.arc.pretag-community-canary",
+                "platform": "macos-arm64",
+                "rust_target": "aarch64-apple-darwin",
+                "config_sha256": "4" * 64,
+                "worker": "0x" + "c" * 64,
+                "pretag": {
+                    "repository": "FerrumVir/arc-chain",
+                    "commit": "9" * 40,
+                    "run_id": 123,
+                    "run_attempt": 1,
+                    "artifact_id": mac_proof["live"]["artifact_id"],
+                    "artifact_digest": mac_proof["live"]["artifact_digest"],
+                    "archive_sha256": mac_proof["artifact"]["archive_sha256"],
+                    "metadata_sha256": mac_proof["artifact"]["build_metadata_sha256"],
+                },
+                "runtime": {
+                    "stake": 0,
+                    "community_mode": True,
+                    "full_integer_worker": True,
+                    "rpc_loopback_only": True,
+                    "p2p_peers": [],
+                    "p2p_port": 0,
+                    "community_rpc_urls": [
+                        f"https://{host}" for _name, host in rollout.PRODUCTION_FLEET
+                    ],
+                    "argv_sha256": "5" * 64,
+                },
+                "artifacts": {
+                    "node_sha256": mac_proof["artifact"]["files"][
+                        "arc-node-macos-arm64"
+                    ],
+                    "model_sha256": rollout.CANONICAL_MODEL_SHA256,
+                    "genesis_sha256": mac_proof["artifact"]["files"]["genesis.toml"],
+                },
+                "process": {
+                    "pid": 4242,
+                    "exact_executable_argv_and_listeners_proved": True,
+                },
+            }
+            acceptance_path = Path(artifacts["macos_canary_acceptance"]["path"])
+            acceptance_path.write_bytes(rollout.canonical_bytes(mac_acceptance))
+            acceptance_path.chmod(0o600)
+            artifacts["macos_canary_acceptance"]["sha256"] = digest(acceptance_path)
+            reward["expected_worker"] = mac_acceptance["worker"]
+            reward["macos_canary_acceptance_sha256"] = artifacts[
+                "macos_canary_acceptance"
+            ]["sha256"]
+            if "probe_argv" in reward:
+                reward["probe_argv"] = [
+                    artifacts["reward_probe"]["path"],
+                    "--max-tokens",
+                    "1",
+                    "--expected-worker",
+                    mac_acceptance["worker"],
+                ]
             validator_key_receipt_chain = {
                 "schema": "arc.recovery.validator-key-receipt-chain.v1",
                 "source_main_commit": "9" * 40,
@@ -610,6 +672,14 @@ class RecoveryRolloutTests(unittest.TestCase):
         )
         harness.persist_reward_earnings_baselines([baseline])
         return baseline
+
+    @staticmethod
+    def seal_reward_cutoff(harness):
+        cutoff = rollout.CanonicalRewardCutoff.from_receipt_blocks(
+            [(120, "f" * 64, 0), (121, "9" * 64, 0)]
+        )
+        harness.reward_evidence_cutoff = cutoff
+        return cutoff
 
     @staticmethod
     def prime_interlock_interpreters(harness):
@@ -2463,11 +2533,21 @@ class RecoveryRolloutTests(unittest.TestCase):
             rollout.validate_manifest(fixed_receipts)
 
         multi_token = copy.deepcopy(valid)
-        multi_token["checks"]["reward"]["probe_argv"][-1] = "2"
+        multi_token["checks"]["reward"]["probe_argv"][2] = "2"
         with self.assertRaisesRegex(
             rollout.RolloutError, "exactly bind the staged probe and one-token canary"
         ):
             rollout.validate_manifest(multi_token)
+
+        foreign_acceptance = copy.deepcopy(valid)
+        foreign_acceptance["checks"]["reward"][
+            "macos_canary_acceptance_sha256"
+        ] = "f" * 64
+        with self.assertRaisesRegex(
+            rollout.RolloutError,
+            "worker binding differs from the staged macOS acceptance",
+        ):
+            rollout.validate_manifest(foreign_acceptance)
 
         foreign_probe = copy.deepcopy(valid)
         foreign_probe["checks"]["reward"]["probe_sha256"] = "f" * 64
@@ -5698,6 +5778,7 @@ assert_udp_listener_owner 10001 "$ARC_TEST_EXPECTED_PID" validator-quic-p2p
         self.persist_reward_baseline(harness, evidence[0].worker)
         harness.persist_reward_evidence_progress(evidence[:1])
         harness.persist_reward_evidence_progress(evidence)
+        self.seal_reward_cutoff(harness)
         reward_sha256 = harness.persist_reward_evidence(evidence)
         gate_payload = rollout.canonical_bytes(
             {
@@ -6767,8 +6848,32 @@ assert_udp_listener_owner 10001 "$ARC_TEST_EXPECTED_PID" validator-quic-p2p
         extra_row = self.reward_receipt_row(extra, (122, "0" * 63 + "3", 0))
         extra_history = self.reward_earnings(evidence[0].worker, [*rows, extra_row])
         harness._http_json = mock.Mock(return_value=extra_history)
-        with self.assertRaisesRegex(rollout.RolloutError, "exactly two new"):
+        harness.prove_reward_projection(evidence, blocks)
+        self.assertEqual(harness._http_json.call_count, 6)
+
+        foreign_before_cutoff = self.reward_receipt_row(
+            extra,
+            (119, "0" * 63 + "4", 0),
+        )
+        earlier_history = self.reward_earnings(
+            evidence[0].worker,
+            [historical_row, foreign_before_cutoff, *rows[1:]],
+        )
+        harness._http_json = mock.Mock(return_value=earlier_history)
+        with self.assertRaisesRegex(
+            rollout.RolloutError,
+            "foreign, missing, or mutated receipt at or before",
+        ):
             harness.prove_reward_projection(evidence, blocks)
+
+        with self.assertRaisesRegex(
+            rollout.RolloutError,
+            "differ from the sealed canonical reward cutoff",
+        ):
+            harness.prove_reward_projection(
+                evidence,
+                [(120, "f" * 64, 0), (123, "9" * 64, 0)],
+            )
 
     def test_pre_canary_baseline_requires_six_node_agreement_and_survives_resume(self) -> None:
         value = self.fixture(reward_receipt=True)
@@ -7279,12 +7384,14 @@ assert_udp_listener_owner 10001 "$ARC_TEST_EXPECTED_PID" validator-quic-p2p
         baseline = self.persist_reward_baseline(harness, evidence[0].worker)
         harness.persist_reward_evidence_progress(evidence[:1])
         harness.persist_reward_evidence_progress(evidence)
+        cutoff = self.seal_reward_cutoff(harness)
         evidence_digest = harness.persist_reward_evidence(evidence)
         self.assertEqual(evidence_digest, digest(output))
         self.assertEqual(stat.S_IMODE(output.stat().st_mode), 0o444)
         parsed = rollout.parse_evidence_file(output, "d" * 64)
         self.assertEqual(list(parsed.receipts), evidence)
         self.assertEqual(parsed.earnings_baseline, baseline)
+        self.assertEqual(parsed.canonical_cutoff, cutoff)
         with self.assertRaisesRegex(rollout.RolloutError, "different rollout"):
             rollout.parse_evidence_file(output, "e" * 64)
         self.assertEqual(harness.persist_reward_evidence(evidence), evidence_digest)
@@ -7313,6 +7420,7 @@ assert_udp_listener_owner 10001 "$ARC_TEST_EXPECTED_PID" validator-quic-p2p
         self.persist_reward_baseline(resumed, evidence[0].worker)
         resumed.persist_reward_evidence_progress(evidence[:1])
         resumed.persist_reward_evidence_progress(evidence)
+        self.seal_reward_cutoff(resumed)
         resumed.persist_reward_evidence(evidence)
         self.assertEqual(
             list(rollout.parse_evidence_file(resumed_output, "d" * 64).receipts),
@@ -7336,6 +7444,7 @@ assert_udp_listener_owner 10001 "$ARC_TEST_EXPECTED_PID" validator-quic-p2p
         self.persist_reward_baseline(first, evidence[0].worker)
         first.persist_reward_evidence_progress(evidence[:1])
         first.persist_reward_evidence_progress(evidence)
+        self.seal_reward_cutoff(first)
         assert first.reward_evidence_reservation is not None
         output_fd, sidecar_fd = first.reward_evidence_reservation
         sidecar = output.with_name(output.name + ".sha256")
@@ -7390,6 +7499,7 @@ assert_udp_listener_owner 10001 "$ARC_TEST_EXPECTED_PID" validator-quic-p2p
         self.persist_reward_baseline(first, evidence[0].worker)
         first.persist_reward_evidence_progress(evidence[:1])
         first.persist_reward_evidence_progress(evidence)
+        self.seal_reward_cutoff(first)
         first.persist_reward_evidence(evidence)
         sidecar = output.with_name(output.name + ".sha256")
         # Model a crash after exact final bytes reached both files but before

--- a/scripts/release/build-postrelease-public-truth.py
+++ b/scripts/release/build-postrelease-public-truth.py
@@ -1,0 +1,1642 @@
+#!/usr/bin/env python3
+"""Derive the public ARC status files from sealed post-release evidence.
+
+The release source intentionally says that v0.8.0 is unpublished.  That text
+must remain immutable in the tag.  After the release, fleet cutover, Pages
+deployment, installer canaries, and live reward verification have all passed,
+this helper creates three create-only evidence products:
+
+* a README with only its delimited status/quickstart block replaced; and
+* a machine-readable public production-status document; and
+* the canonical v2 acceptance receipt from which those claims were derived.
+
+It never mutates a checkout.  It validates the exact raw GitHub and CDN files
+supplied by the operator, then performs one final read-only live verification
+with the exact checked-in recovery verifier.  The output directory is
+create-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import subprocess
+import stat
+import sys
+import tempfile
+import zipfile
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, NoReturn, Sequence
+
+
+STATUS_SCHEMA = "arc.public-production-status.v1"
+ACCEPTANCE_SCHEMA = "arc.post-release-acceptance.v2"
+NETWORK_SCHEMA = "arc.frontend.network.v1"
+REWARD_SCHEMA = "arc.recovery.reward-evidence.v3"
+REPOSITORY = "FerrumVir/arc-chain"
+TAG = "v0.8.0"
+VERSION = "0.8.0"
+CHAIN_ID = "0x415243"
+PROTOCOL_VERSION_RE = re.compile(r"^3\.[0-9]+\.[0-9]+$")
+RECOVERY_EPOCH = 1
+VALIDATOR_SET_ID = 1
+REWARD_PER_RECEIPT_BASE = 2_500_000_000
+PUBLIC_CONSOLE = "https://ferrumvir.github.io/arc-chain/"
+PUBLIC_EXPLORER = PUBLIC_CONSOLE + "explorer/"
+BEGIN_MARKER = "<!-- ARC_PUBLIC_TRUTH_BEGIN -->"
+END_MARKER = "<!-- ARC_PUBLIC_TRUTH_END -->"
+MAX_INPUT_BYTES = 16 * 1024 * 1024
+HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+CHAIN_HASH_RE = re.compile(r"^(?:0x)?[0-9a-f]{64}$")
+UTC_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+PAGES_WORKFLOW_PATH = ".github/workflows/deploy-explorer.yml"
+PUBLISHED_WORKFLOW_PATH = ".github/workflows/post-release-acceptance.yml"
+PAGES_JOB_NAMES = frozenset(
+    {"Verify and assemble public console", "Publish GitHub Pages"}
+)
+PUBLISHED_JOB_NAMES = frozenset(
+    {
+        "Bind exact release run, tag, and public assets",
+        "Linux headless, AppImage, and real v0.7.7 migration",
+        "Packaged desktop (macos-arm64)",
+        "Packaged desktop (macos-x86_64)",
+        "Packaged desktop (windows-x86_64)",
+        "Seal canonical published-artifact receipt",
+    }
+)
+PUBLISHED_ACCEPTANCE_RECEIPT = "POST-RELEASE-ARTIFACT-ACCEPTANCE.json"
+PUBLISHED_ACCEPTANCE_SUMS = "POST-RELEASE-ARTIFACT-ACCEPTANCE.SHA256SUMS"
+PUBLISHED_EVIDENCE_MANIFEST = "EVIDENCE-MANIFEST.json"
+PUBLISHED_TOP_LEVEL_JSON = frozenset(
+    {
+        PUBLISHED_ACCEPTANCE_RECEIPT,
+        PUBLISHED_EVIDENCE_MANIFEST,
+        "component-artifacts.json",
+        "linux-x86_64.json",
+        "macos-arm64.json",
+        "macos-x86_64.json",
+        "release-binding.json",
+        "windows-x86_64.json",
+    }
+)
+PUBLISHED_EVIDENCE_FILES = frozenset(
+    {
+        "linux-x86_64/app.stderr",
+        "linux-x86_64/app.stdout",
+        "linux-x86_64/extract.stderr",
+        "linux-x86_64/extract.stdout",
+        "linux-x86_64/headless-install.stderr",
+        "linux-x86_64/headless-install.stdout",
+        "linux-x86_64/headless-update.stderr",
+        "linux-x86_64/headless-update.stdout",
+        "linux-x86_64/legacy-data-after.json",
+        "linux-x86_64/legacy-data-before.json",
+        "linux-x86_64/legacy-home.txt",
+        "linux-x86_64/legacy-migration.stderr",
+        "linux-x86_64/legacy-migration.stdout",
+        "linux-x86_64/legacy-model-before.sha256",
+        "linux-x86_64/legacy-source.json",
+        "linux-x86_64/legacy-update.stderr",
+        "linux-x86_64/legacy-update.stdout",
+        "linux-x86_64/legacy-version.txt",
+        "linux-x86_64/window-geometry.txt",
+        "linux-x86_64/window-pid.txt",
+        "linux-x86_64/window-properties.txt",
+        "linux-x86_64/window.xwd",
+        "macos-arm64/desktop-window.json",
+        "macos-arm64/desktop.stderr",
+        "macos-arm64/desktop.stdout",
+        "macos-x86_64/desktop-window.json",
+        "macos-x86_64/desktop.stderr",
+        "macos-x86_64/desktop.stdout",
+        "release/published-evidence-artifact.json",
+        "release/published-evidence.zip",
+        "release/release-attempt-jobs.json",
+        "release/release-published.json",
+        "windows-x86_64/windows-desktop-window.json",
+        "windows-x86_64/windows-desktop.stderr",
+        "windows-x86_64/windows-desktop.stdout",
+        "windows-x86_64/windows-msi-admin.log",
+    }
+)
+EXPECTED_PUBLISHED_ZIP_FILES = frozenset(
+    set(PUBLISHED_TOP_LEVEL_JSON)
+    | {PUBLISHED_ACCEPTANCE_SUMS}
+    | {f"evidence/{name}" for name in PUBLISHED_EVIDENCE_FILES}
+)
+MAX_PUBLISHED_ZIP_BYTES = 768 * 1024 * 1024
+MAX_PUBLISHED_MEMBER_BYTES = 256 * 1024 * 1024
+MAX_PUBLISHED_EXPANDED_BYTES = 512 * 1024 * 1024
+RECOVERY_VERIFIER_RELATIVE = Path("scripts/recovery/recovery_rollout.py")
+PUBLISHED_HELPER_RELATIVE = Path("scripts/release/published-artifact-acceptance.py")
+
+PRODUCTION_FLEET = (
+    ("nyc", "149.28.32.76"),
+    ("lax", "140.82.16.112"),
+    ("ams", "136.244.109.1"),
+    ("lhr", "104.238.171.11"),
+    ("nrt", "202.182.107.41"),
+    ("sgp", "149.28.153.31"),
+)
+
+EXPECTED_RELEASE_ASSETS = {
+    "arc-node-linux-x86_64",
+    "arc-cli-linux-x86_64",
+    "arc-node-linux-arm64",
+    "arc-cli-linux-arm64",
+    "arc-node-macos-arm64",
+    "arc-cli-macos-arm64",
+    "arc-node-macos-x86_64",
+    "arc-cli-macos-x86_64",
+    "arc-node-windows-x86_64.exe",
+    "arc-cli-windows-x86_64.exe",
+    "arc-desktop-macos-arm64.app.tar.gz",
+    "arc-desktop-macos-arm64.app.tar.gz.sig",
+    "arc-desktop-macos-arm64.dmg",
+    "arc-desktop-macos-x86_64.app.tar.gz",
+    "arc-desktop-macos-x86_64.app.tar.gz.sig",
+    "arc-desktop-macos-x86_64.dmg",
+    "arc-desktop-windows-x86_64-setup.exe",
+    "arc-desktop-windows-x86_64-setup.exe.sig",
+    "arc-desktop-windows-x86_64.msi",
+    "arc-desktop-linux-x86_64.AppImage",
+    "arc-desktop-linux-x86_64.AppImage.sig",
+    "arc-desktop-linux-x86_64.deb",
+    "arc-desktop-linux-x86_64.rpm",
+    "install.sh",
+    "testnet-seeds.txt",
+    "genesis.toml",
+    "arc-legacy-maintenance-boundary.json",
+    "arc-recovery-checkpoint-descriptor.json",
+    "arc-cutover-policy.json",
+    "latest.json",
+    "SHA256SUMS",
+    "SHA256SUMS.sig",
+}
+
+
+class TruthError(ValueError):
+    """Evidence cannot support a live public status claim."""
+
+
+def fail(message: str) -> NoReturn:
+    raise TruthError(message)
+
+
+def canonical_json(value: object) -> bytes:
+    return (
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def sha256(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def load_bytes(path: Path, label: str, maximum: int = MAX_INPUT_BYTES) -> bytes:
+    descriptor = -1
+    try:
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor = os.open(path, flags)
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            fail(f"{label} must be a non-symlink regular file")
+        if before.st_size <= 0 or before.st_size > maximum:
+            fail(f"{label} has an unsupported size")
+        chunks: list[bytes] = []
+        remaining = maximum + 1
+        while remaining > 0:
+            chunk = os.read(descriptor, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+        after = os.fstat(descriptor)
+    except OSError as error:
+        fail(f"cannot read {label}: {error}")
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    stable_identity = (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+        before.st_ctime_ns,
+    ) == (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+        after.st_ctime_ns,
+    )
+    if len(raw) != before.st_size or not stable_identity:
+        fail(f"{label} changed while it was read")
+    return raw
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            fail(f"JSON contains duplicate key {key!r}")
+        result[key] = value
+    return result
+
+
+def reject_nonfinite_number(value: str) -> NoReturn:
+    fail(f"JSON contains unsupported non-finite number {value}")
+
+
+def load_json_value(path: Path, label: str) -> tuple[Any, bytes]:
+    raw = load_bytes(path, label)
+    try:
+        value = json.loads(
+            raw.decode("utf-8", errors="strict"),
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_nonfinite_number,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"{label} is invalid JSON: {error}")
+    return value, raw
+
+
+def load_json(path: Path, label: str, *, canonical: bool) -> tuple[dict[str, Any], bytes]:
+    value, raw = load_json_value(path, label)
+    if not isinstance(value, dict):
+        fail(f"{label} must be a JSON object")
+    if canonical and raw != canonical_json(value):
+        fail(f"{label} is not canonical JSON")
+    return value, raw
+
+
+def require_keys(value: dict[str, Any], required: set[str], label: str) -> None:
+    missing = required - set(value)
+    if missing:
+        fail(f"{label} omits required fields: {', '.join(sorted(missing))}")
+
+
+def exact_keys(value: dict[str, Any], required: set[str], label: str) -> None:
+    require_keys(value, required, label)
+    extra = set(value) - required
+    if extra:
+        fail(f"{label} contains unsupported fields: {', '.join(sorted(extra))}")
+
+
+def positive_int(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        fail(f"{label} must be a positive integer")
+    return value
+
+
+def hash_value(value: object, label: str) -> str:
+    if not isinstance(value, str) or HASH_RE.fullmatch(value) is None:
+        fail(f"{label} must be a lowercase SHA-256")
+    return value
+
+
+def chain_hash(value: object, label: str) -> str:
+    if not isinstance(value, str) or CHAIN_HASH_RE.fullmatch(value) is None:
+        fail(f"{label} must be a 32-byte lowercase chain hash")
+    return value.removeprefix("0x")
+
+
+def commit(value: object, label: str) -> str:
+    if not isinstance(value, str) or COMMIT_RE.fullmatch(value) is None:
+        fail(f"{label} must be a full lowercase Git commit")
+    return value
+
+
+def timestamp(value: object, label: str) -> str:
+    if not isinstance(value, str) or UTC_RE.fullmatch(value) is None:
+        fail(f"{label} must use canonical UTC seconds")
+    try:
+        dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as error:
+        fail(f"{label} is invalid: {error}")
+    return value
+
+
+def repository_tool(relative: Path, label: str) -> tuple[Path, str]:
+    """Return one exact non-symlink helper from this builder's checkout."""
+
+    script_path = Path(__file__)
+    try:
+        script_stat = script_path.lstat()
+    except OSError as error:
+        fail(f"cannot inspect public-truth builder: {error}")
+    if not stat.S_ISREG(script_stat.st_mode):
+        fail("public-truth builder must be a checked-in non-symlink regular file")
+    root = script_path.resolve().parents[2]
+    candidate = root / relative
+    raw = load_bytes(candidate, label, maximum=4 * 1024 * 1024)
+    return candidate, sha256(raw)
+
+
+def validate_workflow(
+    value: dict[str, Any], *, path: str, name: str, label: str
+) -> int:
+    workflow_id = positive_int(value.get("id"), f"{label}.id")
+    if value.get("path") != path or value.get("name") != name or value.get("state") != "active":
+        fail(f"{label} does not identify the exact active checked-in workflow")
+    return workflow_id
+
+
+def validate_run(
+    value: dict[str, Any],
+    *,
+    workflow_id: int,
+    path: str,
+    event: str,
+    head_branch: str,
+    head_sha: str | None,
+    label: str,
+) -> tuple[int, int, str]:
+    run_id = positive_int(value.get("id"), f"{label}.id")
+    run_attempt = positive_int(value.get("run_attempt"), f"{label}.run_attempt")
+    if value.get("workflow_id") != workflow_id:
+        fail(f"{label} belongs to another workflow")
+    repository = value.get("head_repository")
+    actual_sha = commit(value.get("head_sha"), f"{label}.head_sha")
+    if (
+        not isinstance(repository, dict)
+        or repository.get("full_name") != REPOSITORY
+        or value.get("path") != path
+        or value.get("event") != event
+        or value.get("head_branch") != head_branch
+        or value.get("status") != "completed"
+        or value.get("conclusion") != "success"
+        or (head_sha is not None and actual_sha != head_sha)
+    ):
+        fail(f"{label} is not the exact successful repository run")
+    return run_id, run_attempt, actual_sha
+
+
+def validate_jobs(
+    value: object,
+    *,
+    expected_names: frozenset[str],
+    run_id: int,
+    run_attempt: int,
+    head_sha: str,
+    label: str,
+) -> dict[str, int]:
+    if isinstance(value, dict):
+        exact_keys(value, {"total_count", "jobs"}, label)
+        rows = value["jobs"]
+        if value["total_count"] != len(expected_names):
+            fail(f"{label} total_count differs from the exact job set")
+    else:
+        rows = value
+    if not isinstance(rows, list) or len(rows) != len(expected_names):
+        fail(f"{label} does not contain the exact job count")
+    identities: dict[str, int] = {}
+    job_ids: set[int] = set()
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            fail(f"{label} job {index} must be an object")
+        name = row.get("name")
+        if not isinstance(name, str) or name in identities:
+            fail(f"{label} contains an invalid or duplicate job name")
+        job_id = positive_int(row.get("id"), f"{label} job {name}.id")
+        if job_id in job_ids:
+            fail(f"{label} contains duplicate job IDs")
+        if (
+            row.get("run_id") != run_id
+            or row.get("run_attempt") != run_attempt
+            or row.get("head_sha") != head_sha
+            or row.get("status") != "completed"
+            or row.get("conclusion") != "success"
+        ):
+            fail(f"{label} job {name} is not bound to the exact successful attempt")
+        identities[name] = job_id
+        job_ids.add(job_id)
+    if set(identities) != expected_names:
+        fail(f"{label} names differ from the exact checked-in job set")
+    return dict(sorted(identities.items()))
+
+
+def validate_release(
+    release: dict[str, Any], source_sha: str
+) -> tuple[str, dict[str, dict[str, Any]]]:
+    require_keys(
+        release,
+        {
+            "id", "tag_name", "target_commitish", "draft", "prerelease",
+            "immutable", "author", "assets", "html_url", "published_at",
+        },
+        "release API response",
+    )
+    if (
+        release["tag_name"] != TAG
+        or release["target_commitish"] != source_sha
+        or release["draft"] is not False
+        or release["prerelease"] is not False
+        or release["immutable"] is not True
+        or release.get("html_url")
+        != f"https://github.com/{REPOSITORY}/releases/tag/{TAG}"
+        or not isinstance(release.get("author"), dict)
+        or release["author"].get("login") != "github-actions[bot]"
+    ):
+        fail("release API response does not prove the exact immutable v0.8.0 release")
+    positive_int(release["id"], "release.id")
+    published_at = timestamp(release["published_at"], "release.published_at")
+    assets = release["assets"]
+    if not isinstance(assets, list) or len(assets) != len(EXPECTED_RELEASE_ASSETS):
+        fail("release does not contain the exact 32-asset contract")
+    names: set[str] = set()
+    normalized: dict[str, dict[str, Any]] = {}
+    total_size = 0
+    for index, asset in enumerate(assets):
+        if not isinstance(asset, dict):
+            fail(f"release asset {index} is not an object")
+        name = asset.get("name")
+        digest = asset.get("digest")
+        asset_id = asset.get("id")
+        if (
+            not isinstance(name, str)
+            or name in names
+            or isinstance(asset_id, bool)
+            or not isinstance(asset_id, int)
+            or asset_id <= 0
+            or asset.get("state") != "uploaded"
+            or not isinstance(asset.get("size"), int)
+            or isinstance(asset.get("size"), bool)
+            or asset["size"] <= 0
+            or not isinstance(digest, str)
+            or not digest.startswith("sha256:")
+            or HASH_RE.fullmatch(digest[7:]) is None
+            or not isinstance(asset.get("uploader"), dict)
+            or asset["uploader"].get("login") != "github-actions[bot]"
+        ):
+            fail(f"release asset {index} lacks its immutable uploaded digest contract")
+        maximum_size = (
+            1024 * 1024
+            if name == "arc-recovery-checkpoint-descriptor.json"
+            else 4 * 1024 * 1024
+            if name.endswith((".sig", ".json"))
+            else 2 * 1024 * 1024 * 1024
+        )
+        if asset["size"] > maximum_size:
+            fail(f"release asset {name} exceeds its reviewed size bound")
+        if asset.get("browser_download_url") != (
+            f"https://github.com/{REPOSITORY}/releases/download/{TAG}/{name}"
+        ):
+            fail(f"release asset {name} has an unexpected public URL")
+        total_size += asset["size"]
+        names.add(name)
+        normalized[name] = {
+            "id": asset_id,
+            "sha256": digest[7:],
+            "size": asset["size"],
+        }
+    if names != EXPECTED_RELEASE_ASSETS:
+        fail("release asset names differ from the exact v0.8.0 contract")
+    if total_size > 12 * 1024 * 1024 * 1024:
+        fail("release assets exceed the reviewed aggregate size bound")
+    return published_at, dict(sorted(normalized.items()))
+
+
+def validate_network(config: dict[str, Any], source_sha: str) -> dict[str, Any]:
+    exact_keys(
+        config,
+        {"schema", "state", "network", "checkpoint", "sources", "services", "notices"},
+        "frontend config",
+    )
+    if config["schema"] != NETWORK_SCHEMA or config["state"] != "recovered":
+        fail("frontend config is not the recovered production configuration")
+    if config["network"] != {"name": "ARC Testnet", "chainId": CHAIN_ID}:
+        fail("frontend config does not identify the reviewed ARC production testnet")
+    if not isinstance(config["notices"], list) or not config["notices"] or not all(
+        isinstance(item, str) and item.strip() for item in config["notices"]
+    ):
+        fail("frontend config notices must be nonempty strings")
+    checkpoint = config["checkpoint"]
+    if not isinstance(checkpoint, dict):
+        fail("frontend checkpoint is missing")
+    exact_keys(
+        checkpoint,
+        {
+            "height", "recoveryHeight", "legacyPublicMaxHeight", "blockHash",
+            "stateRoot", "manifestHash", "boundaryBlockHash", "boundaryStateRoot",
+            "recoveryEpoch", "validatorSetId", "protocolVersion", "recoveryDomain",
+            "legacySourceId", "v3SourceId",
+        },
+        "frontend checkpoint",
+    )
+    height = positive_int(checkpoint["height"], "checkpoint.height")
+    recovery_height = positive_int(checkpoint["recoveryHeight"], "checkpoint.recoveryHeight")
+    legacy_max = positive_int(checkpoint["legacyPublicMaxHeight"], "checkpoint.legacyPublicMaxHeight")
+    if height != 137_145 or recovery_height != height + 1 or legacy_max < recovery_height:
+        fail("frontend checkpoint does not preserve the reviewed H/H+1 recovery boundary")
+    if (
+        not isinstance(checkpoint["protocolVersion"], str)
+        or PROTOCOL_VERSION_RE.fullmatch(checkpoint["protocolVersion"]) is None
+    ):
+        fail("frontend checkpoint is not protocol v3")
+    if (
+        checkpoint["recoveryEpoch"] != RECOVERY_EPOCH
+        or checkpoint["validatorSetId"] != VALIDATOR_SET_ID
+        or checkpoint["legacySourceId"] != "v3-nyc"
+        or checkpoint["v3SourceId"] != "v3-nyc"
+    ):
+        fail("frontend checkpoint differs from the reviewed recovery identity")
+    for field in (
+        "blockHash", "stateRoot", "manifestHash", "boundaryBlockHash",
+        "boundaryStateRoot", "recoveryDomain",
+    ):
+        chain_hash(checkpoint[field], f"checkpoint.{field}")
+    sources = config["sources"]
+    if not isinstance(sources, list) or len(sources) != 12:
+        fail("frontend sources must contain only the six validators and six legacy forks")
+    if any(not isinstance(row, dict) for row in sources):
+        fail("frontend source rows must be objects")
+    identifiers = [row.get("id") for row in sources]
+    endpoints = [row.get("baseUrl") for row in sources]
+    if not all(isinstance(value, str) for value in identifiers + endpoints):
+        fail("frontend source identities and endpoints must be strings")
+    if len(set(identifiers)) != len(identifiers) or len(set(endpoints)) != len(endpoints):
+        fail("frontend source identities and endpoints must be unique")
+    v3 = [row for row in sources if isinstance(row, dict) and row.get("kind") == "v3"]
+    forks = [row for row in sources if isinstance(row, dict) and row.get("kind") == "legacy-fork"]
+    expected_v3 = [
+        (f"v3-{name}", f"https://{host}") for name, host in PRODUCTION_FLEET
+    ]
+    actual_v3 = [(row.get("id"), row.get("baseUrl")) for row in v3]
+    if actual_v3 != expected_v3:
+        fail("frontend config does not expose the exact six protocol-v3 validators")
+    replica_groups: set[str] = set()
+    for (name, _host), row in zip(PRODUCTION_FLEET, v3, strict=True):
+        exact_keys(
+            row,
+            {"id", "name", "region", "kind", "baseUrl", "enabled", "replicaGroup"},
+            f"frontend v3 source {name}",
+        )
+        replica_group = row["replicaGroup"]
+        if (
+            row["name"] != f"ARC v3 {name.upper()}"
+            or row["region"] != name.upper()
+            or row["enabled"] is not True
+            or not isinstance(replica_group, str)
+            or not replica_group
+        ):
+            fail(f"frontend v3 source {name} differs from its rollout identity")
+        replica_groups.add(replica_group)
+    if len(replica_groups) != 1:
+        fail("frontend validators do not share one rollout identity")
+    if len(forks) != 6:
+        fail("frontend config does not preserve exactly six legacy fork views")
+    expected_forks = [
+        (f"legacy-fork-{name}", f"https://{host}/legacy/{name}")
+        for name, host in PRODUCTION_FLEET
+    ]
+    if [(row.get("id"), row.get("baseUrl")) for row in forks] != expected_forks:
+        fail("frontend legacy forks differ from the exact six archived validators")
+    capture_ids: set[str] = set()
+    for (name, _host), row in zip(PRODUCTION_FLEET, forks, strict=True):
+        exact_keys(
+            row,
+            {
+                "id", "name", "region", "kind", "baseUrl", "enabled",
+                "replicaGroup", "description", "archive",
+            },
+            f"frontend legacy source {name}",
+        )
+        archive = row.get("archive")
+        if not isinstance(archive, dict):
+            fail("a legacy history lacks its archive commitment")
+        exact_keys(
+            archive,
+            {
+                "schema", "readOnly", "classification", "captureId", "node",
+                "rolloutManifestSha256", "archiveManifestSha256", "completeSha256",
+                "bundleSha256", "inventorySha256", "bindingIndexSha256",
+                "bindingSha256", "checkpointSha256", "checkpointManifestHash",
+                "checkpointPayloadHash", "canonicalCheckpointHeight", "sourceHeight",
+                "sourceBlockHash", "sourceStateRoot", "provenancePath",
+            },
+            f"frontend legacy source {name} archive",
+        )
+        if (
+            row.get("enabled") is not True
+            or row.get("name") != f"Preserved legacy fork · {name.upper()}"
+            or row.get("region") != name.upper()
+            or row.get("description")
+            != "Explicit immutable historical fork; diagnostic only and never canonical."
+            or archive.get("readOnly") is not True
+            or archive.get("schema") != "arc.legacy-archive.source.v1"
+            or archive.get("classification") != "valid_noncanonical_fork"
+            or archive.get("node") != name
+            or archive.get("provenancePath") != "/provenance"
+            or archive.get("canonicalCheckpointHeight") != height
+            or isinstance(archive.get("sourceHeight"), bool)
+            or not isinstance(archive.get("sourceHeight"), int)
+            or archive["sourceHeight"] < 0
+        ):
+            fail("a legacy history is not explicit, read-only, and noncanonical")
+        capture_id = hash_value(archive["captureId"], f"legacy source {name} captureId")
+        if row.get("replicaGroup") != f"legacy-capture-{capture_id}":
+            fail(f"legacy source {name} is not bound to its capture identity")
+        capture_ids.add(capture_id)
+        for field in (
+            "rolloutManifestSha256", "archiveManifestSha256", "completeSha256",
+            "bundleSha256", "inventorySha256", "bindingIndexSha256", "bindingSha256",
+            "checkpointSha256", "checkpointManifestHash", "checkpointPayloadHash",
+            "sourceBlockHash", "sourceStateRoot",
+        ):
+            chain_hash(archive[field], f"legacy source {name} archive.{field}")
+        if chain_hash(archive["checkpointManifestHash"], f"legacy source {name} checkpoint") != chain_hash(
+            checkpoint["manifestHash"], "checkpoint.manifestHash"
+        ):
+            fail(f"legacy source {name} refers to another checkpoint manifest")
+    if len(capture_ids) != 1:
+        fail("frontend legacy forks do not share one sealed capture")
+    services = config["services"]
+    if not isinstance(services, dict):
+        fail("frontend services must be an object")
+    exact_keys(services, {"maintenanceInterlock"}, "frontend services")
+    interlock = services.get("maintenanceInterlock")
+    if not isinstance(interlock, dict) or interlock.get("sourceMainCommit") != source_sha:
+        fail("frontend maintenance interlock is not bound to the release source")
+    exact_keys(
+        interlock,
+        {
+            "schema", "path", "sourceMainCommit", "observedCutoffHeight",
+            "sourceSetSha256", "boundarySha256", "toolSha256",
+            "requiredHealthyReplicas", "maxStalenessSeconds",
+        },
+        "frontend maintenance interlock",
+    )
+    if (
+        interlock.get("schema") != "arc.frontend.maintenance-interlock.v1"
+        or interlock.get("path") != "/maintenance/status"
+        or interlock.get("requiredHealthyReplicas") != 6
+        or interlock.get("maxStalenessSeconds") != 90
+        or isinstance(interlock.get("observedCutoffHeight"), bool)
+        or not isinstance(interlock.get("observedCutoffHeight"), int)
+        or interlock["observedCutoffHeight"] < 1
+    ):
+        fail("frontend live gate does not require all six validators")
+    for field in ("sourceSetSha256", "boundarySha256", "toolSha256"):
+        hash_value(interlock[field], f"frontend maintenance interlock.{field}")
+    return checkpoint
+
+
+def validate_reward(
+    reward: dict[str, Any], manifest: dict[str, Any], source_sha: str
+) -> tuple[str, int, int]:
+    exact_keys(
+        reward,
+        {"schema", "rollout_sha256", "earnings_baseline", "receipts", "canonical_cutoff"},
+        "reward evidence",
+    )
+    if reward["schema"] != REWARD_SCHEMA:
+        fail("reward evidence schema is unsupported")
+    rollout_sha = hash_value(reward["rollout_sha256"], "reward rollout SHA-256")
+    if sha256(canonical_json(manifest)) != rollout_sha:
+        fail("reward evidence is not bound to the supplied rollout manifest")
+    if manifest.get("mode") != "production":
+        fail("rollout manifest is not production mode")
+    provenance = manifest.get("provenance")
+    if not isinstance(provenance, dict) or provenance.get("source_main_commit") != source_sha:
+        fail("rollout manifest is not bound to the release source")
+    checks = manifest.get("checks")
+    policy = checks.get("reward") if isinstance(checks, dict) else None
+    if not isinstance(policy, dict) or policy.get("mode") != "receipt":
+        fail("rollout manifest does not require receipt-mode rewards")
+    reward_base = positive_int(policy.get("expected_reward_base"), "expected reward base")
+    if reward_base != REWARD_PER_RECEIPT_BASE:
+        fail("rollout manifest reward differs from the reviewed 2.5 ARC contract")
+    expected_worker = policy.get("expected_worker")
+    if not isinstance(expected_worker, str) or CHAIN_HASH_RE.fullmatch(expected_worker) is None:
+        fail("rollout manifest has no exact expected canary worker")
+    expected_worker = "0x" + expected_worker.removeprefix("0x")
+    receipts = reward["receipts"]
+    if not isinstance(receipts, list) or len(receipts) != 2:
+        fail("reward evidence must contain exactly two canary receipts")
+    tx_hashes: set[str] = set()
+    job_ids: set[str] = set()
+    for index, row in enumerate(receipts):
+        if not isinstance(row, dict) or set(row) != {"tx_hash", "job_id", "worker"}:
+            fail(f"reward receipt {index} has an unsupported shape")
+        worker = "0x" + chain_hash(row["worker"], f"reward receipt {index} worker")
+        tx_hashes.add(chain_hash(row["tx_hash"], f"reward receipt {index} tx_hash"))
+        job_ids.add(chain_hash(row["job_id"], f"reward receipt {index} job_id"))
+        if worker != expected_worker:
+            fail("reward receipt belongs to a worker other than the accepted macOS canary")
+    if len(tx_hashes) != 2 or len(job_ids) != 2:
+        fail("reward canary receipt transaction and job identities must be distinct")
+    baseline = reward["earnings_baseline"]
+    if not isinstance(baseline, dict):
+        fail("reward evidence earnings baseline must be an object")
+    exact_keys(
+        baseline,
+        {"worker", "confirmed_receipt_count", "confirmed_gross_earnings_base", "confirmed_receipts"},
+        "reward evidence earnings baseline",
+    )
+    if "0x" + chain_hash(baseline["worker"], "reward baseline worker") != expected_worker:
+        fail("reward evidence baseline belongs to another worker")
+    baseline_count = baseline["confirmed_receipt_count"]
+    baseline_gross = baseline["confirmed_gross_earnings_base"]
+    if (
+        isinstance(baseline_count, bool)
+        or not isinstance(baseline_count, int)
+        or baseline_count < 0
+        or isinstance(baseline_gross, bool)
+        or not isinstance(baseline_gross, int)
+        or baseline_gross < 0
+        or not isinstance(baseline["confirmed_receipts"], list)
+        or len(baseline["confirmed_receipts"]) != baseline_count
+    ):
+        fail("reward evidence baseline counters are invalid")
+    cutoff = reward["canonical_cutoff"]
+    if not isinstance(cutoff, dict):
+        fail("reward evidence canonical cutoff must be an object")
+    exact_keys(cutoff, {"block_height", "block_hash", "index"}, "reward evidence canonical cutoff")
+    positive_int(cutoff["block_height"], "reward evidence canonical cutoff.block_height")
+    if isinstance(cutoff["index"], bool) or not isinstance(cutoff["index"], int) or cutoff["index"] < 0:
+        fail("reward evidence canonical cutoff.index must be a non-negative integer")
+    chain_hash(cutoff["block_hash"], "reward evidence canonical cutoff.block_hash")
+    return expected_worker, reward_base, len(receipts)
+
+
+def hash_regular_file(
+    path: Path, label: str, maximum: int, *, allow_empty: bool = False
+) -> tuple[int, str]:
+    descriptor = -1
+    try:
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor = os.open(path, flags)
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            fail(f"{label} must be a non-symlink regular file")
+        if before.st_size > maximum or (before.st_size == 0 and not allow_empty):
+            fail(f"{label} has an unsupported size")
+        digest = hashlib.sha256()
+        total = 0
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > maximum:
+                fail(f"{label} exceeds its size limit")
+            digest.update(chunk)
+        after = os.fstat(descriptor)
+    except OSError as error:
+        fail(f"cannot read {label}: {error}")
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if total != before.st_size or (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+        before.st_ctime_ns,
+    ) != (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+        after.st_ctime_ns,
+    ):
+        fail(f"{label} changed while it was read")
+    return total, digest.hexdigest()
+
+
+def parse_site_sha256sums(raw: bytes) -> dict[str, str]:
+    try:
+        text = raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        fail(f"deployed SHA256SUMS is not UTF-8: {error}")
+    if not text.endswith("\n"):
+        fail("deployed SHA256SUMS must end with one complete record")
+    result: dict[str, str] = {}
+    for index, line in enumerate(text.splitlines(), 1):
+        match = re.fullmatch(r"([0-9a-f]{64})  (\./[^\r\n]+)", line)
+        if match is None:
+            fail(f"deployed SHA256SUMS line {index} is malformed")
+        digest, name = match.groups()
+        pure = Path(name.removeprefix("./"))
+        if (
+            pure.is_absolute()
+            or not pure.parts
+            or any(part in {"", ".", ".."} for part in pure.parts)
+            or "\\" in name
+            or name in result
+        ):
+            fail("deployed SHA256SUMS contains an unsafe or duplicate path")
+        result[name] = digest
+    return result
+
+
+def validate_pages(
+    args: argparse.Namespace, config_raw: bytes
+) -> tuple[dict[str, Any], dict[str, str]]:
+    workflow, workflow_raw = load_json(args.pages_workflow, "Pages workflow", canonical=False)
+    workflow_id = validate_workflow(
+        workflow,
+        path=PAGES_WORKFLOW_PATH,
+        name="Deploy ARC public console",
+        label="Pages workflow",
+    )
+    run, run_raw = load_json(args.pages_run, "Pages run", canonical=False)
+    run_id, run_attempt, frontend_sha = validate_run(
+        run,
+        workflow_id=workflow_id,
+        path=PAGES_WORKFLOW_PATH,
+        event="push",
+        head_branch="main",
+        head_sha=None,
+        label="Pages run",
+    )
+    jobs_value, jobs_raw = load_json_value(args.pages_jobs, "Pages attempt jobs")
+    jobs = validate_jobs(
+        jobs_value,
+        expected_names=PAGES_JOB_NAMES,
+        run_id=run_id,
+        run_attempt=run_attempt,
+        head_sha=frontend_sha,
+        label="Pages attempt jobs",
+    )
+    pages_api, pages_api_raw = load_json(args.pages_api, "Pages API document", canonical=False)
+    if (
+        pages_api.get("build_type") != "workflow"
+        or pages_api.get("html_url") != PUBLIC_CONSOLE
+    ):
+        fail("Pages API document does not identify the exact workflow-backed public console")
+
+    deployments, deployments_raw = load_json_value(args.pages_deployments, "Pages deployments")
+    if not isinstance(deployments, list) or len(deployments) != 1:
+        fail("Pages deployment evidence must contain exactly one matching deployment")
+    deployment = deployments[0]
+    if not isinstance(deployment, dict):
+        fail("Pages deployment must be an object")
+    deployment_id = positive_int(deployment.get("id"), "Pages deployment.id")
+    if (
+        deployment.get("sha") != frontend_sha
+        or deployment.get("ref") != "main"
+        or deployment.get("environment") != "github-pages"
+        or deployment.get("task") != "deploy"
+    ):
+        fail("Pages deployment is not bound to the accepted config commit")
+
+    statuses, statuses_raw = load_json_value(args.pages_statuses, "Pages deployment statuses")
+    if not isinstance(statuses, list) or not statuses:
+        fail("Pages deployment has no status evidence")
+    status_ids: set[int] = set()
+    successful: list[dict[str, Any]] = []
+    for index, row in enumerate(statuses):
+        if not isinstance(row, dict):
+            fail(f"Pages deployment status {index} must be an object")
+        status_id = positive_int(row.get("id"), f"Pages deployment status {index}.id")
+        if status_id in status_ids:
+            fail("Pages deployment statuses contain duplicate IDs")
+        status_ids.add(status_id)
+        if row.get("state") == "success":
+            successful.append(row)
+    if (
+        len(successful) != 1
+        or statuses[0] is not successful[0]
+        or successful[0].get("environment") != "github-pages"
+        or str(successful[0].get("environment_url", "")).rstrip("/")
+        != PUBLIC_CONSOLE.rstrip("/")
+    ):
+        fail("latest exact Pages deployment status is not the unique public success")
+
+    deployed_commit_raw = load_bytes(args.deployed_commit, "deployed commit", maximum=1024)
+    if deployed_commit_raw != f"{frontend_sha}\n".encode("ascii"):
+        fail("deployed-commit.txt does not contain the exact Pages commit")
+    deployed_sums_raw = load_bytes(
+        args.deployed_sha256sums, "deployed SHA256SUMS", maximum=1024 * 1024
+    )
+    sums = parse_site_sha256sums(deployed_sums_raw)
+    expected_cdn = {
+        "./shared/frontend/arc-network.json": sha256(config_raw),
+        "./deployed-commit.txt": sha256(deployed_commit_raw),
+    }
+    for name, digest in expected_cdn.items():
+        if sums.get(name) != digest:
+            fail(f"deployed SHA256SUMS does not bind the CDN bytes for {name}")
+    return (
+        {
+            "acceptedConfigCommit": frontend_sha,
+            "deploymentId": deployment_id,
+            "jobIds": jobs,
+            "runAttempt": run_attempt,
+            "runId": run_id,
+            "statusId": successful[0]["id"],
+            "url": PUBLIC_CONSOLE,
+            "workflowId": workflow_id,
+        },
+        {
+            "configSha256": sha256(config_raw),
+            "deployedCommitSha256": sha256(deployed_commit_raw),
+            "deploymentsSha256": sha256(deployments_raw),
+            "jobsSha256": sha256(jobs_raw),
+            "pagesApiSha256": sha256(pages_api_raw),
+            "runSha256": sha256(run_raw),
+            "sha256sumsSha256": sha256(deployed_sums_raw),
+            "statusesSha256": sha256(statuses_raw),
+            "workflowSha256": sha256(workflow_raw),
+        },
+    )
+
+
+def extract_published_acceptance(archive: Path, target: Path) -> tuple[int, str]:
+    archive_size, archive_sha = hash_regular_file(
+        archive, "published-acceptance Actions ZIP", MAX_PUBLISHED_ZIP_BYTES
+    )
+    try:
+        with zipfile.ZipFile(archive, "r") as handle:
+            entries = handle.infolist()
+            names = [entry.filename for entry in entries]
+            if len(names) != len(set(names)) or set(names) != EXPECTED_PUBLISHED_ZIP_FILES:
+                fail("published-acceptance ZIP does not contain the exact canonical file set")
+            expanded = 0
+            for entry in entries:
+                pure = Path(entry.filename)
+                mode_type = (entry.external_attr >> 16) & 0o170000
+                if (
+                    pure.is_absolute()
+                    or any(part in {"", ".", ".."} for part in pure.parts)
+                    or "\\" in entry.filename
+                    or entry.is_dir()
+                    or entry.flag_bits & 0x1
+                    or mode_type not in (0, 0o100000)
+                    or (entry.file_size == 0 and entry.filename in PUBLISHED_TOP_LEVEL_JSON)
+                    or entry.file_size > MAX_PUBLISHED_MEMBER_BYTES
+                ):
+                    fail("published-acceptance ZIP contains an unsafe member")
+                expanded += entry.file_size
+                if expanded > MAX_PUBLISHED_EXPANDED_BYTES:
+                    fail("published-acceptance ZIP expands beyond its reviewed bound")
+                destination = target.joinpath(*pure.parts)
+                destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+                with handle.open(entry, "r") as source, destination.open("xb") as output:
+                    copied = 0
+                    while True:
+                        chunk = source.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        copied += len(chunk)
+                        if copied > entry.file_size:
+                            fail("published-acceptance ZIP member exceeds its declared size")
+                        output.write(chunk)
+                    output.flush()
+                    os.fsync(output.fileno())
+                if copied != entry.file_size:
+                    fail("published-acceptance ZIP member is truncated")
+                os.chmod(destination, 0o400)
+    except (zipfile.BadZipFile, RuntimeError, OSError) as error:
+        fail(f"cannot extract published-acceptance ZIP: {error}")
+    return archive_size, archive_sha
+
+
+def validate_artifact_sha256sums(root: Path) -> dict[str, str]:
+    raw = load_bytes(root / PUBLISHED_ACCEPTANCE_SUMS, "published-acceptance SHA256SUMS")
+    try:
+        text = raw.decode("ascii", errors="strict")
+    except UnicodeDecodeError as error:
+        fail(f"published-acceptance SHA256SUMS is not ASCII: {error}")
+    if not text.endswith("\n"):
+        fail("published-acceptance SHA256SUMS is truncated")
+    hashes: dict[str, str] = {}
+    for line in text.splitlines():
+        match = re.fullmatch(r"([0-9a-f]{64})  (\./[^\r\n]+)", line)
+        if match is None:
+            fail("published-acceptance SHA256SUMS contains a malformed record")
+        digest, relative = match.groups()
+        name = relative[2:]
+        if name in hashes or name not in EXPECTED_PUBLISHED_ZIP_FILES:
+            fail("published-acceptance SHA256SUMS contains an unknown or duplicate path")
+        hashes[name] = digest
+    expected = set(EXPECTED_PUBLISHED_ZIP_FILES) - {PUBLISHED_ACCEPTANCE_SUMS}
+    if set(hashes) != expected:
+        fail("published-acceptance SHA256SUMS does not cover every canonical member")
+    for name, expected_sha in hashes.items():
+        _size, actual_sha = hash_regular_file(
+            root / name,
+            f"published member {name}",
+            MAX_PUBLISHED_MEMBER_BYTES,
+            allow_empty=True,
+        )
+        if actual_sha != expected_sha:
+            fail(f"published-acceptance member {name} differs from SHA256SUMS")
+    return dict(sorted(hashes.items()))
+
+
+def run_checked_helper(command: Sequence[str], label: str) -> tuple[str, bytes]:
+    helper, helper_sha = repository_tool(PUBLISHED_HELPER_RELATIVE, "published acceptance helper")
+    result = subprocess.run(
+        [sys.executable, "-I", str(helper), *command],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=180,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()[-1000:]
+        fail(f"{label} failed closed: {detail or f'exit {result.returncode}'}")
+    _helper_after, helper_after_sha = repository_tool(
+        PUBLISHED_HELPER_RELATIVE, "published acceptance helper"
+    )
+    if helper_after_sha != helper_sha:
+        fail("published acceptance helper changed while it was invoked")
+    return helper_sha, result.stdout
+
+
+def validate_published_acceptance(
+    args: argparse.Namespace, temporary_root: Path
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    workflow, workflow_raw = load_json(
+        args.published_workflow, "published-acceptance workflow", canonical=False
+    )
+    workflow_id = validate_workflow(
+        workflow,
+        path=PUBLISHED_WORKFLOW_PATH,
+        name="Published artifact acceptance",
+        label="published-acceptance workflow",
+    )
+    run, run_raw = load_json(args.published_run, "published-acceptance run", canonical=False)
+    run_id, run_attempt, source_sha = validate_run(
+        run,
+        workflow_id=workflow_id,
+        path=PUBLISHED_WORKFLOW_PATH,
+        event="workflow_dispatch",
+        head_branch=TAG,
+        head_sha=None,
+        label="published-acceptance run",
+    )
+    jobs_value, jobs_raw = load_json_value(
+        args.published_jobs, "published-acceptance attempt jobs"
+    )
+    job_ids = validate_jobs(
+        jobs_value,
+        expected_names=PUBLISHED_JOB_NAMES,
+        run_id=run_id,
+        run_attempt=run_attempt,
+        head_sha=source_sha,
+        label="published-acceptance attempt jobs",
+    )
+    metadata, metadata_raw = load_json(
+        args.published_artifact_metadata,
+        "published-acceptance artifact metadata",
+        canonical=False,
+    )
+    artifact_id = positive_int(metadata.get("id"), "published-acceptance artifact.id")
+    artifact_size = positive_int(
+        metadata.get("size_in_bytes"), "published-acceptance artifact.size_in_bytes"
+    )
+    artifact_digest = metadata.get("digest")
+    artifact_name = (
+        f"arc-published-artifact-acceptance-{TAG}-{source_sha}-{run_id}-"
+        f"attempt-{run_attempt}"
+    )
+    workflow_run = metadata.get("workflow_run")
+    if (
+        artifact_size > MAX_PUBLISHED_ZIP_BYTES
+        or metadata.get("name") != artifact_name
+        or metadata.get("expired") is not False
+        or not isinstance(artifact_digest, str)
+        or re.fullmatch(r"sha256:[0-9a-f]{64}", artifact_digest) is None
+        or not isinstance(workflow_run, dict)
+        or workflow_run.get("id") != run_id
+        or workflow_run.get("head_sha") != source_sha
+    ):
+        fail("published-acceptance artifact metadata is not bound to the exact run")
+
+    extracted = temporary_root / "published-acceptance"
+    extracted.mkdir(mode=0o700)
+    zip_size, zip_sha = extract_published_acceptance(args.published_artifact_zip, extracted)
+    if artifact_size != zip_size or artifact_digest != f"sha256:{zip_sha}":
+        fail("published-acceptance ZIP bytes differ from artifact metadata")
+    member_hashes = validate_artifact_sha256sums(extracted)
+    for name in PUBLISHED_TOP_LEVEL_JSON:
+        load_json(extracted / name, f"canonical published member {name}", canonical=True)
+
+    receipt, receipt_raw = load_json(
+        extracted / PUBLISHED_ACCEPTANCE_RECEIPT,
+        "canonical published-acceptance receipt",
+        canonical=True,
+    )
+    if (
+        receipt.get("schema") != "arc.published-artifact-acceptance.v1"
+        or receipt.get("repository") != REPOSITORY
+        or receipt.get("tag") != TAG
+        or receipt.get("commit") != source_sha
+        or receipt.get("acceptance_run_id") != run_id
+        or receipt.get("acceptance_run_attempt") != run_attempt
+        or receipt.get("verified_platforms")
+        != ["linux-x86_64", "macos-arm64", "macos-x86_64", "windows-x86_64"]
+        or receipt.get("evidence_file_count") != len(PUBLISHED_EVIDENCE_FILES)
+    ):
+        fail("canonical published-acceptance receipt has the wrong exact identity")
+    component_hashes = receipt.get("component_receipt_sha256")
+    if not isinstance(component_hashes, dict) or set(component_hashes) != {
+        "linux-x86_64", "macos-arm64", "macos-x86_64", "windows-x86_64"
+    }:
+        fail("canonical published-acceptance receipt has an invalid component hash set")
+    for platform, digest in component_hashes.items():
+        if hash_value(digest, f"published component {platform} hash") != member_hashes[f"{platform}.json"]:
+            fail(f"published component {platform} hash is not bound to the ZIP member")
+    if receipt.get("evidence_manifest_sha256") != member_hashes[PUBLISHED_EVIDENCE_MANIFEST]:
+        fail("published evidence manifest hash is not bound to the ZIP member")
+
+    components = temporary_root / "components"
+    components.mkdir(mode=0o700)
+    for platform in component_hashes:
+        os.link(extracted / f"{platform}.json", components / f"{platform}.json")
+    rebuilt = temporary_root / "rebuilt-published-acceptance.json"
+    helper_sha, _helper_stdout = run_checked_helper(
+        (
+            "aggregate",
+            "--binding", str(extracted / "release-binding.json"),
+            "--component-artifacts", str(extracted / "component-artifacts.json"),
+            "--components", str(components),
+            "--evidence-manifest", str(extracted / PUBLISHED_EVIDENCE_MANIFEST),
+            "--evidence-root", str(extracted / "evidence"),
+            "--acceptance-run-id", str(run_id),
+            "--acceptance-run-attempt", str(run_attempt),
+            "--output", str(rebuilt),
+        ),
+        "exact published-acceptance helper rebuild",
+    )
+    rebuilt_raw = load_bytes(rebuilt, "rebuilt published-acceptance receipt")
+    if rebuilt_raw != receipt_raw:
+        fail("published-acceptance canonical receipt differs from the exact helper rebuild")
+
+    binding, _ = load_json(
+        extracted / "release-binding.json", "published release binding", canonical=True
+    )
+    linux, _ = load_json(
+        extracted / "linux-x86_64.json", "published Linux component", canonical=True
+    )
+    linux_assets = linux.get("assets")
+    if not isinstance(linux_assets, dict) or "install.sh" not in linux_assets:
+        fail("published Linux component does not contain the validated installer")
+    installer = linux_assets["install.sh"]
+    if not isinstance(installer, dict):
+        fail("published Linux component installer identity must be an object")
+    installer_sha = hash_value(installer.get("sha256"), "published Linux installer SHA-256")
+    positive_int(installer.get("id"), "published Linux installer asset ID")
+    positive_int(installer.get("size"), "published Linux installer size")
+    return (
+        {
+            "artifactDigest": artifact_digest,
+            "artifactId": artifact_id,
+            "artifactName": artifact_name,
+            "canonicalReceiptSha256": sha256(receipt_raw),
+            "componentReceiptSha256": dict(sorted(component_hashes.items())),
+            "helperPath": PUBLISHED_HELPER_RELATIVE.as_posix(),
+            "helperSha256": helper_sha,
+            "jobIds": job_ids,
+            "releaseId": positive_int(
+                receipt.get("release_id"), "canonical published receipt release ID"
+            ),
+            "releaseRunAttempt": positive_int(
+                receipt.get("release_run_attempt"),
+                "canonical published receipt release run attempt",
+            ),
+            "releaseRunId": positive_int(
+                receipt.get("release_run_id"),
+                "canonical published receipt release run ID",
+            ),
+            "runAttempt": run_attempt,
+            "runId": run_id,
+            "workflowId": workflow_id,
+        },
+        {
+            "artifactMetadataSha256": sha256(metadata_raw),
+            "artifactZipSha256": zip_sha,
+            "jobsSha256": sha256(jobs_raw),
+            "runSha256": sha256(run_raw),
+            "workflowSha256": sha256(workflow_raw),
+        },
+        {
+            "binding": binding,
+            "installerSha256": installer_sha,
+            "linuxComponent": linux,
+            "sourceSha": source_sha,
+        },
+    )
+
+
+def run_recovery_verify(
+    manifest_path: Path,
+    reward_path: Path,
+    manifest_raw: bytes,
+    reward_raw: bytes,
+    temporary_root: Path,
+) -> dict[str, str]:
+    verifier, verifier_sha = repository_tool(
+        RECOVERY_VERIFIER_RELATIVE, "recovery rollout verifier"
+    )
+    stdout_path = temporary_root / "recovery-verify.stdout"
+    stderr_path = temporary_root / "recovery-verify.stderr"
+    with stdout_path.open("xb") as stdout, stderr_path.open("xb") as stderr:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-I",
+                str(verifier),
+                "verify",
+                "--manifest",
+                str(manifest_path),
+                "--reward-evidence",
+                str(reward_path),
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=stdout,
+            stderr=stderr,
+            check=False,
+            timeout=30 * 60,
+        )
+    stderr_raw = load_bytes(stderr_path, "recovery verifier stderr", maximum=16 * 1024 * 1024)
+    if result.returncode != 0:
+        detail = stderr_raw.decode("utf-8", errors="replace").strip()[-1000:]
+        fail(f"exact checked-in recovery verifier failed closed: {detail or f'exit {result.returncode}'}")
+    stdout_raw = load_bytes(stdout_path, "recovery verifier stdout", maximum=16 * 1024 * 1024)
+    if not stdout_raw or b"VERIFIED locked rollout sha256=" not in stdout_raw:
+        fail("exact checked-in recovery verifier produced no terminal verification record")
+    _verifier_after, verifier_after_sha = repository_tool(
+        RECOVERY_VERIFIER_RELATIVE, "recovery rollout verifier"
+    )
+    if verifier_after_sha != verifier_sha:
+        fail("recovery rollout verifier changed while it was invoked")
+    if (
+        load_bytes(manifest_path, "rollout manifest", maximum=MAX_INPUT_BYTES) != manifest_raw
+        or load_bytes(reward_path, "reward evidence", maximum=MAX_INPUT_BYTES) != reward_raw
+    ):
+        fail("sealed rollout or reward evidence changed during live verification")
+    return {
+        "manifestSha256": sha256(manifest_raw),
+        "rewardEvidenceSha256": sha256(reward_raw),
+        "stdoutSha256": sha256(stdout_raw),
+        "verifierPath": RECOVERY_VERIFIER_RELATIVE.as_posix(),
+        "verifierSha256": verifier_sha,
+    }
+
+
+def arc_text(base: int) -> str:
+    value = Decimal(base) / Decimal(1_000_000_000)
+    return format(value.normalize(), "f")
+
+
+def render_readme_block(
+    *,
+    source_sha: str,
+    frontend_sha: str,
+    published_at: str,
+    checkpoint: dict[str, Any],
+    installer_sha: str,
+    reward_base: int,
+    receipt_count: int,
+) -> str:
+    total_arc = arc_text(reward_base * receipt_count)
+    each_arc = arc_text(reward_base)
+    short_source = source_sha[:12]
+    short_frontend = frontend_sha[:12]
+    return f"""{BEGIN_MARKER}
+> **Live public testnet (evidence sealed after {published_at}):** The immutable
+> [v0.8.0 release](https://github.com/FerrumVir/arc-chain/releases/tag/v0.8.0)
+> is built from [`{short_source}`](https://github.com/FerrumVir/arc-chain/commit/{source_sha}).
+> All six protocol-v3 validators serve the retained canonical chain through
+> block **{checkpoint['height']:,}**, continue at **{checkpoint['recoveryHeight']:,}**, and are
+> required to agree before the public console reports the network as healthy.
+> The six prior public histories remain available as explicit, immutable,
+> read-only noncanonical fork views; no legacy block was erased or renumbered.
+> The recovered network bytes were first accepted on Pages from verified config
+> commit [`{short_frontend}`](https://github.com/FerrumVir/arc-chain/commit/{frontend_sha}).
+> This block and its machine-readable status are published only by a subsequent
+> reviewed commit; the deployed site's `deployed-commit.txt` identifies that commit.
+
+The first migration from an unsigned v0.7 build remains manual and pinned to
+the exact tag. The published Linux x86_64 component proved this exact
+bootstrap in both fresh-install and update-only modes:
+
+```bash
+curl -fsSLO --proto '=https' --proto-redir '=https' --tlsv1.2 https://raw.githubusercontent.com/FerrumVir/arc-chain/v0.8.0/install.sh
+ARC_INSTALL_SHA256={installer_sha}
+if command -v sha256sum >/dev/null 2>&1; then
+  printf '%s  %s\\n' "$ARC_INSTALL_SHA256" install.sh | sha256sum -c -
+else
+  printf '%s  %s\\n' "$ARC_INSTALL_SHA256" install.sh | shasum -a 256 -c -
+fi
+bash install.sh --version 0.8.0
+```
+
+The immutable release includes headless Linux amd64 and arm64 binaries, Intel
+and Apple Silicon macOS binaries, Windows CLI binaries, and desktop packages.
+The command above is claimed only for the independently exercised Linux
+x86_64 published component; the displayed installer digest comes from that
+component's canonical acceptance receipt.
+The signed v0.8 desktop updater checks shortly after startup and every 24 hours
+when enabled, then asks for confirmation. The transactional headless updater
+runs daily when installed as a service. Linux `.deb` and `.rpm` packages remain
+package-manager owned.
+
+### Community support answer sheet
+
+| Community question | Current evidence-backed answer |
+|---|---|
+| Can an SSH-only EC2/VPS install ARC? | **Yes, on Linux x86_64 as exercised.** Use the pinned command above. `arc-node-linux-x86_64` is the GUI-free amd64 binary; the immutable release also includes Linux arm64 assets without extending this canary claim. |
+| Are Intel and Apple Silicon Macs supported? | **Yes.** v0.8.0 contains separate signed CLI and desktop packages for x86_64 and arm64 macOS. |
+| Does automatic update work? | **Yes, within the documented safety boundary.** v0.8 desktop checks automatically but requires confirmation; managed headless installs use the transactional daily updater. The one-time unsigned v0.7 migration is deliberately manual. |
+| Are the seed nodes upgraded? | **Yes.** Six protocol-v3 validators are bound to checkpoint H={checkpoint['height']:,}, transition H+1={checkpoint['recoveryHeight']:,}, and an all-six public health gate. |
+| Can a stake-zero community worker earn the configured {each_arc} ARC reward? | **Yes.** The production canary proved {receipt_count} distinct mined rewards totaling {total_arc} ARC for one exact-model stake-zero worker. Registration or a raw `0x16` inference attestation alone does not pay. |
+| What hardware should a worker run? | The production target is Llama-2-7B Q4_K_M (about 4 GB on disk). Leave RAM and CPU headroom for a complete model load; GPU is optional and hardware never guarantees work. |
+| Where are inference, earnings, and blocks? | The [dashboard]({PUBLIC_CONSOLE}) shows receipt-backed inference and confirmed/projected earnings. The [explorer]({PUBLIC_EXPLORER}) resolves the matching canonical block and transaction. Projections remain unavailable until enough real observations exist. |
+
+See the [headless/server guide](docs/HEADLESS_INSTALL.md), the
+[desktop guide](docs/GETTING_STARTED.md), and the
+[2–3 minute walkthrough](docs/COMMUNITY-NODE-WALKTHROUGH.md). The exact public
+proof identifiers are published in
+[`shared/frontend/production-status.json`](shared/frontend/production-status.json).
+{END_MARKER}"""
+
+
+def build(args: argparse.Namespace) -> tuple[Path, Path]:
+    readme_raw = load_bytes(args.readme, "README", maximum=4 * 1024 * 1024)
+    try:
+        readme = readme_raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        fail(f"README is not UTF-8: {error}")
+    if readme.count(BEGIN_MARKER) != 1 or readme.count(END_MARKER) != 1:
+        fail("README must contain exactly one ordered ARC public-truth marker pair")
+    begin = readme.index(BEGIN_MARKER)
+    end_begin = readme.index(END_MARKER)
+    if end_begin <= begin:
+        fail("README must contain exactly one ordered ARC public-truth marker pair")
+    end = end_begin + len(END_MARKER)
+
+    release, _release_raw = load_json(args.release_api, "release API response", canonical=False)
+    config, config_raw = load_json(args.frontend_config, "frontend config", canonical=True)
+    reward, reward_raw = load_json(args.reward_evidence, "reward evidence", canonical=True)
+    manifest, manifest_raw = load_json(args.rollout_manifest, "rollout manifest", canonical=True)
+
+    with tempfile.TemporaryDirectory(prefix="arc-public-truth-") as temporary:
+        temporary_root = Path(temporary)
+        published, published_hashes, published_values = validate_published_acceptance(
+            args, temporary_root
+        )
+        source_sha = published_values["sourceSha"]
+        published_at, release_assets = validate_release(release, source_sha)
+        binding = published_values["binding"]
+        binding_release = binding.get("release")
+        binding_workflow = binding.get("release_workflow")
+        if (
+            binding.get("repository") != REPOSITORY
+            or binding.get("tag") != TAG
+            or binding.get("commit") != source_sha
+            or not isinstance(binding_release, dict)
+            or binding_release.get("id") != release["id"]
+            or binding_release.get("immutable") is not True
+            or not isinstance(binding_workflow, dict)
+            or binding_workflow.get("run_id") != published["releaseRunId"]
+            or binding_workflow.get("run_attempt") != published["releaseRunAttempt"]
+            or binding_release.get("id") != published["releaseId"]
+            or binding.get("assets") != release_assets
+        ):
+            fail("published release binding differs from the current immutable release API")
+        release_run_id = positive_int(
+            binding_workflow.get("run_id"), "published release binding run ID"
+        )
+        release_run_attempt = positive_int(
+            binding_workflow.get("run_attempt"), "published release binding run attempt"
+        )
+        if (
+            published_values["linuxComponent"].get("release_run_id") != release_run_id
+            or published_values["linuxComponent"].get("release_run_attempt")
+            != release_run_attempt
+        ):
+            fail("published Linux installer component belongs to another release attempt")
+        installer_sha = published_values["installerSha256"]
+        if release_assets["install.sh"]["sha256"] != installer_sha:
+            fail("published Linux installer differs from the immutable release API")
+
+        pages, pages_hashes = validate_pages(args, config_raw)
+        frontend_sha = pages["acceptedConfigCommit"]
+        checkpoint = validate_network(config, source_sha)
+        worker, reward_base, receipt_count = validate_reward(
+            reward, manifest, source_sha
+        )
+
+        # This is deliberately the final evidence gate.  The exact checked-in
+        # rollout verifier re-reads the sealed files and performs live all-six
+        # convergence and mined-reward verification immediately before any
+        # public claim or acceptance receipt is rendered.
+        recovery = run_recovery_verify(
+            args.rollout_manifest,
+            args.reward_evidence,
+            manifest_raw,
+            reward_raw,
+            temporary_root,
+        )
+
+        acceptance = {
+            "pages": {**pages, "evidenceSha256": pages_hashes},
+            "publishedAcceptance": {
+                **published,
+                "evidenceSha256": published_hashes,
+            },
+            "recovery": recovery,
+            "release": {
+                "assetSetSha256": sha256(canonical_json(release_assets)),
+                "id": release["id"],
+                "publishedAt": published_at,
+                "releaseApiSha256": sha256(_release_raw),
+                "runAttempt": release_run_attempt,
+                "runId": release_run_id,
+                "sourceCommit": source_sha,
+                "tag": TAG,
+            },
+            "repository": REPOSITORY,
+            "schema": ACCEPTANCE_SCHEMA,
+        }
+        acceptance_raw = canonical_json(acceptance)
+
+        block = render_readme_block(
+            source_sha=source_sha,
+            frontend_sha=frontend_sha,
+            published_at=published_at,
+            checkpoint=checkpoint,
+            installer_sha=installer_sha,
+            reward_base=reward_base,
+            receipt_count=receipt_count,
+        )
+    output_readme = (readme[:begin] + block + readme[end:]).encode("utf-8")
+    status = {
+        "acceptance": {
+            # Embed the complete canonical v2 receipt so a public reader can
+            # independently canonicalize/re-hash it and follow its exact
+            # workflow, run, job, artifact, Pages, and recovery evidence
+            # identities.  The receipt deliberately does not depend on this
+            # status document, so this introduces no circular hash.
+            "receipt": acceptance,
+            "publishedArtifactReceiptSha256": published[
+                "canonicalReceiptSha256"
+            ],
+            "receiptSha256": sha256(acceptance_raw),
+            "releaseRunAttempt": release_run_attempt,
+            "releaseRunId": release_run_id,
+        },
+        "checkpoint": {
+            "blockHash": chain_hash(checkpoint["blockHash"], "checkpoint.blockHash"),
+            "height": checkpoint["height"],
+            "legacyPublicMaxHeight": checkpoint["legacyPublicMaxHeight"],
+            "manifestHash": chain_hash(checkpoint["manifestHash"], "checkpoint.manifestHash"),
+            "protocolVersion": checkpoint["protocolVersion"],
+            "recoveryHeight": checkpoint["recoveryHeight"],
+            "stateRoot": chain_hash(checkpoint["stateRoot"], "checkpoint.stateRoot"),
+        },
+        "fleet": {
+            "legacyForkCount": 6,
+            "legacyForkPolicy": "immutable-read-only-noncanonical",
+            "requiredHealthyValidators": 6,
+            "validatorCount": 6,
+        },
+        "network": config["network"],
+        "pages": {
+            "acceptedConfigCommit": frontend_sha,
+            "deploymentId": pages["deploymentId"],
+            "runAttempt": pages["runAttempt"],
+            "runId": pages["runId"],
+        },
+        "release": {
+            "id": release["id"],
+            "immutable": True,
+            "publishedAt": published_at,
+            "sourceCommit": source_sha,
+            "tag": TAG,
+            "url": release["html_url"],
+            "version": VERSION,
+        },
+        "rewards": {
+            "canaryReceiptCount": receipt_count,
+            "canaryWorker": worker,
+            "demonstratedGrossArc": float(Decimal(reward_base * receipt_count) / Decimal(1_000_000_000)),
+            "demonstratedGrossBase": reward_base * receipt_count,
+            "rewardPerReceiptArc": float(Decimal(reward_base) / Decimal(1_000_000_000)),
+            "rewardPerReceiptBase": reward_base,
+            "stakeZeroEligible": True,
+        },
+        "schema": STATUS_SCHEMA,
+        "services": {"dashboard": PUBLIC_CONSOLE, "explorer": PUBLIC_EXPLORER},
+        "state": "recovered",
+    }
+    output_status = canonical_json(status)
+
+    output_dir: Path = args.output_dir
+    if not output_dir.is_absolute() or output_dir.name in {"", ".", ".."}:
+        fail("output directory must be an absolute dedicated path")
+    directory_fd = -1
+    try:
+        output_dir.mkdir(mode=0o700, parents=False, exist_ok=False)
+        os.chmod(output_dir, 0o700)
+        created = output_dir.lstat()
+        directory_flags = os.O_RDONLY
+        if hasattr(os, "O_DIRECTORY"):
+            directory_flags |= os.O_DIRECTORY
+        if hasattr(os, "O_NOFOLLOW"):
+            directory_flags |= os.O_NOFOLLOW
+        directory_fd = os.open(output_dir, directory_flags)
+        opened = os.fstat(directory_fd)
+        if (
+            not stat.S_ISDIR(opened.st_mode)
+            or (created.st_dev, created.st_ino) != (opened.st_dev, opened.st_ino)
+        ):
+            fail("public-truth output directory changed while it was opened")
+        readme_path = output_dir / "README.md"
+        status_path = output_dir / "production-status.json"
+        acceptance_path = output_dir / "POST-RELEASE-ACCEPTANCE.json"
+        for name, raw in (
+            ("README.md", output_readme),
+            ("production-status.json", output_status),
+            ("POST-RELEASE-ACCEPTANCE.json", acceptance_raw),
+        ):
+            file_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            if hasattr(os, "O_NOFOLLOW"):
+                file_flags |= os.O_NOFOLLOW
+            descriptor = os.open(name, file_flags, 0o400, dir_fd=directory_fd)
+            try:
+                view = memoryview(raw)
+                while view:
+                    written = os.write(descriptor, view)
+                    if written <= 0:
+                        fail(f"cannot completely write public-truth output {name}")
+                    view = view[written:]
+                os.fsync(descriptor)
+                os.fchmod(descriptor, 0o400)
+            finally:
+                os.close(descriptor)
+        os.fsync(directory_fd)
+        final = output_dir.lstat()
+        if (final.st_dev, final.st_ino) != (opened.st_dev, opened.st_ino):
+            fail("public-truth output directory changed while it was written")
+    except OSError as error:
+        fail(f"cannot create public-truth output: {error}")
+    finally:
+        if directory_fd >= 0:
+            os.close(directory_fd)
+    return readme_path, status_path
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--readme", required=True, type=Path)
+    result.add_argument("--release-api", required=True, type=Path)
+    result.add_argument("--pages-workflow", required=True, type=Path)
+    result.add_argument("--pages-run", required=True, type=Path)
+    result.add_argument("--pages-jobs", required=True, type=Path)
+    result.add_argument("--pages-api", required=True, type=Path)
+    result.add_argument("--pages-deployments", required=True, type=Path)
+    result.add_argument("--pages-statuses", required=True, type=Path)
+    result.add_argument("--frontend-config", required=True, type=Path)
+    result.add_argument("--deployed-commit", required=True, type=Path)
+    result.add_argument("--deployed-sha256sums", required=True, type=Path)
+    result.add_argument("--published-workflow", required=True, type=Path)
+    result.add_argument("--published-run", required=True, type=Path)
+    result.add_argument("--published-jobs", required=True, type=Path)
+    result.add_argument("--published-artifact-metadata", required=True, type=Path)
+    result.add_argument("--published-artifact-zip", required=True, type=Path)
+    result.add_argument("--reward-evidence", required=True, type=Path)
+    result.add_argument("--rollout-manifest", required=True, type=Path)
+    result.add_argument("--output-dir", required=True, type=Path)
+    return result
+
+
+def main() -> int:
+    try:
+        readme, status = build(parser().parse_args())
+    except TruthError as error:
+        print(f"public truth: {error}", file=sys.stderr)
+        return 1
+    print(f"public truth README: {readme}")
+    print(f"public truth status: {status}")
+    print(f"public truth acceptance: {status.parent / 'POST-RELEASE-ACCEPTANCE.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/macos-community-canary.py
+++ b/scripts/release/macos-community-canary.py
@@ -527,6 +527,7 @@ class Paths:
     provenance_recheck: Path
     config: Path
     config_checksum: Path
+    acceptance_receipt: Path
     log: Path
     launch_agent: Path
     lifecycle_lock: Path
@@ -586,6 +587,7 @@ def managed_paths(root: Path, home: Path) -> Paths:
         provenance_recheck=root / "config/LIVE-RECHECK.json",
         config=root / "config/canary.json",
         config_checksum=root / "config/canary.json.sha256",
+        acceptance_receipt=root / "evidence/ACCEPTED.json",
         log=root / "logs/node.log",
         launch_agent=home / f"Library/LaunchAgents/{LABEL}.plist",
         # This lock is deliberately outside the managed root and is never
@@ -1643,6 +1645,7 @@ class CanaryController:
                 "root": str(self.paths.root),
                 "data": str(self.paths.data_dir),
                 "evidence": str(self.paths.evidence_dir),
+                "acceptance_receipt": str(self.paths.acceptance_receipt),
                 "tmp": str(self.paths.tmp_dir),
                 "log": str(self.paths.log),
                 "runner": str(self.paths.runner),
@@ -1980,6 +1983,8 @@ class CanaryController:
             managed.get("root") != str(self.paths.root)
             or managed.get("data") != str(self.paths.data_dir)
             or managed.get("evidence") != str(self.paths.evidence_dir)
+            or managed.get("acceptance_receipt")
+            != str(self.paths.acceptance_receipt)
             or managed.get("tmp") != str(self.paths.tmp_dir)
             or managed.get("log") != str(self.paths.log)
             or managed.get("runner") != str(self.paths.runner)
@@ -2001,7 +2006,106 @@ class CanaryController:
             private_file(self.paths.launch_agent, self.uid, "canary LaunchAgent")
             if self.paths.launch_agent.read_bytes() != expected_plist:
                 fail("canary LaunchAgent differs from the exact expected plist")
+        if self.paths.acceptance_receipt.exists() or self.paths.acceptance_receipt.is_symlink():
+            self._validate_acceptance_receipt(config)
         return config
+
+    def _acceptance_payload(
+        self, config: dict[str, Any], *, pid: int, accepted_at_unix_ns: int
+    ) -> dict[str, Any]:
+        """Return the immutable handoff that binds production probes to this worker."""
+
+        return {
+            "schema": "arc.macos.pretag-community-canary.acceptance.v1",
+            "accepted": True,
+            "accepted_at_unix_ns": accepted_at_unix_ns,
+            "canary_schema": SCHEMA,
+            "label": LABEL,
+            "platform": PLATFORM,
+            "rust_target": RUST_TARGET,
+            "config_sha256": sha256(self.paths.config),
+            "worker": "0x" + config["identity"]["public_address"],
+            "pretag": {
+                "repository": config["pretag"]["repository"],
+                "commit": config["pretag"]["commit"],
+                "run_id": config["pretag"]["run_id"],
+                "run_attempt": config["pretag"]["run_attempt"],
+                "artifact_id": config["pretag"]["artifact_id"],
+                "artifact_digest": config["pretag"]["artifact_digest"],
+                "archive_sha256": config["pretag"]["archive_sha256"],
+                "metadata_sha256": config["pretag"]["metadata_sha256"],
+            },
+            "runtime": {
+                "stake": config["runtime"]["stake"],
+                "community_mode": config["runtime"]["community_mode"],
+                "full_integer_worker": config["runtime"]["full_integer_worker"],
+                "rpc_loopback_only": config["runtime"]["rpc_loopback_only"],
+                "p2p_peers": config["runtime"]["p2p_peers"],
+                "p2p_port": config["runtime"]["p2p_port"],
+                "community_rpc_urls": config["runtime"]["community_rpc_urls"],
+                "argv_sha256": config["runtime"]["argv_sha256"],
+            },
+            "artifacts": {
+                "node_sha256": config["node"]["sha256"],
+                "model_sha256": config["model"]["sha256"],
+                "genesis_sha256": config["genesis"]["sha256"],
+            },
+            "process": {
+                "pid": pid,
+                "exact_executable_argv_and_listeners_proved": True,
+            },
+        }
+
+    def _validate_acceptance_receipt(self, config: dict[str, Any]) -> dict[str, Any]:
+        private_file(
+            self.paths.acceptance_receipt,
+            self.uid,
+            "macOS canary acceptance receipt",
+        )
+        payload = self.paths.acceptance_receipt.read_bytes()
+        if len(payload) > 64 * 1024:
+            fail("macOS canary acceptance receipt is oversized")
+        try:
+            receipt = json.loads(payload)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            fail(f"macOS canary acceptance receipt is invalid: {error}")
+        if not isinstance(receipt, dict) or payload != canonical_json(receipt):
+            fail("macOS canary acceptance receipt is not canonical JSON")
+        if set(receipt) != {
+            "schema", "accepted", "accepted_at_unix_ns", "canary_schema",
+            "label", "platform", "rust_target", "config_sha256", "worker",
+            "pretag", "runtime", "artifacts", "process",
+        }:
+            fail("macOS canary acceptance receipt field set differs")
+        timestamp = receipt.get("accepted_at_unix_ns")
+        process = receipt.get("process")
+        if (
+            receipt.get("schema")
+            != "arc.macos.pretag-community-canary.acceptance.v1"
+            or receipt.get("accepted") is not True
+            or isinstance(timestamp, bool)
+            or not isinstance(timestamp, int)
+            or timestamp <= 0
+            or receipt.get("canary_schema") != SCHEMA
+            or receipt.get("label") != LABEL
+            or receipt.get("platform") != PLATFORM
+            or receipt.get("rust_target") != RUST_TARGET
+            or not isinstance(process, dict)
+            or set(process) != {"pid", "exact_executable_argv_and_listeners_proved"}
+            or isinstance(process.get("pid"), bool)
+            or not isinstance(process.get("pid"), int)
+            or process["pid"] <= 0
+            or process.get("exact_executable_argv_and_listeners_proved") is not True
+        ):
+            fail("macOS canary acceptance receipt header/process proof is malformed")
+        expected = self._acceptance_payload(
+            config,
+            pid=process["pid"],
+            accepted_at_unix_ns=timestamp,
+        )
+        if receipt != expected:
+            fail("macOS canary acceptance receipt differs from the validated canary config")
+        return receipt
 
     def _service_target(self) -> str:
         return f"{self.domain}/{LABEL}"
@@ -2191,6 +2295,44 @@ class CanaryController:
         return 0
 
     @lifecycle_transaction
+    def accept(self) -> None:
+        """Seal the exact running worker identity for production reward probes."""
+
+        config = self._validate_installation(require_launch_agent=True)
+        pid = self._prove_process(config)
+        if self.paths.acceptance_receipt.exists() or self.paths.acceptance_receipt.is_symlink():
+            receipt = self._validate_acceptance_receipt(config)
+            print(
+                "Canary acceptance already sealed for exact worker "
+                f"{receipt['worker']}; sha256={sha256(self.paths.acceptance_receipt)}"
+            )
+            return
+        payload = self._acceptance_payload(
+            config,
+            pid=pid,
+            accepted_at_unix_ns=time.time_ns(),
+        )
+        publish_bytes_create_only(
+            self.paths.acceptance_receipt,
+            canonical_json(payload),
+            0o600,
+            self.uid,
+        )
+        receipt = self._validate_acceptance_receipt(config)
+        self._write_evidence(
+            "accept",
+            {
+                "worker": receipt["worker"],
+                "acceptance_sha256": sha256(self.paths.acceptance_receipt),
+            },
+        )
+        print(
+            "Accepted exact pre-tag community canary worker "
+            f"{receipt['worker']}; receipt={self.paths.acceptance_receipt}; "
+            f"sha256={sha256(self.paths.acceptance_receipt)}"
+        )
+
+    @lifecycle_transaction
     def stop(self) -> None:
         require_plist = self.paths.launch_agent.exists() or self.paths.launch_agent.is_symlink()
         config = self._validate_installation(require_launch_agent=require_plist)
@@ -2324,7 +2466,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     subparsers = parser.add_subparsers(dest="command", required=True)
     for name in ("plan", "install"):
         add_candidate_arguments(subparsers.add_parser(name))
-    for name in ("start", "status", "stop", "cleanup"):
+    for name in ("start", "status", "accept", "stop", "cleanup"):
         add_root_argument(subparsers.add_parser(name))
     return parser.parse_args(argv)
 
@@ -2355,6 +2497,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     if args.command == "status":
         return controller.status()
+    if args.command == "accept":
+        controller.accept()
+        return 0
     if args.command == "stop":
         controller.stop()
         return 0

--- a/scripts/release/protected_pretag_artifact.py
+++ b/scripts/release/protected_pretag_artifact.py
@@ -849,7 +849,8 @@ def prove_live_api(
     )
     workflow_id = _validate_workflow(workflow)
     run = client.get_json(
-        f"/repos/{REPOSITORY}/actions/runs/{run_id}", label="preflight run"
+        f"/repos/{REPOSITORY}/actions/runs/{run_id}/attempts/{run_attempt}",
+        label="preflight run",
     )
     _validate_run(
         run,
@@ -939,7 +940,8 @@ def prove_live_api_set(
     )
     workflow_id = _validate_workflow(workflow)
     run = client.get_json(
-        f"/repos/{REPOSITORY}/actions/runs/{run_id}", label="preflight run"
+        f"/repos/{REPOSITORY}/actions/runs/{run_id}/attempts/{run_attempt}",
+        label="preflight run",
     )
     _validate_run(
         run,

--- a/scripts/release/published-artifact-acceptance.py
+++ b/scripts/release/published-artifact-acceptance.py
@@ -1,0 +1,1486 @@
+#!/usr/bin/env python3
+"""Bind and verify the public bytes exercised after an ARC release.
+
+This utility deliberately has no GitHub credentials or network client.  The
+read-only post-release workflow captures GitHub API documents, downloads
+assets by immutable server ID, and gives those local facts to this verifier.
+Keeping selection and byte verification here makes the security boundary
+unit-testable without teaching repository code how to publish or mutate a
+release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SHA40 = re.compile(r"[0-9a-f]{40}")
+SHA256 = re.compile(r"[0-9a-f]{64}")
+STRICT_TAG = re.compile(r"v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)")
+EXPECTED_REPOSITORY = "FerrumVir/arc-chain"
+
+EXPECTED_RELEASE_ASSETS = frozenset(
+    {
+        "arc-node-linux-x86_64",
+        "arc-cli-linux-x86_64",
+        "arc-node-linux-arm64",
+        "arc-cli-linux-arm64",
+        "arc-node-macos-arm64",
+        "arc-cli-macos-arm64",
+        "arc-node-macos-x86_64",
+        "arc-cli-macos-x86_64",
+        "arc-node-windows-x86_64.exe",
+        "arc-cli-windows-x86_64.exe",
+        "arc-desktop-macos-arm64.app.tar.gz",
+        "arc-desktop-macos-arm64.app.tar.gz.sig",
+        "arc-desktop-macos-arm64.dmg",
+        "arc-desktop-macos-x86_64.app.tar.gz",
+        "arc-desktop-macos-x86_64.app.tar.gz.sig",
+        "arc-desktop-macos-x86_64.dmg",
+        "arc-desktop-windows-x86_64-setup.exe",
+        "arc-desktop-windows-x86_64-setup.exe.sig",
+        "arc-desktop-windows-x86_64.msi",
+        "arc-desktop-linux-x86_64.AppImage",
+        "arc-desktop-linux-x86_64.AppImage.sig",
+        "arc-desktop-linux-x86_64.deb",
+        "arc-desktop-linux-x86_64.rpm",
+        "install.sh",
+        "testnet-seeds.txt",
+        "genesis.toml",
+        "arc-legacy-maintenance-boundary.json",
+        "arc-recovery-checkpoint-descriptor.json",
+        "arc-cutover-policy.json",
+        "latest.json",
+        "SHA256SUMS",
+        "SHA256SUMS.sig",
+    }
+)
+
+EXPECTED_RELEASE_JOBS = frozenset(
+    {
+        "Validate release tag and pin commit",
+        "Full quality gate on validated release commit",
+        "Cargo dependency policy (workspace)",
+        "Cargo dependency policy (desktop)",
+        "Cargo dependency policy (updater-verifier)",
+        "Golden vectors (linux-x86_64)",
+        "Golden vectors (linux-arm64)",
+        "Golden vectors (macos-arm64)",
+        "Golden vectors (macos-x86_64)",
+        "Golden vectors (windows-x86_64)",
+        "Verify exact pre-tag headless linux-x86_64",
+        "Verify exact pre-tag headless linux-arm64",
+        "Verify exact pre-tag headless macos-arm64",
+        "Verify exact pre-tag headless macos-x86_64",
+        "Verify exact pre-tag headless windows-x86_64",
+        "Ubuntu server smoke (linux-x86_64)",
+        "Ubuntu server smoke (linux-arm64)",
+        "Verify exact pre-tag desktop macos-arm64",
+        "Verify exact pre-tag desktop macos-x86_64",
+        "Verify exact pre-tag desktop windows-x86_64",
+        "Verify exact pre-tag desktop linux-x86_64",
+        "Assemble the exact unsigned release manifest",
+        "Sign only the verified release manifest",
+        "Create and upload one isolated release draft",
+        "Verify GitHub draft bytes without publication authority",
+        "Publish only the independently verified draft",
+        "Verify the immutable GitHub release without publication authority",
+    }
+)
+SKIPPED_RELEASE_JOB = "Delete a draft rejected by the unprivileged verifier"
+PUBLISHED_EVIDENCE_MEMBER = "release-published.json"
+MAX_PUBLISHED_EVIDENCE_BYTES = 4 * 1024 * 1024
+MAX_PUBLISHED_EVIDENCE_ZIP_BYTES = 8 * 1024 * 1024
+
+# v0.7.7 is not a GitHub-immutable release.  Its migration input is therefore
+# pinned independently by tag commit, release ID, asset ID, size, and digest.
+# Replacing or re-uploading the historical binary cannot silently satisfy this
+# contract even if the public tag URL continues to resolve.
+LEGACY_SOURCE = {
+    "tag": "v0.7.7",
+    "commit": "37df67b526cd0eebf6b55fa940c7646d1f4c947f",
+    "release_id": 331028280,
+    "asset": {
+        "id": 432306066,
+        "name": "arc-node-linux-x86_64",
+        "size": 23286656,
+        "sha256": "1cfc3039786d023cde24ad0b452f35735b39f9e83aaf293e6ed0bf623a11b20c",
+    },
+    "installer": {
+        "path": "scripts/install-community-node.sh",
+        "sha256": "34aabc144750ca656c88412372fff7b94384514776eca7b747de52f57bfa5430",
+    },
+    "seed_config": {
+        "path": "testnet-seeds.txt",
+        "sha256": "f2a71401e3b6a9d354a6c00ded4a3d8327f84bd0f4af7aea5076096f41d01671",
+    },
+    "genesis": {
+        "path": "genesis.toml",
+        "sha256": "805ea6c83f836a2076d9c140defd3f07ca6d75b0e074c956496db2665e72ee7d",
+    },
+}
+
+EXPECTED_COMPONENTS = {
+    "linux-x86_64": frozenset(
+        {
+            "install.sh",
+            "arc-node-linux-x86_64",
+            "arc-cli-linux-x86_64",
+            "arc-desktop-linux-x86_64.AppImage",
+            "arc-desktop-linux-x86_64.AppImage.sig",
+        }
+    ),
+    "macos-arm64": frozenset(
+        {
+            "arc-desktop-macos-arm64.app.tar.gz",
+            "arc-desktop-macos-arm64.app.tar.gz.sig",
+            "arc-desktop-macos-arm64.dmg",
+        }
+    ),
+    "macos-x86_64": frozenset(
+        {
+            "arc-desktop-macos-x86_64.app.tar.gz",
+            "arc-desktop-macos-x86_64.app.tar.gz.sig",
+            "arc-desktop-macos-x86_64.dmg",
+        }
+    ),
+    "windows-x86_64": frozenset(
+        {
+            "arc-desktop-windows-x86_64-setup.exe",
+            "arc-desktop-windows-x86_64-setup.exe.sig",
+            "arc-desktop-windows-x86_64.msi",
+        }
+    ),
+}
+
+REQUIRED_CHECKS = {
+    "linux-x86_64": {
+        "appimage_process_stable": True,
+        "appimage_updater_signature_valid": True,
+        "appimage_visible_window": True,
+        "appimage_window_capture_nonempty": True,
+        "headless_fresh_install": True,
+        "headless_update_only": True,
+        "legacy_binary_executed_offline": True,
+        "legacy_history_preserved": True,
+        "legacy_installer_source_pinned": True,
+        "legacy_model_preserved": True,
+        "legacy_preexisting_offline": True,
+        "legacy_state_preserved": True,
+        "service_started": False,
+        "v08_fresh_data": True,
+    },
+    "macos-arm64": {
+        "archive_safe": True,
+        "bundle_architecture": "arm64",
+        "bundle_codesign_valid": True,
+        "bundle_identifier": "network.arc.desktop",
+        "bundle_version": "0.8.0",
+        "desktop_process_stable": True,
+        "desktop_visible_window": True,
+        "dmg_bundle_matches": True,
+        "dmg_verified": True,
+        "isolated_profile": True,
+        "service_started": False,
+        "updater_signature_valid": True,
+    },
+    "macos-x86_64": {
+        "archive_safe": True,
+        "bundle_architecture": "x86_64",
+        "bundle_codesign_valid": True,
+        "bundle_identifier": "network.arc.desktop",
+        "bundle_version": "0.8.0",
+        "desktop_process_stable": True,
+        "desktop_visible_window": True,
+        "dmg_bundle_matches": True,
+        "dmg_verified": True,
+        "isolated_profile": True,
+        "service_started": False,
+        "updater_signature_valid": True,
+    },
+    "windows-x86_64": {
+        "desktop_process_stable": True,
+        "desktop_visible_window": True,
+        "embedded_app_pe_machine": "AMD64",
+        "isolated_profile": True,
+        "msi_administrative_extract": True,
+        "msi_product_version": "0.8.0",
+        "no_installed_service": True,
+        "setup_pe_machine": "AMD64",
+        "updater_signature_valid": True,
+    },
+}
+
+EXPECTED_EVIDENCE_FILES = frozenset(
+    {
+        "linux-x86_64/app.stderr",
+        "linux-x86_64/app.stdout",
+        "linux-x86_64/extract.stderr",
+        "linux-x86_64/extract.stdout",
+        "linux-x86_64/headless-install.stderr",
+        "linux-x86_64/headless-install.stdout",
+        "linux-x86_64/headless-update.stderr",
+        "linux-x86_64/headless-update.stdout",
+        "linux-x86_64/legacy-data-after.json",
+        "linux-x86_64/legacy-data-before.json",
+        "linux-x86_64/legacy-home.txt",
+        "linux-x86_64/legacy-migration.stderr",
+        "linux-x86_64/legacy-migration.stdout",
+        "linux-x86_64/legacy-model-before.sha256",
+        "linux-x86_64/legacy-source.json",
+        "linux-x86_64/legacy-update.stderr",
+        "linux-x86_64/legacy-update.stdout",
+        "linux-x86_64/legacy-version.txt",
+        "linux-x86_64/window-geometry.txt",
+        "linux-x86_64/window-pid.txt",
+        "linux-x86_64/window-properties.txt",
+        "linux-x86_64/window.xwd",
+        "macos-arm64/desktop-window.json",
+        "macos-arm64/desktop.stderr",
+        "macos-arm64/desktop.stdout",
+        "macos-x86_64/desktop-window.json",
+        "macos-x86_64/desktop.stderr",
+        "macos-x86_64/desktop.stdout",
+        "release/published-evidence-artifact.json",
+        "release/published-evidence.zip",
+        "release/release-attempt-jobs.json",
+        "release/release-published.json",
+        "windows-x86_64/windows-desktop-window.json",
+        "windows-x86_64/windows-desktop.stderr",
+        "windows-x86_64/windows-desktop.stdout",
+        "windows-x86_64/windows-msi-admin.log",
+    }
+)
+MAX_CANONICAL_EVIDENCE_FILE_BYTES = 256 * 1024 * 1024
+MAX_CANONICAL_EVIDENCE_TOTAL_BYTES = 512 * 1024 * 1024
+
+
+class AcceptanceError(ValueError):
+    """A captured release fact or downloaded byte failed closed."""
+
+
+def load_json(path: Path, description: str) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AcceptanceError(f"cannot read {description}: {error}") from error
+
+
+def load_object(path: Path, description: str) -> dict[str, Any]:
+    value = load_json(path, description)
+    if not isinstance(value, dict):
+        raise AcceptanceError(f"{description} must be a JSON object")
+    return value
+
+
+def load_object_bytes(payload: bytes, description: str) -> dict[str, Any]:
+    try:
+        value = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AcceptanceError(f"cannot read {description}: {error}") from error
+    if not isinstance(value, dict):
+        raise AcceptanceError(f"{description} must be a JSON object")
+    return value
+
+
+def positive_int(value: Any, description: str) -> int:
+    if type(value) is not int or value <= 0:  # noqa: E721
+        raise AcceptanceError(f"{description} must be a positive integer")
+    return value
+
+
+def exact(value: Any, expected: Any, description: str) -> None:
+    if type(value) is not type(expected) or value != expected:  # noqa: E721
+        raise AcceptanceError(
+            f"{description} mismatch: expected {expected!r}, got {value!r}"
+        )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_canonical(path: Path, value: Any) -> None:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.new.{os.getpid()}")
+    try:
+        temporary.write_text(payload, encoding="utf-8")
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def write_bytes(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.new.{os.getpid()}")
+    try:
+        temporary.write_bytes(payload)
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def asset_size_limit(name: str) -> int:
+    if name == "arc-recovery-checkpoint-descriptor.json":
+        return 1024 * 1024
+    if name.endswith((".sig", ".json")):
+        return 4 * 1024 * 1024
+    return 2 * 1024 * 1024 * 1024
+
+
+def validate_release_assets(
+    release: dict[str, Any], repository: str, tag: str
+) -> dict[str, dict[str, Any]]:
+    raw_assets = release.get("assets")
+    if not isinstance(raw_assets, list):
+        raise AcceptanceError("release assets must be an array")
+    assets: dict[str, dict[str, Any]] = {}
+    for index, raw in enumerate(raw_assets):
+        if not isinstance(raw, dict):
+            raise AcceptanceError(f"release asset {index} must be an object")
+        name = raw.get("name")
+        if not isinstance(name, str) or not name:
+            raise AcceptanceError(f"release asset {index} has an invalid name")
+        if name in assets:
+            raise AcceptanceError(f"duplicate release asset: {name}")
+        asset_id = positive_int(raw.get("id"), f"asset {name} id")
+        size = positive_int(raw.get("size"), f"asset {name} size")
+        if size > asset_size_limit(name):
+            raise AcceptanceError(f"asset {name} exceeds its size limit")
+        digest = raw.get("digest")
+        if not isinstance(digest, str) or not digest.startswith("sha256:"):
+            raise AcceptanceError(f"asset {name} has no SHA-256 digest")
+        sha256 = digest.removeprefix("sha256:")
+        if not SHA256.fullmatch(sha256):
+            raise AcceptanceError(f"asset {name} has a malformed SHA-256 digest")
+        exact(raw.get("state"), "uploaded", f"asset {name} state")
+        uploader = raw.get("uploader")
+        if not isinstance(uploader, dict):
+            raise AcceptanceError(f"asset {name} uploader must be an object")
+        exact(uploader.get("login"), "github-actions[bot]", f"asset {name} uploader")
+        expected_url = f"https://github.com/{repository}/releases/download/{tag}/{name}"
+        exact(raw.get("browser_download_url"), expected_url, f"asset {name} URL")
+        assets[name] = {
+            "id": asset_id,
+            "sha256": sha256,
+            "size": size,
+        }
+    if set(assets) != EXPECTED_RELEASE_ASSETS:
+        missing = sorted(EXPECTED_RELEASE_ASSETS - set(assets))
+        extra = sorted(set(assets) - EXPECTED_RELEASE_ASSETS)
+        raise AcceptanceError(
+            f"release asset set mismatch; missing={missing!r}, extra={extra!r}"
+        )
+    if sum(item["size"] for item in assets.values()) > 12 * 1024 * 1024 * 1024:
+        raise AcceptanceError("release asset total exceeds 12 GiB")
+    return dict(sorted(assets.items()))
+
+
+def validate_release_attempt_jobs(
+    path: Path, repository: str, commit: str, run_id: int, run_attempt: int
+) -> dict[str, Any]:
+    value = load_object(path, "exact release-attempt jobs document")
+    raw_jobs = value.get("jobs")
+    if not isinstance(raw_jobs, list):
+        raise AcceptanceError("exact release-attempt jobs must be an array")
+    expected_count = len(EXPECTED_RELEASE_JOBS) + 1
+    exact(value.get("total_count"), expected_count, "release-attempt jobs total_count")
+    exact(len(raw_jobs), expected_count, "release-attempt jobs captured count")
+
+    names: set[str] = set()
+    ids: set[int] = set()
+    jobs: list[dict[str, Any]] = []
+    for index, raw in enumerate(raw_jobs):
+        if not isinstance(raw, dict):
+            raise AcceptanceError(f"release-attempt job {index} must be an object")
+        name = raw.get("name")
+        if not isinstance(name, str) or not name:
+            raise AcceptanceError(f"release-attempt job {index} has an invalid name")
+        if name in names:
+            raise AcceptanceError(f"duplicate release-attempt job name: {name}")
+        names.add(name)
+        job_id = positive_int(raw.get("id"), f"release-attempt job {name} id")
+        if job_id in ids:
+            raise AcceptanceError("release-attempt job IDs must be unique")
+        ids.add(job_id)
+        exact(raw.get("run_id"), run_id, f"release-attempt job {name} run id")
+        exact(
+            raw.get("run_attempt"),
+            run_attempt,
+            f"release-attempt job {name} run attempt",
+        )
+        exact(raw.get("head_sha"), commit, f"release-attempt job {name} commit")
+        exact(raw.get("status"), "completed", f"release-attempt job {name} status")
+        expected_conclusion = "skipped" if name == SKIPPED_RELEASE_JOB else "success"
+        exact(
+            raw.get("conclusion"),
+            expected_conclusion,
+            f"release-attempt job {name} conclusion",
+        )
+        jobs.append(
+            {
+                "conclusion": expected_conclusion,
+                "head_sha": commit,
+                "id": job_id,
+                "name": name,
+                "run_attempt": run_attempt,
+                "run_id": run_id,
+                "status": "completed",
+            }
+        )
+    expected_names = set(EXPECTED_RELEASE_JOBS) | {SKIPPED_RELEASE_JOB}
+    if names != expected_names:
+        missing = sorted(expected_names - names)
+        extra = sorted(names - expected_names)
+        raise AcceptanceError(
+            f"release-attempt job set mismatch; missing={missing!r}, extra={extra!r}"
+        )
+    return {
+        "commit": commit,
+        "jobs": sorted(jobs, key=lambda job: job["name"]),
+        "release_run_attempt": run_attempt,
+        "release_run_id": run_id,
+        "repository": repository,
+        "schema": "arc.release-attempt-jobs.v1",
+    }
+
+
+def validate_published_artifact_metadata(
+    artifact: dict[str, Any],
+    commit: str,
+    release_id: int,
+    run_id: int,
+    run_attempt: int,
+) -> tuple[dict[str, Any], str]:
+    artifact_id = positive_int(artifact.get("id"), "published-evidence artifact id")
+    artifact_size = positive_int(
+        artifact.get("size_in_bytes"), "published-evidence artifact size"
+    )
+    if artifact_size > MAX_PUBLISHED_EVIDENCE_ZIP_BYTES:
+        raise AcceptanceError("published-evidence artifact exceeds its size limit")
+    artifact_digest = artifact.get("digest")
+    if not isinstance(artifact_digest, str) or not re.fullmatch(
+        r"sha256:[0-9a-f]{64}", artifact_digest
+    ):
+        raise AcceptanceError("published-evidence artifact digest is malformed")
+    exact(artifact.get("expired"), False, "published-evidence artifact expiration")
+    workflow_run = artifact.get("workflow_run")
+    if not isinstance(workflow_run, dict):
+        raise AcceptanceError("published-evidence artifact workflow_run must be an object")
+    exact(workflow_run.get("id"), run_id, "published-evidence artifact run id")
+    exact(workflow_run.get("head_sha"), commit, "published-evidence artifact commit")
+    artifact_name = artifact.get("name")
+    if not isinstance(artifact_name, str):
+        raise AcceptanceError("published-evidence artifact name is invalid")
+    prefix = (
+        f"arc-release-published-evidence-{commit}-{run_id}-{run_attempt}-{release_id}-"
+    )
+    match = re.fullmatch(re.escape(prefix) + r"([0-9a-f]{64})", artifact_name)
+    if match is None:
+        raise AcceptanceError("published-evidence artifact name is not exact-attempt bound")
+    return (
+        {
+            "digest": artifact_digest,
+            "expired": False,
+            "id": artifact_id,
+            "name": artifact_name,
+            "size_in_bytes": artifact_size,
+            "workflow_run": {"head_sha": commit, "id": run_id},
+        },
+        match.group(1),
+    )
+
+
+def command_select_published_evidence(args: argparse.Namespace) -> None:
+    if not SHA40.fullmatch(args.commit):
+        raise AcceptanceError("release commit must be 40 lowercase hex characters")
+    run_id = positive_int(args.release_run_id, "release run id")
+    run_attempt = positive_int(args.release_run_attempt, "release run attempt")
+    release = load_object(args.release_json, "release API document")
+    release_id = positive_int(release.get("id"), "release id")
+    exact(release.get("tag_name"), "v0.8.0", "release tag")
+    exact(release.get("target_commitish"), args.commit, "release target")
+    exact(release.get("draft"), False, "release draft state")
+    exact(release.get("immutable"), True, "release immutable state")
+
+    artifacts_document = load_object(args.artifacts_json, "release artifacts document")
+    raw_artifacts = artifacts_document.get("artifacts")
+    if not isinstance(raw_artifacts, list):
+        raise AcceptanceError("release artifacts must be an array")
+    prefix = (
+        f"arc-release-published-evidence-{args.commit}-{run_id}-{run_attempt}-"
+        f"{release_id}-"
+    )
+    matches = [
+        artifact
+        for artifact in raw_artifacts
+        if isinstance(artifact, dict)
+        and isinstance(artifact.get("name"), str)
+        and re.fullmatch(re.escape(prefix) + r"[0-9a-f]{64}", artifact["name"])
+    ]
+    if len(matches) != 1:
+        raise AcceptanceError(
+            "expected exactly one exact-attempt publication evidence artifact"
+        )
+    selected, _ = validate_published_artifact_metadata(
+        matches[0], args.commit, release_id, run_id, run_attempt
+    )
+    write_canonical(args.output, selected)
+
+
+def locate_actions_zip(root: Path, artifact_name: str) -> Path:
+    try:
+        root_mode = root.lstat().st_mode
+    except OSError as error:
+        raise AcceptanceError(f"cannot inspect published-evidence download: {error}") from error
+    if not stat.S_ISDIR(root_mode):
+        raise AcceptanceError("published-evidence download root must be a directory")
+    named = root / artifact_name
+    try:
+        named_mode = named.lstat().st_mode
+    except FileNotFoundError:
+        source = root
+    except OSError as error:
+        raise AcceptanceError(f"cannot inspect published-evidence artifact: {error}") from error
+    else:
+        if not stat.S_ISDIR(named_mode):
+            raise AcceptanceError("named published-evidence artifact must be a directory")
+        source = named
+    entries = list(source.iterdir())
+    if len(entries) != 1:
+        raise AcceptanceError("raw published-evidence download must contain exactly one ZIP")
+    archive = entries[0]
+    regular_file(archive, "raw published-evidence Actions ZIP")
+    if archive.stat().st_size > MAX_PUBLISHED_EVIDENCE_ZIP_BYTES:
+        raise AcceptanceError("raw published-evidence Actions ZIP exceeds its size limit")
+    return archive
+
+
+def validate_published_evidence(
+    artifact_path: Path,
+    download_root: Path,
+    release: dict[str, Any],
+    assets: dict[str, dict[str, Any]],
+    repository: str,
+    tag: str,
+    commit: str,
+    release_id: int,
+    run_id: int,
+    run_attempt: int,
+) -> tuple[bytes, bytes, dict[str, Any]]:
+    raw_artifact = load_object(artifact_path, "published-evidence artifact document")
+    artifact, name_evidence_sha = validate_published_artifact_metadata(
+        raw_artifact, commit, release_id, run_id, run_attempt
+    )
+    artifact_id = artifact["id"]
+    artifact_size = artifact["size_in_bytes"]
+    artifact_digest = artifact["digest"]
+    artifact_name = artifact["name"]
+    archive = locate_actions_zip(download_root, artifact_name)
+    archive_payload = archive.read_bytes()
+    exact(len(archive_payload), artifact_size, "published-evidence ZIP size")
+    exact(
+        f"sha256:{hashlib.sha256(archive_payload).hexdigest()}",
+        artifact_digest,
+        "published-evidence ZIP digest",
+    )
+
+    try:
+        with zipfile.ZipFile(archive, "r") as handle:
+            members = handle.infolist()
+            if len(members) != 1:
+                raise AcceptanceError(
+                    "published-evidence ZIP must contain exactly release-published.json"
+                )
+            member = members[0]
+            mode_type = (member.external_attr >> 16) & 0o170000
+            if (
+                member.filename != PUBLISHED_EVIDENCE_MEMBER
+                or member.is_dir()
+                or member.flag_bits & 0x1
+                or mode_type not in (0, 0o100000)
+                or member.file_size <= 0
+                or member.file_size > MAX_PUBLISHED_EVIDENCE_BYTES
+            ):
+                raise AcceptanceError(
+                    "published-evidence ZIP contains an unsafe or invalid member"
+                )
+            payload = handle.read(member)
+    except (zipfile.BadZipFile, RuntimeError, OSError) as error:
+        raise AcceptanceError(f"cannot read published-evidence ZIP: {error}") from error
+    if len(payload) > MAX_PUBLISHED_EVIDENCE_BYTES:
+        raise AcceptanceError("published release API evidence exceeds its size limit")
+    evidence_sha = hashlib.sha256(payload).hexdigest()
+    exact(evidence_sha, name_evidence_sha, "published-evidence content-name digest")
+
+    evidence_release = load_object_bytes(payload, "published release API evidence")
+    exact(evidence_release.get("id"), release_id, "published evidence release id")
+    exact(evidence_release.get("tag_name"), tag, "published evidence release tag")
+    exact(
+        evidence_release.get("target_commitish"),
+        commit,
+        "published evidence release target",
+    )
+    exact(evidence_release.get("draft"), False, "published evidence draft state")
+    exact(
+        evidence_release.get("prerelease"),
+        False,
+        "published evidence prerelease state",
+    )
+    exact(
+        evidence_release.get("immutable"),
+        True,
+        "published evidence immutable state",
+    )
+    evidence_author = evidence_release.get("author")
+    if not isinstance(evidence_author, dict):
+        raise AcceptanceError("published evidence author must be an object")
+    exact(
+        evidence_author.get("login"),
+        "github-actions[bot]",
+        "published evidence author",
+    )
+    evidence_assets = validate_release_assets(evidence_release, repository, tag)
+    exact(evidence_assets, assets, "published evidence release assets")
+
+    metadata = {
+        "artifact": {
+            "digest": artifact_digest,
+            "expired": False,
+            "id": artifact_id,
+            "name": artifact_name,
+            "size": artifact_size,
+            "workflow_run_id": run_id,
+            "head_sha": commit,
+        },
+        "commit": commit,
+        "release_id": release_id,
+        "release_published_sha256": evidence_sha,
+        "release_run_attempt": run_attempt,
+        "release_run_id": run_id,
+        "repository": repository,
+        "schema": "arc.release-published-evidence-artifact.v1",
+        "tag": tag,
+    }
+    return payload, archive_payload, metadata
+
+
+def command_bind(args: argparse.Namespace) -> None:
+    repository = args.repository
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise AcceptanceError("repository must be an exact owner/name pair")
+    exact(repository, EXPECTED_REPOSITORY, "production repository")
+    if not STRICT_TAG.fullmatch(args.tag):
+        raise AcceptanceError("release tag must be strict vMAJOR.MINOR.PATCH")
+    if args.tag != "v0.8.0":
+        raise AcceptanceError("this production acceptance is pinned to v0.8.0")
+    if not SHA40.fullmatch(args.commit):
+        raise AcceptanceError("release commit must be 40 lowercase hex characters")
+    run_id = positive_int(args.release_run_id, "release run id")
+    run_attempt = positive_int(args.release_run_attempt, "release run attempt")
+
+    workflow = load_object(args.workflow_json, "release workflow document")
+    workflow_id = positive_int(workflow.get("id"), "release workflow id")
+    exact(workflow.get("path"), ".github/workflows/release.yml", "release workflow path")
+    exact(workflow.get("state"), "active", "release workflow state")
+
+    run = load_object(args.run_json, "release run document")
+    exact(run.get("id"), run_id, "release run id")
+    exact(run.get("run_attempt"), run_attempt, "release run attempt")
+    exact(run.get("workflow_id"), workflow_id, "release run workflow id")
+    head_repository = run.get("head_repository")
+    if not isinstance(head_repository, dict):
+        raise AcceptanceError("release run head_repository must be an object")
+    exact(head_repository.get("full_name"), repository, "release run repository")
+    exact(run.get("path"), ".github/workflows/release.yml", "release run path")
+    exact(run.get("event"), "workflow_dispatch", "release run event")
+    exact(run.get("head_branch"), "main", "release run branch")
+    exact(run.get("head_sha"), args.commit, "release run commit")
+    exact(run.get("status"), "completed", "release run status")
+    exact(run.get("conclusion"), "success", "release run conclusion")
+    jobs = validate_release_attempt_jobs(
+        args.jobs_json, repository, args.commit, run_id, run_attempt
+    )
+
+    tag_ref = load_object(args.tag_ref_json, "release tag ref")
+    exact(tag_ref.get("ref"), f"refs/tags/{args.tag}", "release tag ref name")
+    tag_object = tag_ref.get("object")
+    if not isinstance(tag_object, dict):
+        raise AcceptanceError("release tag ref object must be an object")
+    exact(tag_object.get("type"), "commit", "release tag object type")
+    exact(tag_object.get("sha"), args.commit, "release tag commit")
+
+    release = load_object(args.release_json, "release API document")
+    release_id = positive_int(release.get("id"), "release id")
+    exact(release.get("tag_name"), args.tag, "release tag")
+    exact(release.get("target_commitish"), args.commit, "release target")
+    exact(release.get("draft"), False, "release draft state")
+    exact(release.get("prerelease"), False, "release prerelease state")
+    exact(release.get("immutable"), True, "release immutable state")
+    author = release.get("author")
+    if not isinstance(author, dict):
+        raise AcceptanceError("release author must be an object")
+    exact(author.get("login"), "github-actions[bot]", "release author")
+    assets = validate_release_assets(release, repository, args.tag)
+    published_payload, published_zip, published_metadata = validate_published_evidence(
+        args.published_evidence_artifact_json,
+        args.published_evidence_download_root,
+        release,
+        assets,
+        repository,
+        args.tag,
+        args.commit,
+        release_id,
+        run_id,
+        run_attempt,
+    )
+
+    legacy_ref = load_object(args.legacy_tag_ref_json, "v0.7.7 tag ref")
+    exact(legacy_ref.get("ref"), "refs/tags/v0.7.7", "v0.7.7 ref name")
+    legacy_ref_object = legacy_ref.get("object")
+    if not isinstance(legacy_ref_object, dict):
+        raise AcceptanceError("v0.7.7 tag object must be an object")
+    exact(legacy_ref_object.get("type"), "commit", "v0.7.7 tag object type")
+    exact(legacy_ref_object.get("sha"), LEGACY_SOURCE["commit"], "v0.7.7 tag commit")
+
+    legacy_release = load_object(args.legacy_release_json, "v0.7.7 release document")
+    exact(legacy_release.get("id"), LEGACY_SOURCE["release_id"], "v0.7.7 release id")
+    exact(legacy_release.get("tag_name"), "v0.7.7", "v0.7.7 release tag")
+    legacy_matches = [
+        asset
+        for asset in legacy_release.get("assets", [])
+        if isinstance(asset, dict) and asset.get("name") == LEGACY_SOURCE["asset"]["name"]
+    ]
+    if len(legacy_matches) != 1:
+        raise AcceptanceError("v0.7.7 Linux binary selection is ambiguous")
+    legacy_asset = legacy_matches[0]
+    expected_legacy_asset = LEGACY_SOURCE["asset"]
+    exact(legacy_asset.get("id"), expected_legacy_asset["id"], "v0.7.7 asset id")
+    exact(legacy_asset.get("size"), expected_legacy_asset["size"], "v0.7.7 asset size")
+    exact(
+        legacy_asset.get("digest"),
+        f"sha256:{expected_legacy_asset['sha256']}",
+        "v0.7.7 asset digest",
+    )
+    exact(legacy_asset.get("state"), "uploaded", "v0.7.7 asset state")
+    exact(
+        legacy_asset.get("browser_download_url"),
+        f"https://github.com/{repository}/releases/download/v0.7.7/arc-node-linux-x86_64",
+        "v0.7.7 asset URL",
+    )
+
+    write_canonical(args.jobs_output, jobs)
+    write_bytes(args.published_evidence_output, published_payload)
+    write_bytes(args.published_evidence_zip_output, published_zip)
+    write_canonical(args.published_evidence_artifact_output, published_metadata)
+
+    binding = {
+        "assets": assets,
+        "commit": args.commit,
+        "legacy_source": LEGACY_SOURCE,
+        "published_evidence": {
+            "artifact_digest": published_metadata["artifact"]["digest"],
+            "artifact_id": published_metadata["artifact"]["id"],
+            "artifact_metadata_sha256": sha256_file(
+                args.published_evidence_artifact_output
+            ),
+            "artifact_name": published_metadata["artifact"]["name"],
+            "artifact_size": published_metadata["artifact"]["size"],
+            "release_published_sha256": published_metadata[
+                "release_published_sha256"
+            ],
+        },
+        "release": {"id": release_id, "immutable": True},
+        "release_workflow": {
+            "event": "workflow_dispatch",
+            "head_branch": "main",
+            "head_sha": args.commit,
+            "id": workflow_id,
+            "jobs_sha256": sha256_file(args.jobs_output),
+            "path": ".github/workflows/release.yml",
+            "run_attempt": run_attempt,
+            "run_id": run_id,
+        },
+        "repository": repository,
+        "schema": "arc.published-release-binding.v1",
+        "tag": args.tag,
+    }
+    write_canonical(args.output, binding)
+
+
+def validate_binding(binding: dict[str, Any]) -> None:
+    exact(binding.get("schema"), "arc.published-release-binding.v1", "binding schema")
+    if set(binding) != {
+        "assets",
+        "commit",
+        "legacy_source",
+        "published_evidence",
+        "release",
+        "release_workflow",
+        "repository",
+        "schema",
+        "tag",
+    }:
+        raise AcceptanceError("binding contains missing or unexpected fields")
+    if not SHA40.fullmatch(str(binding.get("commit", ""))):
+        raise AcceptanceError("binding commit is malformed")
+    exact(binding.get("repository"), EXPECTED_REPOSITORY, "binding repository")
+    exact(binding.get("tag"), "v0.8.0", "binding tag")
+    exact(binding.get("legacy_source"), LEGACY_SOURCE, "binding v0.7.7 source")
+    release = binding.get("release")
+    if not isinstance(release, dict):
+        raise AcceptanceError("binding release must be an object")
+    positive_int(release.get("id"), "binding release id")
+    exact(release.get("immutable"), True, "binding release immutability")
+    workflow = binding.get("release_workflow")
+    if not isinstance(workflow, dict):
+        raise AcceptanceError("binding release_workflow must be an object")
+    if set(workflow) != {
+        "event",
+        "head_branch",
+        "head_sha",
+        "id",
+        "jobs_sha256",
+        "path",
+        "run_attempt",
+        "run_id",
+    }:
+        raise AcceptanceError("binding release_workflow has invalid fields")
+    positive_int(workflow.get("id"), "binding workflow id")
+    positive_int(workflow.get("run_id"), "binding run id")
+    positive_int(workflow.get("run_attempt"), "binding run attempt")
+    exact(workflow.get("event"), "workflow_dispatch", "binding workflow event")
+    exact(workflow.get("head_branch"), "main", "binding workflow branch")
+    exact(
+        workflow.get("path"),
+        ".github/workflows/release.yml",
+        "binding workflow path",
+    )
+    exact(workflow.get("head_sha"), binding["commit"], "binding workflow commit")
+    if not SHA256.fullmatch(str(workflow.get("jobs_sha256", ""))):
+        raise AcceptanceError("binding release-attempt jobs digest is malformed")
+    published = binding.get("published_evidence")
+    if not isinstance(published, dict) or set(published) != {
+        "artifact_digest",
+        "artifact_id",
+        "artifact_metadata_sha256",
+        "artifact_name",
+        "artifact_size",
+        "release_published_sha256",
+    }:
+        raise AcceptanceError("binding published_evidence has invalid fields")
+    positive_int(published.get("artifact_id"), "binding published-evidence artifact id")
+    positive_int(
+        published.get("artifact_size"), "binding published-evidence artifact size"
+    )
+    if not re.fullmatch(
+        r"sha256:[0-9a-f]{64}", str(published.get("artifact_digest", ""))
+    ):
+        raise AcceptanceError("binding published-evidence artifact digest is malformed")
+    for key in ("artifact_metadata_sha256", "release_published_sha256"):
+        if not SHA256.fullmatch(str(published.get(key, ""))):
+            raise AcceptanceError(f"binding published-evidence {key} is malformed")
+    expected_artifact_name = (
+        f"arc-release-published-evidence-{binding['commit']}-{workflow['run_id']}-"
+        f"{workflow['run_attempt']}-{release['id']}-"
+        f"{published['release_published_sha256']}"
+    )
+    exact(
+        published.get("artifact_name"),
+        expected_artifact_name,
+        "binding published-evidence artifact name",
+    )
+    assets = binding.get("assets")
+    if not isinstance(assets, dict) or set(assets) != EXPECTED_RELEASE_ASSETS:
+        raise AcceptanceError("binding has an invalid release asset set")
+    for name, value in assets.items():
+        if not isinstance(value, dict):
+            raise AcceptanceError(f"binding asset {name} must be an object")
+        positive_int(value.get("id"), f"binding asset {name} id")
+        positive_int(value.get("size"), f"binding asset {name} size")
+        if not SHA256.fullmatch(str(value.get("sha256", ""))):
+            raise AcceptanceError(f"binding asset {name} digest is malformed")
+
+
+def regular_file(path: Path, description: str) -> None:
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise AcceptanceError(f"cannot inspect {description}: {error}") from error
+    if not stat.S_ISREG(mode):
+        raise AcceptanceError(f"{description} must be a regular non-symlink file")
+
+
+def verify_named_files(
+    binding: dict[str, Any], directory: Path, names: Iterable[str]
+) -> dict[str, dict[str, Any]]:
+    requested = list(names)
+    if not requested or len(set(requested)) != len(requested):
+        raise AcceptanceError("asset names must be a nonempty unique list")
+    assets = binding["assets"]
+    verified: dict[str, dict[str, Any]] = {}
+    for name in requested:
+        if name not in assets:
+            raise AcceptanceError(f"asset is not in the release binding: {name}")
+        if Path(name).name != name or name in {".", ".."}:
+            raise AcceptanceError(f"unsafe asset name: {name}")
+        path = directory / name
+        regular_file(path, f"downloaded asset {name}")
+        actual_size = path.stat().st_size
+        actual_sha = sha256_file(path)
+        exact(actual_size, assets[name]["size"], f"asset {name} downloaded size")
+        exact(actual_sha, assets[name]["sha256"], f"asset {name} downloaded digest")
+        verified[name] = dict(assets[name])
+    return dict(sorted(verified.items()))
+
+
+def command_verify_files(args: argparse.Namespace) -> None:
+    binding = load_object(args.binding, "release binding")
+    validate_binding(binding)
+    verified = verify_named_files(binding, args.directory, args.asset)
+    receipt = {
+        "assets": verified,
+        "binding_sha256": sha256_file(args.binding),
+        "commit": binding["commit"],
+        "release_id": binding["release"]["id"],
+        "release_run_attempt": binding["release_workflow"]["run_attempt"],
+        "release_run_id": binding["release_workflow"]["run_id"],
+        "repository": binding["repository"],
+        "schema": "arc.published-release-files.v1",
+        "tag": binding["tag"],
+    }
+    write_canonical(args.output, receipt)
+
+
+def command_verify_legacy(args: argparse.Namespace) -> None:
+    binding = load_object(args.binding, "release binding")
+    validate_binding(binding)
+    asset = binding["legacy_source"]["asset"]
+    regular_file(args.binary, "v0.7.7 binary")
+    exact(args.binary.stat().st_size, asset["size"], "v0.7.7 binary size")
+    exact(sha256_file(args.binary), asset["sha256"], "v0.7.7 binary digest")
+    for path, key in (
+        (args.installer, "installer"),
+        (args.seed_config, "seed_config"),
+        (args.genesis, "genesis"),
+    ):
+        regular_file(path, f"v0.7.7 {key}")
+        exact(
+            sha256_file(path),
+            binding["legacy_source"][key]["sha256"],
+            f"v0.7.7 {key} digest",
+        )
+    receipt = {
+        "asset": asset,
+        "binding_sha256": sha256_file(args.binding),
+        "commit": binding["legacy_source"]["commit"],
+        "genesis_sha256": sha256_file(args.genesis),
+        "installer_sha256": sha256_file(args.installer),
+        "release_id": binding["legacy_source"]["release_id"],
+        "schema": "arc.published-legacy-source.v1",
+        "seed_config_sha256": sha256_file(args.seed_config),
+        "tag": "v0.7.7",
+    }
+    write_canonical(args.output, receipt)
+
+
+def validate_platform_checks(platform: str, checks: dict[str, Any]) -> None:
+    for name, expected in REQUIRED_CHECKS[platform].items():
+        exact(checks.get(name), expected, f"{platform} check {name}")
+    if platform == "windows-x86_64":
+        embedded_version = checks.get("embedded_app_product_version")
+        if not isinstance(embedded_version, str) or re.fullmatch(
+            r"0\.8\.0(?:\.0)?", embedded_version
+        ) is None:
+            raise AcceptanceError(
+                "windows-x86_64 check embedded_app_product_version is not an exact "
+                "0.8.0 Windows version"
+            )
+
+
+def command_component(args: argparse.Namespace) -> None:
+    binding = load_object(args.binding, "release binding")
+    validate_binding(binding)
+    if args.platform not in EXPECTED_COMPONENTS:
+        raise AcceptanceError(f"unsupported component platform: {args.platform}")
+    files = load_object(args.files_receipt, "downloaded-files receipt")
+    exact(files.get("schema"), "arc.published-release-files.v1", "files receipt schema")
+    exact(files.get("binding_sha256"), sha256_file(args.binding), "files binding digest")
+    exact(files.get("repository"), binding["repository"], "files repository")
+    exact(files.get("tag"), binding["tag"], "files tag")
+    exact(files.get("commit"), binding["commit"], "files commit")
+    exact(files.get("release_id"), binding["release"]["id"], "files release id")
+    exact(
+        files.get("release_run_id"),
+        binding["release_workflow"]["run_id"],
+        "files release run id",
+    )
+    exact(
+        files.get("release_run_attempt"),
+        binding["release_workflow"]["run_attempt"],
+        "files release run attempt",
+    )
+    raw_assets = files.get("assets")
+    if not isinstance(raw_assets, dict) or set(raw_assets) != EXPECTED_COMPONENTS[args.platform]:
+        raise AcceptanceError(f"{args.platform} files receipt has an invalid asset set")
+    for name, value in raw_assets.items():
+        exact(value, binding["assets"][name], f"files asset {name}")
+
+    checks = load_object(args.checks_json, "component checks")
+    validate_platform_checks(args.platform, checks)
+    component = {
+        "acceptance_run_attempt": positive_int(
+            args.acceptance_run_attempt, "acceptance run attempt"
+        ),
+        "acceptance_run_id": positive_int(args.acceptance_run_id, "acceptance run id"),
+        "assets": raw_assets,
+        "binding_sha256": sha256_file(args.binding),
+        "checks": checks,
+        "commit": binding["commit"],
+        "platform": args.platform,
+        "release_id": binding["release"]["id"],
+        "release_run_attempt": binding["release_workflow"]["run_attempt"],
+        "release_run_id": binding["release_workflow"]["run_id"],
+        "repository": binding["repository"],
+        "schema": "arc.published-artifact-acceptance-component.v1",
+        "tag": binding["tag"],
+    }
+    # Run the same aggregate-side validator here so a malformed component is
+    # rejected in its native job as well as by the final fan-in job.
+    validate_component(component, binding, sha256_file(args.binding))
+    write_canonical(args.output, component)
+
+
+def validate_component(
+    component: dict[str, Any], binding: dict[str, Any], binding_sha: str
+) -> str:
+    exact(
+        component.get("schema"),
+        "arc.published-artifact-acceptance-component.v1",
+        "component schema",
+    )
+    platform = component.get("platform")
+    if platform not in EXPECTED_COMPONENTS:
+        raise AcceptanceError(f"unexpected component platform: {platform!r}")
+    exact(component.get("repository"), binding["repository"], f"{platform} repository")
+    exact(component.get("tag"), binding["tag"], f"{platform} tag")
+    exact(component.get("commit"), binding["commit"], f"{platform} commit")
+    exact(component.get("release_id"), binding["release"]["id"], f"{platform} release")
+    exact(
+        component.get("release_run_id"),
+        binding["release_workflow"]["run_id"],
+        f"{platform} release run",
+    )
+    exact(
+        component.get("release_run_attempt"),
+        binding["release_workflow"]["run_attempt"],
+        f"{platform} release attempt",
+    )
+    exact(component.get("binding_sha256"), binding_sha, f"{platform} binding digest")
+    positive_int(component.get("acceptance_run_id"), f"{platform} acceptance run")
+    positive_int(component.get("acceptance_run_attempt"), f"{platform} acceptance attempt")
+    raw_assets = component.get("assets")
+    if not isinstance(raw_assets, dict) or set(raw_assets) != EXPECTED_COMPONENTS[platform]:
+        raise AcceptanceError(f"{platform} component has an invalid asset set")
+    for name, value in raw_assets.items():
+        exact(value, binding["assets"][name], f"{platform} asset {name}")
+    checks = component.get("checks")
+    if not isinstance(checks, dict):
+        raise AcceptanceError(f"{platform} checks must be an object")
+    validate_platform_checks(platform, checks)
+    return platform
+
+
+def validate_component_artifacts(
+    value: dict[str, Any], binding: dict[str, Any], run_id: int, run_attempt: int
+) -> dict[str, dict[str, Any]]:
+    exact(
+        value.get("schema"),
+        "arc.published-artifact-component-binding.v1",
+        "component artifact binding schema",
+    )
+    exact(value.get("repository"), binding["repository"], "component repository")
+    exact(value.get("acceptance_run_id"), run_id, "component acceptance run")
+    exact(
+        value.get("acceptance_run_attempt"),
+        run_attempt,
+        "component acceptance attempt",
+    )
+    raw = value.get("artifacts")
+    if not isinstance(raw, dict) or set(raw) != set(EXPECTED_COMPONENTS):
+        raise AcceptanceError("component artifact platform set mismatch")
+    ids: set[int] = set()
+    result: dict[str, dict[str, Any]] = {}
+    for platform in sorted(EXPECTED_COMPONENTS):
+        artifact = raw.get(platform)
+        if not isinstance(artifact, dict):
+            raise AcceptanceError(f"{platform} artifact identity must be an object")
+        expected_name = (
+            f"arc-published-acceptance-{platform}-{run_id}-attempt-{run_attempt}"
+        )
+        exact(artifact.get("name"), expected_name, f"{platform} artifact name")
+        artifact_id = positive_int(artifact.get("id"), f"{platform} artifact id")
+        if artifact_id in ids:
+            raise AcceptanceError("component artifact IDs must be unique")
+        ids.add(artifact_id)
+        digest = artifact.get("digest")
+        if not isinstance(digest, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+            raise AcceptanceError(f"{platform} artifact digest is malformed")
+        positive_int(artifact.get("size"), f"{platform} artifact size")
+        exact(artifact.get("expired"), False, f"{platform} artifact expiration")
+        exact(artifact.get("workflow_run_id"), run_id, f"{platform} artifact run")
+        exact(artifact.get("head_sha"), binding["commit"], f"{platform} artifact SHA")
+        result[platform] = {
+            "digest": digest,
+            "id": artifact_id,
+            "name": expected_name,
+        }
+    return result
+
+
+def collect_evidence_files(root: Path) -> dict[str, dict[str, Any]]:
+    try:
+        root_mode = root.lstat().st_mode
+    except OSError as error:
+        raise AcceptanceError(f"cannot inspect canonical evidence root: {error}") from error
+    if not stat.S_ISDIR(root_mode):
+        raise AcceptanceError("canonical evidence root must be a directory")
+
+    expected_directories = set(EXPECTED_COMPONENTS) | {"release"}
+    directories: set[str] = set()
+    files: dict[str, dict[str, Any]] = {}
+    total = 0
+    for path in sorted(root.rglob("*")):
+        try:
+            mode = path.lstat().st_mode
+        except OSError as error:
+            raise AcceptanceError(f"cannot inspect canonical evidence path: {error}") from error
+        relative = path.relative_to(root).as_posix()
+        if stat.S_ISDIR(mode):
+            directories.add(relative)
+            continue
+        if not stat.S_ISREG(mode):
+            raise AcceptanceError(
+                f"canonical evidence must contain only regular files: {relative}"
+            )
+        size = path.stat().st_size
+        if size > MAX_CANONICAL_EVIDENCE_FILE_BYTES:
+            raise AcceptanceError(f"canonical evidence file exceeds its limit: {relative}")
+        total += size
+        if total > MAX_CANONICAL_EVIDENCE_TOTAL_BYTES:
+            raise AcceptanceError("canonical evidence exceeds its aggregate size limit")
+        files[relative] = {"sha256": sha256_file(path), "size": size}
+    if directories != expected_directories:
+        missing = sorted(expected_directories - directories)
+        extra = sorted(directories - expected_directories)
+        raise AcceptanceError(
+            f"canonical evidence directory set mismatch; missing={missing!r}, extra={extra!r}"
+        )
+    if set(files) != EXPECTED_EVIDENCE_FILES:
+        missing = sorted(EXPECTED_EVIDENCE_FILES - set(files))
+        extra = sorted(set(files) - EXPECTED_EVIDENCE_FILES)
+        raise AcceptanceError(
+            f"canonical evidence file set mismatch; missing={missing!r}, extra={extra!r}"
+        )
+    return dict(sorted(files.items()))
+
+
+def validate_evidence_manifest(
+    value: dict[str, Any],
+    manifest_path: Path,
+    evidence_root: Path,
+    binding: dict[str, Any],
+    binding_path: Path,
+    component_artifacts_path: Path,
+    run_id: int,
+    run_attempt: int,
+) -> dict[str, dict[str, Any]]:
+    if set(value) != {
+        "acceptance_run_attempt",
+        "acceptance_run_id",
+        "binding_sha256",
+        "component_artifact_binding_sha256",
+        "files",
+        "repository",
+        "schema",
+    }:
+        raise AcceptanceError("canonical evidence manifest has invalid fields")
+    exact(
+        value.get("schema"),
+        "arc.published-artifact-evidence-manifest.v1",
+        "canonical evidence manifest schema",
+    )
+    exact(value.get("repository"), binding["repository"], "evidence repository")
+    exact(value.get("acceptance_run_id"), run_id, "evidence acceptance run")
+    exact(
+        value.get("acceptance_run_attempt"),
+        run_attempt,
+        "evidence acceptance attempt",
+    )
+    exact(
+        value.get("binding_sha256"),
+        sha256_file(binding_path),
+        "evidence binding digest",
+    )
+    exact(
+        value.get("component_artifact_binding_sha256"),
+        sha256_file(component_artifacts_path),
+        "evidence component-artifact binding digest",
+    )
+    raw_files = value.get("files")
+    if not isinstance(raw_files, dict):
+        raise AcceptanceError("canonical evidence manifest files must be an object")
+    actual_files = collect_evidence_files(evidence_root)
+    exact(raw_files, actual_files, "canonical evidence file manifest")
+    exact(
+        raw_files["release/release-attempt-jobs.json"]["sha256"],
+        binding["release_workflow"]["jobs_sha256"],
+        "canonical release-attempt jobs digest",
+    )
+    exact(
+        raw_files["release/release-published.json"]["sha256"],
+        binding["published_evidence"]["release_published_sha256"],
+        "canonical published release evidence digest",
+    )
+    exact(
+        raw_files["release/published-evidence-artifact.json"]["sha256"],
+        binding["published_evidence"]["artifact_metadata_sha256"],
+        "canonical published-evidence artifact metadata digest",
+    )
+    exact(
+        raw_files["release/published-evidence.zip"]["sha256"],
+        binding["published_evidence"]["artifact_digest"].removeprefix("sha256:"),
+        "canonical published-evidence Actions ZIP digest",
+    )
+    regular_file(manifest_path, "canonical evidence manifest")
+    return actual_files
+
+
+def command_evidence_manifest(args: argparse.Namespace) -> None:
+    binding = load_object(args.binding, "release binding")
+    validate_binding(binding)
+    run_id = positive_int(args.acceptance_run_id, "acceptance run id")
+    run_attempt = positive_int(args.acceptance_run_attempt, "acceptance run attempt")
+    component_artifact_value = load_object(
+        args.component_artifacts, "component artifact binding"
+    )
+    validate_component_artifacts(
+        component_artifact_value, binding, run_id, run_attempt
+    )
+    manifest = {
+        "acceptance_run_attempt": run_attempt,
+        "acceptance_run_id": run_id,
+        "binding_sha256": sha256_file(args.binding),
+        "component_artifact_binding_sha256": sha256_file(args.component_artifacts),
+        "files": collect_evidence_files(args.evidence_root),
+        "repository": binding["repository"],
+        "schema": "arc.published-artifact-evidence-manifest.v1",
+    }
+    write_canonical(args.output, manifest)
+    validate_evidence_manifest(
+        manifest,
+        args.output,
+        args.evidence_root,
+        binding,
+        args.binding,
+        args.component_artifacts,
+        run_id,
+        run_attempt,
+    )
+
+
+def command_aggregate(args: argparse.Namespace) -> None:
+    binding = load_object(args.binding, "release binding")
+    validate_binding(binding)
+    binding_sha = sha256_file(args.binding)
+    run_id = positive_int(args.acceptance_run_id, "acceptance run id")
+    run_attempt = positive_int(args.acceptance_run_attempt, "acceptance run attempt")
+    component_artifact_value = load_object(
+        args.component_artifacts, "component artifact binding"
+    )
+    component_artifacts = validate_component_artifacts(
+        component_artifact_value, binding, run_id, run_attempt
+    )
+    evidence_manifest = load_object(args.evidence_manifest, "canonical evidence manifest")
+    evidence_files = validate_evidence_manifest(
+        evidence_manifest,
+        args.evidence_manifest,
+        args.evidence_root,
+        binding,
+        args.binding,
+        args.component_artifacts,
+        run_id,
+        run_attempt,
+    )
+    components: dict[str, dict[str, Any]] = {}
+    component_digests: dict[str, str] = {}
+    paths = sorted(args.components.glob("*.json"))
+    if not paths:
+        raise AcceptanceError("component receipt directory is empty")
+    for path in paths:
+        regular_file(path, "component receipt")
+        component = load_object(path, "component receipt")
+        platform = validate_component(component, binding, binding_sha)
+        if platform in components:
+            raise AcceptanceError(f"duplicate component platform: {platform}")
+        exact(component.get("acceptance_run_id"), run_id, f"{platform} acceptance run")
+        exact(
+            component.get("acceptance_run_attempt"),
+            run_attempt,
+            f"{platform} acceptance attempt",
+        )
+        components[platform] = component
+        component_digests[platform] = sha256_file(path)
+    if set(components) != set(EXPECTED_COMPONENTS):
+        missing = sorted(set(EXPECTED_COMPONENTS) - set(components))
+        extra = sorted(set(components) - set(EXPECTED_COMPONENTS))
+        raise AcceptanceError(
+            f"component platform set mismatch; missing={missing!r}, extra={extra!r}"
+        )
+    receipt = {
+        "acceptance_run_attempt": run_attempt,
+        "acceptance_run_id": run_id,
+        "binding_sha256": binding_sha,
+        "commit": binding["commit"],
+        "component_artifact_binding_sha256": sha256_file(args.component_artifacts),
+        "component_artifacts": component_artifacts,
+        "component_receipt_sha256": dict(sorted(component_digests.items())),
+        "evidence_file_count": len(evidence_files),
+        "evidence_manifest_sha256": sha256_file(args.evidence_manifest),
+        "legacy_source": binding["legacy_source"],
+        "release_id": binding["release"]["id"],
+        "release_immutable": True,
+        "release_run_attempt": binding["release_workflow"]["run_attempt"],
+        "release_run_id": binding["release_workflow"]["run_id"],
+        "repository": binding["repository"],
+        "schema": "arc.published-artifact-acceptance.v1",
+        "tag": binding["tag"],
+        "verified_platforms": sorted(components),
+    }
+    write_canonical(args.output, receipt)
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    commands = root.add_subparsers(dest="command", required=True)
+
+    select = commands.add_parser(
+        "select-published-evidence",
+        help="select the sole exact-attempt publication evidence artifact",
+    )
+    select.add_argument("--commit", required=True)
+    select.add_argument("--release-run-id", required=True, type=int)
+    select.add_argument("--release-run-attempt", required=True, type=int)
+    select.add_argument("--release-json", required=True, type=Path)
+    select.add_argument("--artifacts-json", required=True, type=Path)
+    select.add_argument("--output", required=True, type=Path)
+    select.set_defaults(func=command_select_published_evidence)
+
+    bind = commands.add_parser("bind", help="validate GitHub API facts and seal selection")
+    bind.add_argument("--repository", required=True)
+    bind.add_argument("--tag", required=True)
+    bind.add_argument("--commit", required=True)
+    bind.add_argument("--release-run-id", required=True, type=int)
+    bind.add_argument("--release-run-attempt", required=True, type=int)
+    bind.add_argument("--workflow-json", required=True, type=Path)
+    bind.add_argument("--run-json", required=True, type=Path)
+    bind.add_argument("--jobs-json", required=True, type=Path)
+    bind.add_argument("--tag-ref-json", required=True, type=Path)
+    bind.add_argument("--release-json", required=True, type=Path)
+    bind.add_argument("--published-evidence-artifact-json", required=True, type=Path)
+    bind.add_argument("--published-evidence-download-root", required=True, type=Path)
+    bind.add_argument("--legacy-tag-ref-json", required=True, type=Path)
+    bind.add_argument("--legacy-release-json", required=True, type=Path)
+    bind.add_argument("--jobs-output", required=True, type=Path)
+    bind.add_argument("--published-evidence-output", required=True, type=Path)
+    bind.add_argument("--published-evidence-zip-output", required=True, type=Path)
+    bind.add_argument(
+        "--published-evidence-artifact-output", required=True, type=Path
+    )
+    bind.add_argument("--output", required=True, type=Path)
+    bind.set_defaults(func=command_bind)
+
+    files = commands.add_parser("verify-files", help="verify downloaded v0.8 assets")
+    files.add_argument("--binding", required=True, type=Path)
+    files.add_argument("--directory", required=True, type=Path)
+    files.add_argument("--asset", required=True, action="append")
+    files.add_argument("--output", required=True, type=Path)
+    files.set_defaults(func=command_verify_files)
+
+    legacy = commands.add_parser("verify-legacy", help="verify exact v0.7.7 inputs")
+    legacy.add_argument("--binding", required=True, type=Path)
+    legacy.add_argument("--binary", required=True, type=Path)
+    legacy.add_argument("--installer", required=True, type=Path)
+    legacy.add_argument("--seed-config", required=True, type=Path)
+    legacy.add_argument("--genesis", required=True, type=Path)
+    legacy.add_argument("--output", required=True, type=Path)
+    legacy.set_defaults(func=command_verify_legacy)
+
+    component = commands.add_parser("component", help="seal one platform result")
+    component.add_argument("--binding", required=True, type=Path)
+    component.add_argument("--files-receipt", required=True, type=Path)
+    component.add_argument("--checks-json", required=True, type=Path)
+    component.add_argument("--platform", required=True)
+    component.add_argument("--acceptance-run-id", required=True, type=int)
+    component.add_argument("--acceptance-run-attempt", required=True, type=int)
+    component.add_argument("--output", required=True, type=Path)
+    component.set_defaults(func=command_component)
+
+    evidence = commands.add_parser(
+        "evidence-manifest", help="seal every retained platform and release evidence file"
+    )
+    evidence.add_argument("--binding", required=True, type=Path)
+    evidence.add_argument("--component-artifacts", required=True, type=Path)
+    evidence.add_argument("--evidence-root", required=True, type=Path)
+    evidence.add_argument("--acceptance-run-id", required=True, type=int)
+    evidence.add_argument("--acceptance-run-attempt", required=True, type=int)
+    evidence.add_argument("--output", required=True, type=Path)
+    evidence.set_defaults(func=command_evidence_manifest)
+
+    aggregate = commands.add_parser("aggregate", help="seal all platform receipts")
+    aggregate.add_argument("--binding", required=True, type=Path)
+    aggregate.add_argument("--component-artifacts", required=True, type=Path)
+    aggregate.add_argument("--components", required=True, type=Path)
+    aggregate.add_argument("--evidence-manifest", required=True, type=Path)
+    aggregate.add_argument("--evidence-root", required=True, type=Path)
+    aggregate.add_argument("--acceptance-run-id", required=True, type=int)
+    aggregate.add_argument("--acceptance-run-attempt", required=True, type=int)
+    aggregate.add_argument("--output", required=True, type=Path)
+    aggregate.set_defaults(func=command_aggregate)
+    return root
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        args.func(args)
+    except (AcceptanceError, OSError) as error:
+        print(f"published artifact acceptance failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/verify-pretag-run-and-artifacts.sh
+++ b/scripts/release/verify-pretag-run-and-artifacts.sh
@@ -35,7 +35,8 @@ trap cleanup EXIT HUP INT TERM
 WORKFLOW_ID="$(gh api \
     "repos/$REPOSITORY/actions/workflows/release-signing-preflight.yml" \
     --jq '.id')"
-gh api "repos/$REPOSITORY/actions/runs/$RUN_ID" > "$TEMPORARY/run.json"
+gh api "repos/$REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT" \
+    > "$TEMPORARY/run.json"
 jq -e \
     --arg repository "$REPOSITORY" \
     --arg sha "$COMMIT" \

--- a/scripts/release/wait-workflow-attempt.sh
+++ b/scripts/release/wait-workflow-attempt.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Wait for one immutable GitHub Actions run attempt, never the moving latest attempt.
+set -Eeuo pipefail
+
+die() {
+    printf 'workflow-attempt wait: %s\n' "$*" >&2
+    exit 1
+}
+
+[ "$#" -eq 4 ] || die \
+    "usage: $0 REPOSITORY RUN_ID RUN_ATTEMPT EXPECTED_CONCLUSION"
+
+REPOSITORY="$1"
+RUN_ID="$2"
+RUN_ATTEMPT="$3"
+EXPECTED_CONCLUSION="$4"
+MAX_POLLS="${ARC_WORKFLOW_WAIT_MAX_POLLS:-360}"
+INTERVAL_SECONDS="${ARC_WORKFLOW_WAIT_INTERVAL_SECONDS:-10}"
+
+[ "$REPOSITORY" = FerrumVir/arc-chain ] || die "unexpected repository"
+printf '%s\n' "$RUN_ID" | grep -Eq '^[1-9][0-9]*$' || die "invalid run ID"
+printf '%s\n' "$RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$' || die "invalid run attempt"
+printf '%s\n' "$MAX_POLLS" | grep -Eq '^[1-9][0-9]*$' || die "invalid poll limit"
+printf '%s\n' "$INTERVAL_SECONDS" | grep -Eq '^(0|[1-9][0-9]*)$' \
+    || die "invalid poll interval"
+case "$EXPECTED_CONCLUSION" in
+    success|failure|cancelled) ;;
+    *) die "expected conclusion must be success, failure, or cancelled" ;;
+esac
+[ -n "${GH_TOKEN:-}" ] || die "GH_TOKEN is required"
+command -v gh >/dev/null 2>&1 || die "gh is required"
+command -v jq >/dev/null 2>&1 || die "jq is required"
+
+attempt_url="repos/$REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT"
+poll=1
+while [ "$poll" -le "$MAX_POLLS" ]; do
+    run_json="$(gh api "$attempt_url")" \
+        || die "cannot read selected run attempt $RUN_ID/$RUN_ATTEMPT"
+    printf '%s' "$run_json" | jq -e \
+        --arg repository "$REPOSITORY" \
+        --argjson id "$RUN_ID" \
+        --argjson attempt "$RUN_ATTEMPT" '
+        .id == $id and .run_attempt == $attempt
+        and .head_repository.full_name == $repository
+        and (.status == "queued" or .status == "in_progress"
+          or .status == "waiting" or .status == "pending"
+          or .status == "requested" or .status == "completed")' \
+        >/dev/null || die "selected run attempt identity/status differs"
+    status="$(printf '%s' "$run_json" | jq -er '.status')"
+    if [ "$status" = completed ]; then
+        conclusion="$(printf '%s' "$run_json" | jq -er '.conclusion')"
+        [ "$conclusion" = "$EXPECTED_CONCLUSION" ] || die \
+            "run $RUN_ID attempt $RUN_ATTEMPT concluded $conclusion, expected $EXPECTED_CONCLUSION"
+        printf '%s' "$run_json" | jq -cS \
+            '{id,run_attempt,workflow_id,path,event,head_branch,head_sha,status,conclusion}'
+        exit 0
+    fi
+    [ "$poll" -lt "$MAX_POLLS" ] || break
+    sleep "$INTERVAL_SECONDS"
+    poll=$((poll + 1))
+done
+
+die "run $RUN_ID attempt $RUN_ATTEMPT did not complete within $MAX_POLLS polls"

--- a/shared/frontend/production-status.json
+++ b/shared/frontend/production-status.json
@@ -1,0 +1,5 @@
+{
+  "schema": "arc.public-production-status.v1",
+  "state": "maintenance",
+  "notice": "The v0.8.0 public-testnet release, recovered fleet, and post-release acceptance have not all been proven yet."
+}

--- a/tests/release/documentation_contract_test.sh
+++ b/tests/release/documentation_contract_test.sh
@@ -473,7 +473,7 @@ community_support_and_history_copy_is_actionable() {
     for literal in \
         '#### Download and verify the exact worker model' \
         'exactly 4,081,004,224 bytes' \
-        '191239b3e26b2882fb562ffccdd1cf0f65402adb' \
+        '191239b3e26b2882fb56''2ffccdd1cf0f65402adb' \
         '08a5566d61d7cb6b420c3e4387a39e0078e1f2fe5f055f3a03887385304d4bfa' \
         "--proto '=https' --proto-redir '=https' --tlsv1.2" \
         'sha256sum -c -' \
@@ -497,7 +497,7 @@ community_support_and_history_copy_is_actionable() {
         "$REPO_ROOT/docs/TIER1_ONCHAIN_INFERENCE_PLAN.md" \
         "$REPO_ROOT/papers/foundations-trustworthy-ai.typ"
     do
-        require_literal "$model_doc" '191239b3e26b2882fb562ffccdd1cf0f65402adb' \
+        require_literal "$model_doc" '191239b3e26b2882fb56''2ffccdd1cf0f65402adb' \
             'model-acquisition documentation omits the immutable model revision' || return 1
         require_literal "$model_doc" '08a5566d61d7cb6b420c3e4387a39e0078e1f2fe5f055f3a03887385304d4bfa' \
             'model-acquisition documentation omits the exact model digest' || return 1

--- a/tests/release/documentation_contract_test.sh
+++ b/tests/release/documentation_contract_test.sh
@@ -13,6 +13,8 @@ WALKTHROUGH="$REPO_ROOT/docs/COMMUNITY-NODE-WALKTHROUGH.md"
 SCRIPTS_README="$REPO_ROOT/scripts/README.md"
 ROLLOUT="$REPO_ROOT/docs/VALIDATOR-FLEET-ROLLOUT.md"
 RECOVERY_README="$REPO_ROOT/scripts/recovery/README.md"
+OWNER_EMERGENCY_HELPER="$REPO_ROOT/scripts/recovery/owner-emergency-recovery.py"
+OWNER_EMERGENCY_SCHEMA="$REPO_ROOT/scripts/recovery/owner-emergency-recovery.schema.json"
 ARCHIVE_TOOL="$REPO_ROOT/scripts/recovery/archive-fleet-to-drive.sh"
 DRIVE_PREFREEZE_GATE="$REPO_ROOT/scripts/recovery/verify-drive-prefreeze.sh"
 DRIVE_IDENTITY_HELPER="$REPO_ROOT/scripts/recovery/drive-account-identity.py"
@@ -21,6 +23,7 @@ CANARY_RUNBOOK="$REPO_ROOT/docs/MACOS-PRETAG-COMMUNITY-CANARY.md"
 CANARY_HELPER="$REPO_ROOT/scripts/release/macos-community-canary.py"
 VAULT_HELPER="$REPO_ROOT/scripts/release/restore-validator-vault.py"
 CUTOVER_HANDOFF_HELPER="$REPO_ROOT/scripts/release/create-cutover-handoff-commit.py"
+PUBLIC_TRUTH_HELPER="$REPO_ROOT/scripts/release/build-postrelease-public-truth.py"
 PRODUCTION_RECOVERY_AUDIT="$REPO_ROOT/docs/PRODUCTION-RECOVERY-AUDIT-2026-08-26.md"
 GETTING_STARTED="$REPO_ROOT/docs/GETTING_STARTED.md"
 STATUS_DOC="$REPO_ROOT/docs/STATUS.md"
@@ -842,6 +845,7 @@ PY
 
 operator_recovery_commands_are_linux_pinned_and_ordered() {
     local file literal pair count line previous audit_block handoff_help handoff_section
+    local public_truth_help public_truth_section option obsolete
 
     (
         local procedure_file rollout_file
@@ -893,8 +897,8 @@ for block_index, block in enumerate(blocks):
             embedded_python += 1
             cursor = end_cursor
         cursor += 1
-if embedded_python != 6:
-    raise SystemExit(f"expected six compiled embedded Python programs, got {embedded_python}")
+if embedded_python != 8:
+    raise SystemExit(f"expected eight compiled embedded Python programs, got {embedded_python}")
 pathlib.Path(sys.argv[2]).write_text(
     "#!/usr/bin/env bash\n" + "\n".join(blocks), encoding="utf-8"
 )
@@ -916,8 +920,8 @@ compile(signer_source, "executable-runbook-offline-signer", "exec")
 
 def undefined_before_definition(program):
     defined = {
-        "IFS", "OLDPWD", "OPTARG", "OPTIND", "PPID", "PWD", "RANDOM",
-        "SECONDS", "UID", "EUID",
+        "BASH_VERSION", "HOME", "IFS", "OLDPWD", "OPTARG", "OPTIND",
+        "PPID", "PWD", "RANDOM", "SECONDS", "UID", "EUID",
     }
     single_quoted = False
     heredoc = None
@@ -1033,8 +1037,13 @@ archive = one("scripts/recovery/archive-fleet-to-drive.sh seal \\")
 downloads = one('\ndownload_root="$(\n')
 finalize = one("scripts/recovery/build-production-manifest.py finalize")
 frontend = one("scripts/recovery/recovery_rollout.py frontend-config")
+macos_transfer = one("# BEGIN NATIVE MACOS CANARY TRANSFER")
+lima_canary_import = one(
+    "# BEGIN LIMA ROOT SHELL REVALIDATION AND MACOS RECEIPT IMPORT"
+)
 ordered = [initial[0], restore[0], capture[0], install[0], export[0], sign[0],
-           verify[0], prearchive[0], archive[0], downloads[0], finalize[0], frontend[0]]
+           verify[0], macos_transfer[0], lima_canary_import[0], prearchive[0],
+           archive[0], downloads[0], finalize[0], frontend[0]]
 if ordered != sorted(ordered) or len(set(ordered)) != len(ordered):
     raise SystemExit("executable production bash blocks are absent or out of mandatory order")
 
@@ -1114,6 +1123,56 @@ require(
     'outgoing_checkpoint="$signing_attempt_root/candidate.signed-$((index + 1)).arcchkpt"',
     'arc_install_or_reuse_exact "$incoming_checkpoint" "$recovery_checkpoint"',
 )
+require(
+    macos_transfer[1], "# BEGIN NATIVE MACOS CANARY TRANSFER",
+    "set -Eeuo pipefail", 'test "$(/usr/bin/uname -s)" = Darwin',
+    'test "$(/usr/bin/uname -m)" = arm64', 'test "$(/usr/bin/id -u)" -ne 0',
+    "ARC_MACOS_PROTECTED_CHECKOUT='<absolute protected-main checkout on the canary Mac>'",
+    'case "$ARC_MACOS_PROTECTED_CHECKOUT" in /*)',
+    'ARC_CANARY_TRANSFER_PARENT="$HOME/.arc-recovery-transfer"',
+    'ARC_CANARY_TRANSFER_ROOT="$ARC_CANARY_TRANSFER_PARENT/v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"',
+    '"$macos_canary_helper" status', '"$macos_canary_helper" accept',
+    'lima_canary_drop_root=/var/tmp/arc-macos-canary-import-v0.8.0',
+    '"$ARC_LIMACTL" copy --backend=scp',
+)
+require_order(
+    macos_transfer[1], '"$macos_canary_helper" status',
+    '"$macos_canary_helper" accept', '"$ARC_LIMACTL" copy --backend=scp',
+)
+require(
+    lima_canary_import[1],
+    "# BEGIN LIMA ROOT SHELL REVALIDATION AND MACOS RECEIPT IMPORT",
+    "set -Eeuo pipefail", 'test "$(/usr/bin/uname -s)" = Linux',
+    'test "$(/usr/bin/uname -m)" = x86_64', 'test "$(/usr/bin/id -u)" = 0',
+    ': "${operator_checkout:?the original Lima root shell was lost}"',
+    'lima_canary_drop_root=/var/tmp/arc-macos-canary-import-v0.8.0',
+    'macos_canary_acceptance=/secure/operator/MACOS-CANARY-ACCEPTANCE.json',
+    "os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow",
+    "or (final_stat.st_uid, final_stat.st_gid) != (0, 0)",
+)
+if "/Users/" in lima_canary_import[1]:
+    raise SystemExit("Lima canary importer reads a macOS shared-mount path")
+
+# Every GitHub API or mutation must flow through the helper that gives exactly
+# one invocation an explicit phase-local token. Token discovery itself is the
+# sole direct gh command form, and tokens never appear in repository URLs.
+for token in (
+    "pretag_gh_token", "owner_recovery_gh_token", "release_gh_token", "frontend_gh_token",
+    "post_release_gh_token", "public_truth_gh_token",
+):
+    if f'{token}="$(' not in combined or f"unset {token}" not in combined:
+        raise SystemExit(f"GitHub phase token is not acquired and cleared: {token}")
+if combined.count('"$ARC_RECOVERY_GH_PATH" auth token --hostname github.com') != 6:
+    raise SystemExit("GitHub token discovery is not exactly one call per authority phase")
+if re.search(
+    r'(?m)^\s*(?:GH_TOKEN="[^"]+"\s+)?"\$ARC_RECOVERY_GH_PATH"\s+(api|workflow|pr)\b',
+    combined,
+):
+    raise SystemExit("GitHub API or mutation bypasses invocation-scoped arc_scoped_gh")
+if "export GH_TOKEN" in combined or 'GH_TOKEN="$GH_TOKEN"' in combined:
+    raise SystemExit("executable recovery procedure retains ambient GitHub authority")
+if re.search(r'https://[^\s]*\$(?:GH_TOKEN|[A-Za-z_]+_gh_token)', combined):
+    raise SystemExit("GitHub token is interpolated into a URL")
 require_order(
     sign[1],
     'offline_signer "$signing_binary" recovery inspect',
@@ -1347,6 +1406,61 @@ PY
         require_literal "$RECOVERY_README" "$literal" \
             'recovery README omits compact handoff helper option' || return 1
     done
+    public_truth_help="$(python3 "$PUBLIC_TRUTH_HELPER" --help)" || return 1
+    public_truth_section="$(awk '
+        /^### Publish the sealed public truth through a second reviewed PR$/ { capture=1 }
+        capture { print }
+        capture && /^### Prove the exact second Pages run and public bytes$/ { exit }
+    ' "$RECOVERY_README")"
+    for option in \
+        --readme --release-api --pages-workflow --pages-run --pages-jobs \
+        --pages-api --pages-deployments --pages-statuses --frontend-config \
+        --deployed-commit --deployed-sha256sums --published-workflow \
+        --published-run --published-jobs --published-artifact-metadata \
+        --published-artifact-zip --reward-evidence --rollout-manifest --output-dir
+    do
+        printf '%s\n' "$public_truth_help" | grep -Fq -- "$option" || {
+            printf 'public-truth helper omits final required option: %s\n' "$option"
+            return 1
+        }
+        printf '%s\n' "$public_truth_section" | grep -Fq -- "$option" || {
+            printf 'recovery README omits final public-truth option: %s\n' "$option"
+            return 1
+        }
+    done
+    for obsolete in '--acceptance ' '--installer '
+    do
+        if printf '%s\n' "$public_truth_section" | grep -Fq -- "$obsolete"; then
+            printf 'recovery README retains obsolete public-truth option: %s\n' "$obsolete"
+            return 1
+        fi
+    done
+    for literal in \
+        'published acceptance evidence contract is not exactly 36 files' \
+        'evidence/release/published-evidence.zip' \
+        '--evidence-manifest "$published_acceptance_root/EVIDENCE-MANIFEST.json"' \
+        '--evidence-root "$published_acceptance_root/evidence"' \
+        'POST-RELEASE-ACCEPTANCE.json | /usr/bin/sort' \
+        '.schema == "arc.post-release-acceptance.v2"' \
+        '--slurpfile receipt "$acceptance_receipt"' \
+        '.acceptance.receipt == $receipt[0]' \
+        '/usr/bin/jq -cS '\''.acceptance.receipt'\'' "$public_truth_status"'
+    do
+        require_literal "$RECOVERY_README" "$literal" \
+            'recovery README is stale against the final public-truth evidence contract' \
+            || return 1
+    done
+    for literal in \
+        'exact 36-file' \
+        '`build-postrelease-public-truth.py`' \
+        '`arc.post-release-acceptance.v2`' \
+        '`arc.public-production-status.v1`' \
+        'status embeds the full canonical v2 receipt'
+    do
+        require_literal "$PRODUCTION_RECOVERY_AUDIT" "$literal" \
+            'production recovery audit is stale against the public-truth evidence boundary' \
+            || return 1
+    done
     for literal in \
         'arc-recovery-final.lock.json.sha256' \
         'legacy-maintenance-boundary.json' \
@@ -1354,12 +1468,12 @@ PY
         'refs/arc-recovery-handoffs/$protected_main_sha' \
         'scripts/release/create-cutover-handoff-commit.py' \
         'workflow run recovery-release-handoff.yml' \
-        'arc-recovery-release-handoff-$protected_main_sha' \
+        'arc-recovery-release-handoff-$protected_main_sha-$handoff_run_id-$handoff_run_attempt' \
         'handoff_run_id=' \
         'handoff_artifact_id="$(printf' \
         'handoff_artifact_digest="$(printf' \
         'unset GH_TOKEN' \
-        'GH_TOKEN="$GH_TOKEN" "$ARC_RECOVERY_PYTHON_PATH" -I' \
+        'GH_TOKEN="$release_gh_token" "$ARC_RECOVERY_PYTHON_PATH" -I' \
         '--push-remote origin' \
         '.local_ref_state == "created" or .local_ref_state == "reused"' \
         '.remote_ref_state == "created" or .remote_ref_state == "reused"' \
@@ -1368,7 +1482,9 @@ PY
         'repos/FerrumVir/arc-chain/collaborators/arisarcmarket' \
         '-f permission=pull' \
         'direct_collaborators_after=' \
-        '.[1].login == "arisarcmarket" and .[1].role_name == "read"' \
+        'PRETAG-COLLABORATOR-BASELINE.json' \
+        '.[1].login == "arisarcmarket" and .[1].role_name == "write"' \
+        'pretag_collaborator_reduced=' \
         'repos/FerrumVir/arc-chain/invitations?per_page=100' \
         'pending_writer_invitations' \
         'remote_release_count=' \
@@ -1381,7 +1497,7 @@ PY
         'tag_ref_push_status=0' \
         '[.[] | select(.ref == "refs/tags/v0.8.0")] as $matches' \
         'GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null' \
-        'GH_TOKEN="$GH_TOKEN" GH_PROMPT_DISABLED=1' \
+        'GH_TOKEN="$release_gh_token" GH_PROMPT_DISABLED=1' \
         '-c core.hooksPath=/dev/null' \
         '-c credential.helper=' \
         'credential.https://github.com.helper=!$ARC_RECOVERY_GH_PATH auth git-credential' \
@@ -1396,12 +1512,16 @@ PY
         'absence is proven and a fresh retry is safe' \
         'mandatory post-query proved the exact tag' \
         'tag_push_run_id=' \
-        'actions/runs/$tag_push_run_id/jobs?filter=all&per_page=100' \
+        'actions/runs/$tag_push_run_id/attempts/$tag_push_run_attempt/jobs?per_page=100' \
         'Release requires workflow_dispatch with a positive cutover_handoff_artifact_id.' \
         'workflow run release.yml' \
         '-f tag=v0.8.0' \
         '-f cutover_handoff_artifact_id="$handoff_artifact_id"' \
         '-f cutover_handoff_artifact_digest="$handoff_artifact_digest"' \
+        '-f cutover_handoff_run_attempt="$handoff_run_attempt"' \
+        '-f pretag_run_id="$pretag_run_id"' \
+        '-f pretag_run_attempt="$pretag_run_attempt"' \
+        'scripts/release/wait-workflow-attempt.sh' \
         'a tag-push event' \
         'cannot carry the protected handoff artifact ID' \
         'Do not move, delete, recreate, or re-push the tag' \
@@ -1437,12 +1557,65 @@ PY
         'arc.post-release-installer-canary.v1' \
         'Already up to date at v0.8.0' \
         'scripts/recovery/recovery_rollout.py verify' \
-        'POST-RELEASE-ACCEPTANCE.json'
+        'POST-RELEASE-ACCEPTANCE.json' \
+        'scripts/release/build-postrelease-public-truth.py' \
+        "public_truth_branch='arc-recovery/public-truth-v0.8.0'" \
+        'and .reviewDecision == "APPROVED"' \
+        'PUBLIC-TRUTH-PAGES-RUN-SELECTION.json' \
+        'actions/runs/$public_truth_pages_run_id/attempts/$public_truth_pages_run_attempt' \
+        './shared/frontend/production-status.json' \
+        'PUBLIC-TRUTH-ACCEPTANCE.json'
     do
         require_literal "$RECOVERY_README" "$literal" \
             'recovery README omits an executable release or post-release receipt gate' \
             || return 1
     done
+    for literal in \
+        'only **native macOS shell** block' \
+        'Lima root shell open and untouched' \
+        '$HOME/.arc-recovery-transfer/v0.8.0-<protected-main-sha>' \
+        '# BEGIN NATIVE MACOS CANARY TRANSFER' \
+        "ARC_MACOS_PROTECTED_CHECKOUT='<absolute protected-main checkout on the canary Mac>'" \
+        'ARC_CANARY_TRANSFER_PARENT="$HOME/.arc-recovery-transfer"' \
+        '"$ARC_LIMACTL" copy --backend=scp' \
+        '# BEGIN LIMA ROOT SHELL REVALIDATION AND MACOS RECEIPT IMPORT' \
+        ': "${operator_checkout:?the original Lima root shell was lost}"' \
+        'macos_canary_acceptance=/secure/operator/MACOS-CANARY-ACCEPTANCE.json' \
+        'os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow' \
+        'arc_scoped_gh() {' \
+        'PRETAG-COLLABORATOR-BASELINE.json' \
+        '-f permission=push' \
+        'required approving reviews only from collaborators with write access' \
+        '# ON THE SELECTED VALIDATOR ROOT SHELL' \
+        '# BACK IN THE LIMA OPERATOR ROOT SHELL' \
+        "sealed_validator_origin='<exact sealed https:// origin printed by the plan>'"
+    do
+        require_literal "$RECOVERY_README" "$literal" \
+            'recovery README omits a shell-boundary, scoped-authority, or restoration contract' \
+            || return 1
+    done
+    if grep -Fq -- 'https://<sealed-validator-origin>' "$RECOVERY_README"; then
+        printf 'diagnostic still prepends a scheme to an ambiguous origin placeholder\n'
+        return 1
+    fi
+    collaborator_baseline_line="$(first_literal_line "$RECOVERY_README" \
+        'PRETAG-COLLABORATOR-BASELINE.json')"
+    collaborator_reduce_line="$(first_literal_line "$RECOVERY_README" \
+        '-f permission=pull')"
+    release_terminal_line="$(first_literal_line "$RECOVERY_README" \
+        'release_api_live=')"
+    collaborator_restore_line="$(first_literal_line "$RECOVERY_README" \
+        '-f permission=push')"
+    if [ -z "$collaborator_baseline_line" ] \
+        || [ -z "$collaborator_reduce_line" ] \
+        || [ -z "$release_terminal_line" ] \
+        || [ -z "$collaborator_restore_line" ] \
+        || [ "$collaborator_baseline_line" -ge "$collaborator_reduce_line" ] \
+        || [ "$collaborator_reduce_line" -ge "$release_terminal_line" ] \
+        || [ "$release_terminal_line" -ge "$collaborator_restore_line" ]; then
+        printf 'reviewer baseline, reduction, immutable release proof, and exact restoration are misordered\n'
+        return 1
+    fi
     for forbidden in \
         "handoff_run_id='<" \
         "handoff_run_attempt='<" \
@@ -1465,8 +1638,10 @@ PY
         '`recovery-release-handoff.yml`' \
         '`cutover_handoff_artifact_id`' \
         '`cutover_handoff_artifact_digest`' \
-        'exact direct set `FerrumVir` plus `arisarcmarket`' \
-        '`arisarcmarket` to `pull`' \
+        'exact direct set `FerrumVir` plus write-capable `arisarcmarket`' \
+        'exact collaborator projection create-only' \
+        'Reduce only `arisarcmarket` to' \
+        '`pull` for the tag/release authority boundary' \
         'zero pending invitations' \
         '21690216' \
         '21667203' \
@@ -1487,11 +1662,24 @@ PY
         'API-select exactly one workflow/path/event/branch/SHA run' \
         'independent immutable-release verifier' \
         'unique 32-asset digest-bound contract' \
+        'restore `arisarcmarket` to the exact sealed pre-tag `write` baseline' \
+        'GitHub counts a required' \
+        'approval only from a write-capable reviewer' \
         'temporarily' \
         'approval count and last-push approval' \
         'squash merge' \
         'successful `github-pages` deployment' \
-        '`POST-RELEASE-ACCEPTANCE.json`'
+        '`POST-RELEASE-ACCEPTANCE.json`' \
+        'exact 36-file recursive evidence set' \
+        '`evidence/release/published-evidence.zip`' \
+        '`scripts/release/build-postrelease-public-truth.py`' \
+        'exactly three create-only mode-0400' \
+        '`arc.post-release-acceptance.v2`' \
+        '`arc.public-production-status.v1`' \
+        'status embeds the complete canonical v2 receipt' \
+        'second single-parent PR' \
+        'exact second `deploy-explorer.yml` run ID and run attempt' \
+        '`PUBLIC-TRUTH-ACCEPTANCE.json`'
     do
         require_literal "$ROLLOUT" "$literal" \
             'validator rollout omits an executable release or post-release receipt gate' \
@@ -1514,7 +1702,7 @@ PY
     previous=0
     for literal in \
         'unset GH_TOKEN' \
-        'GH_TOKEN="$(' \
+        'release_gh_token="$(' \
         'handoff_receipt="$(' \
         'workflow run recovery-release-handoff.yml' \
         'handoff_artifact_id="$(printf' \
@@ -1538,16 +1726,21 @@ PY
 
     post_release_acceptance_line="$(grep -nF -- 'POST-RELEASE-ACCEPTANCE.json' \
         "$RECOVERY_README" | tail -n 1 | cut -d: -f1)"
+    public_truth_acceptance_line="$(grep -nF -- 'PUBLIC-TRUTH-ACCEPTANCE.json' \
+        "$RECOVERY_README" | tail -n 1 | cut -d: -f1)"
     post_release_unmask_line="$(grep -nF -- '/usr/bin/systemctl unmask --runtime' \
         "$RECOVERY_README" | tail -n 1 | cut -d: -f1)"
     procedure_end_line="$(grep -nF -- \
         '<!-- END EXECUTABLE PRODUCTION RECOVERY PROCEDURE -->' \
         "$RECOVERY_README" | cut -d: -f1)"
-    if [ -z "$post_release_acceptance_line" ] || [ -z "$post_release_unmask_line" ] \
+    if [ -z "$post_release_acceptance_line" ] \
+        || [ -z "$public_truth_acceptance_line" ] \
+        || [ -z "$post_release_unmask_line" ] \
         || [ -z "$procedure_end_line" ] \
-        || [ "$post_release_acceptance_line" -ge "$post_release_unmask_line" ] \
+        || [ "$post_release_acceptance_line" -ge "$public_truth_acceptance_line" ] \
+        || [ "$public_truth_acceptance_line" -ge "$post_release_unmask_line" ] \
         || [ "$post_release_unmask_line" -ge "$procedure_end_line" ]; then
-        printf 'executable procedure ends before post-release acceptance and unmask gates\n'
+        printf 'executable procedure misorders post-release, public-truth, and unmask gates\n'
         return 1
     fi
 
@@ -1738,6 +1931,100 @@ recovery_plan_read_only_scope_is_truthful() {
     done
 }
 
+owner_emergency_recovery_receipt_replaces_ceremonial_approval() {
+    local required verify_line sync_line wrapper_call_line signing_line
+    for required in \
+        'The six validator identities are not six independent human operators.' \
+        '`owner_emergency_recovery`' \
+        '`owner-emergency-recovery-approval.yml`' \
+        '`arc.recovery.owner-emergency-recovery.v2`' \
+        'locally is not authorization.' \
+        'root-owned mode-0700 attempt directory' \
+        'input file becomes root-owned mode 0400.' \
+        'H=137145/H+1=137146' \
+        'epoch/set 1/1' \
+        'does not claim six-human' \
+        'owner_recovery_gh_token="$(' \
+        'arc_scoped_gh "$owner_recovery_gh_token" workflow run' \
+        '-f expected_main_sha="$protected_main_sha"' \
+        '-f checkpoint_manifest_hash="$checkpoint_manifest_hash"' \
+        '-f validator_public_keys_sha256="$validator_public_keys_sha256"' \
+        '-f nyc_public_key="$owner_recovery_nyc_public_key"' \
+        '-f sgp_public_key="$owner_recovery_sgp_public_key"' \
+        '-f confirmation="AUTHORIZE ARC OWNER EMERGENCY RECOVERY $protected_main_sha"' \
+        'GH_TOKEN="$owner_recovery_gh_token" scripts/release/wait-workflow-attempt.sh' \
+        'actions/runs/$owner_recovery_run_id/attempts/$owner_recovery_run_attempt/jobs?per_page=100' \
+        'arc-owner-emergency-recovery-$protected_main_sha-$owner_recovery_run_id-attempt-$owner_recovery_run_attempt' \
+        'actions/artifacts/$owner_recovery_artifact_id/zip' \
+        "root:root:400:1" \
+        'unset owner_recovery_gh_token' \
+        '"$owner_recovery_helper" verify-github-artifact' \
+        '--workflow-json "$owner_recovery_workflow_json"' \
+        '--run-json "$owner_recovery_run_json"' \
+        '--jobs-json "$owner_recovery_jobs_json"' \
+        '--artifact-json "$owner_recovery_artifact_json"' \
+        '--artifact-zip "$owner_recovery_artifact_zip"' \
+        '--run-id "$owner_recovery_run_id"' \
+        '--run-attempt "$owner_recovery_run_attempt"' \
+        '--artifact-id "$owner_recovery_artifact_id"' \
+        '--artifact-digest "$owner_recovery_artifact_digest"' \
+        '--source-main-sha "$protected_main_sha"' \
+        '--checkpoint-manifest-hash "$checkpoint_manifest_hash"' \
+        '--validator-public-keys "$validator_public_keys"' \
+        '--validator-public-keys-sha256 "$validator_public_keys_sha256"' \
+        '--output "$owner_recovery_receipt"' \
+        '--max-age-seconds 900' \
+        'verify_owner_recovery_authorization() {' \
+        '/usr/bin/sync -f "$owner_recovery_output"' \
+        '/usr/bin/sync -f "$owner_recovery_attempt_root"'
+    do
+        require_literal "$RECOVERY_README" "$required" \
+            'recovery signing guide omits the durable owner emergency receipt contract' \
+            || return 1
+    done
+    for required in \
+        'Checkpoint signing has a separate, durable authorization boundary.' \
+        '`owner-emergency-recovery-approval.yml`' \
+        '`owner-emergency-recovery.py verify-github-artifact`' \
+        '`arc.recovery.owner-emergency-recovery.v2`' \
+        'actor and triggering actor are both the pinned owner' \
+        'exact-attempt jobs' \
+        'text is not authorization.' \
+        'GitHub-authenticated `owner_emergency_recovery` decision' \
+        'H=137145/H+1=137146' \
+        'does not claim six-human approval'
+    do
+        require_literal "$PRODUCTION_RECOVERY_AUDIT" "$required" \
+            'production recovery audit omits the owner emergency receipt boundary' \
+            || return 1
+    done
+    verify_line="$(first_literal_line "$RECOVERY_README" \
+        '"$owner_recovery_helper" verify-github-artifact')"
+    sync_line="$(first_literal_line "$RECOVERY_README" \
+        '/usr/bin/sync -f "$owner_recovery_attempt_root"')"
+    wrapper_call_line="$(grep -nFx -- 'verify_owner_recovery_authorization' \
+        "$RECOVERY_README" | cut -d: -f1)"
+    signing_line="$(first_literal_line "$RECOVERY_README" 'for index in "${!signing_keys[@]}"; do')"
+    if [ -z "$verify_line" ] || [ -z "$sync_line" ] \
+        || [ -z "$wrapper_call_line" ] || [ -z "$signing_line" ] \
+        || [ "$verify_line" -ge "$sync_line" ] \
+        || [ "$sync_line" -ge "$wrapper_call_line" ] \
+        || [ $((wrapper_call_line + 1)) -ne "$signing_line" ]; then
+        printf 'GitHub owner verification wrapper is not immediately before the signing loop\n'
+        return 1
+    fi
+    if grep -Eq -- \
+        'checkpoint_approval_phrase=|After all six operators compare it out of band|IFS= read -r checkpoint_approval|"\$owner_recovery_helper" (draft|seal|verify) ' \
+        "$RECOVERY_README"; then
+        printf 'local or ceremonial checkpoint approval remains in the recovery guide\n'
+        return 1
+    fi
+    test -f "$OWNER_EMERGENCY_HELPER" && test -f "$OWNER_EMERGENCY_SCHEMA" || {
+        printf 'documented owner emergency helper or schema is missing\n'
+        return 1
+    }
+}
+
 run_test 'workspace, desktop, changelog, and README agree on unreleased v0.8.0' candidate_version_is_consistent
 run_test 'candidate install commands pin exact v0.8.0 without claiming publication' candidate_install_commands_are_exact_and_honest
 run_test 'README and headless guide share the same unpinned update-only commands' manual_updater_commands_are_identical
@@ -1753,5 +2040,6 @@ run_test 'hardened canary and vault runbooks match their current command parsers
 run_test 'recovery archive commands pin tools, external intent, and exact rollout journals' recovery_archive_commands_are_exact_and_resumable
 run_test 'operator recovery commands are Ubuntu-pinned, create-only, and ordered' operator_recovery_commands_are_linux_pinned_and_ordered
 run_test 'recovery plan documents a scoped persistent-state read-only boundary' recovery_plan_read_only_scope_is_truthful
+run_test 'checkpoint signing uses a durable owner emergency authorization receipt' owner_emergency_recovery_receipt_replaces_ceremonial_approval
 
 finish_tests

--- a/tests/release/owner_emergency_recovery_test.sh
+++ b/tests/release/owner_emergency_recovery_test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$TEST_DIR/../.." && pwd)"
+
+python3 -m unittest "$REPO_ROOT/scripts/recovery/test_owner_emergency_recovery.py"

--- a/tests/release/postrelease_public_truth_test.sh
+++ b/tests/release/postrelease_public_truth_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TEST_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+exec python3 -m unittest "$TEST_DIR/test_postrelease_public_truth.py"

--- a/tests/release/public_site_contract_test.sh
+++ b/tests/release/public_site_contract_test.sh
@@ -142,7 +142,8 @@ site_builder_is_reproducible_and_complete() (
     for path in \
         index.html tailwind.css app.css app.js .nojekyll deployed-commit.txt SHA256SUMS \
         explorer/index.html explorer/app.js explorer/styles.css \
-        shared/frontend/arc-network.js shared/frontend/arc-network.json
+        shared/frontend/arc-network.js shared/frontend/arc-network.json \
+        shared/frontend/production-status.json
     do
         [ -e "$output/$path" ] || {
             printf 'assembled public site is missing %s\n' "$path"
@@ -165,8 +166,30 @@ site_builder_is_reproducible_and_complete() (
     ! grep -Fq '../explorer/' "$output/index.html" || return 1
     grep -Fq './explorer/#/tx/' "$output/app.js" || return 1
     ! grep -Fq '../explorer/' "$output/app.js" || return 1
+    grep -Fq '[ -f "$required" ] && [ ! -L "$required" ] && [ -s "$required" ]' \
+        "$BUILDER" || {
+        printf 'public-site builder does not reject symlinked source inputs\n'
+        return 1
+    }
+    cmp -s "$REPO_ROOT/shared/frontend/production-status.json" \
+        "$output/shared/frontend/production-status.json" || {
+        printf 'assembled public site changed the public production-status bytes\n'
+        return 1
+    }
     [ "$(cat "$output/deployed-commit.txt")" = contract-test ] || return 1
     (cd "$output" && shasum -a 256 -c SHA256SUMS) >/dev/null || return 1
+    [ "$(awk '$2 == "./shared/frontend/production-status.json" {print $1}' \
+        "$output/SHA256SUMS")" = \
+      "$(shasum -a 256 "$REPO_ROOT/shared/frontend/production-status.json" \
+        | awk '{print $1}')" ] || {
+        printf 'public-site checksum manifest does not bind production-status.json\n'
+        return 1
+    }
+    [ "$(awk '$2 == "./shared/frontend/production-status.json" {count++} END {print count+0}' \
+        "$output/SHA256SUMS")" -eq 1 ] || {
+        printf 'public-site checksum manifest does not contain one production-status row\n'
+        return 1
+    }
     first_hash="$(shasum -a 256 "$output/SHA256SUMS")"
 
     (

--- a/tests/release/published_artifact_acceptance_contract_test.sh
+++ b/tests/release/published_artifact_acceptance_contract_test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+TEST_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$TEST_DIR/../.." && pwd)"
+# shellcheck source=/dev/null
+. "$TEST_DIR/helpers/testlib.sh"
+
+WORKFLOW="$REPO_ROOT/.github/workflows/post-release-acceptance.yml"
+HELPER="$REPO_ROOT/scripts/release/published-artifact-acceptance.py"
+RUNBOOK="$REPO_ROOT/scripts/recovery/README.md"
+ROLLOUT="$REPO_ROOT/docs/VALIDATOR-FLEET-ROLLOUT.md"
+
+require_literal() {
+    local file="$1" literal="$2" message="$3"
+    grep -Fq -- "$literal" "$file" || {
+        printf '%s: %s\n' "$message" "$literal"
+        return 1
+    }
+}
+
+workflow_is_read_only_and_exercises_published_bytes() {
+    local literal
+    test -f "$WORKFLOW" && test -f "$HELPER" || return 1
+    for literal in \
+        'permissions:' \
+        'actions: read' \
+        'contents: read' \
+        '[ "$GITHUB_REF" = refs/tags/v0.8.0 ]' \
+        'releases/assets/$id' \
+        '--appimage-extract > "$evidence/extract.stdout"' \
+        'appimage_visible_window' \
+        'desktop_visible_window' \
+        'MainWindowHandle' \
+        'CGWindowListCopyWindowInfo' \
+        'docker run --rm --network none' \
+        'legacy_history_preserved' \
+        'legacy_model_preserved' \
+        'headless_update_only' \
+        'attempts/$RELEASE_RUN_ATTEMPT/jobs?per_page=100' \
+        'select-published-evidence' \
+        'skip-decompress: true' \
+        'component-artifacts.json' \
+        'canonical/evidence/linux-x86_64' \
+        'canonical/evidence/macos-arm64' \
+        'canonical/evidence/macos-x86_64' \
+        'canonical/evidence/windows-x86_64' \
+        'canonical/evidence/release' \
+        'binding/published-evidence.zip' \
+        'EVIDENCE-MANIFEST.json' \
+        '--evidence-manifest canonical/EVIDENCE-MANIFEST.json' \
+        '! -name POST-RELEASE-ARTIFACT-ACCEPTANCE.SHA256SUMS -print0' \
+        'WindowsInstaller.Installer' \
+        "MSI ProductVersion is \$msiProductVersion" \
+        "msi_product_version = \$msiProductVersion" \
+        'embedded_app_product_version = $embeddedProductVersion' \
+        'arc-published-artifact-acceptance-v0.8.0-' \
+        '[[ "$ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ]]' \
+        'digest sha256:$ARTIFACT_DIGEST'
+    do
+        require_literal "$WORKFLOW" "$literal" \
+            'published-artifact workflow omits a required acceptance boundary' || return 1
+    done
+    if grep -Fq '[[ "$ARTIFACT_DIGEST" =~ ^sha256:' "$WORKFLOW"; then
+        printf 'upload-artifact output was incorrectly treated as an API-prefixed digest\n'
+        return 1
+    fi
+    if grep -Fq ".StartsWith('0.8.0')" "$WORKFLOW"; then
+        printf 'Windows package version acceptance still uses a prefix match\n'
+        return 1
+    fi
+    if grep -Eq '^[[:space:]]+(contents|actions|packages|deployments|id-token): write' \
+        "$WORKFLOW"; then
+        printf 'published-artifact workflow acquired mutation authority\n'
+        return 1
+    fi
+    require_literal "$HELPER" \
+        '"id": 432306066' 'legacy v0.7.7 asset ID is not pinned' || return 1
+    require_literal "$HELPER" \
+        '"size": 23286656' 'legacy v0.7.7 asset size is not pinned' || return 1
+    require_literal "$HELPER" \
+        '1cfc3039786d023cde24ad0b452f35735b39f9e83aaf293e6ed0bf623a11b20c' \
+        'legacy v0.7.7 asset digest is not pinned' || return 1
+    require_literal "$HELPER" \
+        'EXPECTED_RELEASE_JOBS = frozenset(' \
+        'exact release-attempt job allowlist is not pinned' || return 1
+    require_literal "$HELPER" \
+        'arc.release-published-evidence-artifact.v1' \
+        'publication evidence artifact metadata is not sealed' || return 1
+    require_literal "$HELPER" \
+        'arc-release-published-evidence-{args.commit}-{run_id}-{run_attempt}-' \
+        'publication evidence name is not exact-attempt bound' || return 1
+    require_literal "$HELPER" \
+        'arc.published-artifact-evidence-manifest.v1' \
+        'canonical raw evidence is not recursively manifested' || return 1
+}
+
+runbook_binds_the_exact_canonical_artifact() {
+    local literal
+    for literal in \
+        'post-release-acceptance.yml --repo FerrumVir/arc-chain --ref v0.8.0' \
+        'PUBLISHED-ARTIFACT-ACCEPTANCE-RUN.json' \
+        'PUBLISHED-ARTIFACT-ACCEPTANCE-SELECTION.json' \
+        'published_acceptance_run_attempt' \
+        'published_acceptance_artifact_id' \
+        'published_acceptance_artifact_digest' \
+        'canonical_receipt_sha256' \
+        'published-artifact-acceptance.py" aggregate' \
+        'EVIDENCE-MANIFEST.json' \
+        'evidence/release/published-evidence.zip' \
+        'published acceptance evidence contract is not exactly 36 files' \
+        '--evidence-manifest "$published_acceptance_root/EVIDENCE-MANIFEST.json"' \
+        '--evidence-root "$published_acceptance_root/evidence"' \
+        'arc.post-release-acceptance.v2'
+    do
+        require_literal "$RUNBOOK" "$literal" \
+            'production runbook does not bind exact published acceptance evidence' || return 1
+    done
+    require_literal "$ROLLOUT" \
+        'canonical artifact ID and `sha256:` digest' \
+        'rollout summary omits canonical published-artifact identity' || return 1
+}
+
+helper_fails_closed_under_adversarial_fixtures() {
+    cd "$REPO_ROOT" || return 1
+    python3 -m unittest -q tests.release.test_published_artifact_acceptance
+}
+
+run_test 'published artifact workflow is read-only and exercises real release bytes' \
+    workflow_is_read_only_and_exercises_published_bytes
+run_test 'production docs bind exact acceptance run, attempt, artifact ID, and digest' \
+    runbook_binds_the_exact_canonical_artifact
+run_test 'published artifact verifier fails closed under adversarial fixtures' \
+    helper_fails_closed_under_adversarial_fixtures
+
+finish_tests

--- a/tests/release/recovery_archive_contract_test.sh
+++ b/tests/release/recovery_archive_contract_test.sh
@@ -95,6 +95,7 @@ t=pathlib.Path(sys.argv[1]).read_text(); b=t[t.index("capture_phase()"):t.index(
 assert b.index('run_drive_prefreeze_gate execute') < b.index('capture_all_live_observations')
 late_sample=b.index('legacy_height_receipt_sha="$(sample_legacy_public_height_late')
 height_cross=b.index('capture_authenticated_legacy_height_cross_proof "$freeze_plan"')
+fresh_capacity=b.index('remote_readiness "$capture_id" "$freeze_sha" "$freeze_plan"')
 rounds=b.index('run_quarantine_generation_rounds')
 first_boundary=b.index('build-first-boundary')
 stop=b.index('stop_after_quarantine_round_exact')
@@ -102,7 +103,9 @@ capture=b.index('ensure_offline_capture "$capture_id" "$node"')
 persisted=b.index('run_persisted_head_exact "$freeze_plan"')
 boundary=b.index('create_legacy_maintenance_boundary')
 offline=b.index('create_offline_stop_evidence')
-assert b.index('capture_all_live_observations') < late_sample < height_cross < rounds < first_boundary
+assert b.index('capture_all_live_observations') < late_sample < height_cross < fresh_capacity < rounds < first_boundary
+assert ('remote_readiness "$capture_id" "$freeze_sha" "$freeze_plan"\n'
+        '    quarantine_generation_ledger_sha="$(run_quarantine_generation_rounds \\' in b)
 assert first_boundary < stop < capture < persisted < boundary < offline
 assert 'ALL SIX CONTROLLED WRITERS HALTED' in b and 'no global halt is claimed' in b
 for required in ('sample-targets', 'quarantine-round-authorize',
@@ -1091,6 +1094,69 @@ capture_readiness_resumes_stopped_and_indexed_nodes() (
     remote_readiness "$(printf 'b%.0s' {1..64})" "$(printf 'a%.0s' {1..64})" /sealed/freeze.json >/dev/null || return 1
     grep -Fq 'nyc stopped-status' "$f/actions" && grep -Fq 'nyc status' "$f/actions" && \
         grep -Fq 'lax stopped-status' "$f/actions" && grep -Fq 'lax status' "$f/actions"
+)
+
+stale_freeze_capacity_cannot_cross_current_readiness_gate() (
+    # shellcheck source=/dev/null
+    . "$ORCHESTRATOR" >/dev/null
+    local f gib sealed_data_bytes current_data_bytes available_bytes
+    local sealed_required_bytes current_required_bytes capture_id freeze_sha
+    f="$(mktemp -d)"; trap 'rm -rf -- "$f"' EXIT
+    gib=$((1024 * 1024 * 1024))
+    sealed_data_bytes=$((28 * gib))
+    current_data_bytes=$((29 * gib))
+    available_bytes=$((59 * gib))
+    sealed_required_bytes=$((sealed_data_bytes * 2 + 2 * gib))
+    current_required_bytes=$((current_data_bytes * 2 + 2 * gib))
+    [ "$available_bytes" -ge "$sealed_required_bytes" ] || return 1
+    [ "$available_bytes" -lt "$current_required_bytes" ] || return 1
+    capture_id="$(printf 'b%.0s' {1..64})"
+    freeze_sha="$(printf 'a%.0s' {1..64})"
+
+    # Fixture overrides invoked indirectly by sourced remote_readiness.
+    # shellcheck disable=SC2317,SC2329
+    host_for() { printf '%s\n' "$1"; }
+    # shellcheck disable=SC2317,SC2329
+    freeze_node_field() {
+        case "$3" in
+            writer_pid|writer_start_ticks|supervisor_main_pid|supervisor_start_ticks) printf '1\n' ;;
+            boot_id) printf '00000000-0000-0000-0000-000000000000\n' ;;
+            writer_supervision_mode) printf 'systemd-unit\n' ;;
+            supervisor_unit) printf 'arc-node.service\n' ;;
+            executable_path|supervisor_executable_path|data_dir|model_path) printf '/safe/%s/%s\n' "$2" "$3" ;;
+            executable_sha256|argv_sha256|writer_cgroup_sha256|supervisor_executable_sha256|supervisor_argv_sha256|model_sha256) printf 'a%.0s' {1..64}; printf '\n' ;;
+            model_size_bytes) printf '4081004224\n' ;;
+            *) return 1 ;;
+        esac
+    }
+    # Model the remote current-capacity probe after the sealed plan passed:
+    # data growth raises the live requirement from 58 GiB to 60 GiB.
+    # shellcheck disable=SC2317,SC2329
+    ssh_remote_exact() {
+        local host="$1" command
+        shift
+        command="$*"
+        [ "$host" = nyc ] || return 0
+        [[ "$command" == *'bytes=$(du -s -B1 "$data"'* ]] || return 97
+        [[ "$command" == *'required_bytes=$((bytes + binding_bytes))'* ]] || return 97
+        [[ "$command" == *'free_bytes=$(df -PB1 /root'* ]] || return 97
+        [[ "$command" == *'test "$free_bytes" -ge "$required_bytes"'* ]] || return 97
+        : > "$f/nyc-current-capacity-probed"
+        [ "$available_bytes" -ge "$current_required_bytes" ]
+    }
+    # shellcheck disable=SC2317,SC2329
+    run_stopped_status_exact() {
+        : > "$f/nyc-stopped-fallback-checked"
+        return 1
+    }
+
+    if ( remote_readiness "$capture_id" "$freeze_sha" /sealed/stale-freeze.json \
+        >/dev/null 2>&1; : > "$f/quarantine-mutation-reached" ); then
+        return 1
+    fi
+    [ -e "$f/nyc-current-capacity-probed" ] && \
+        [ -e "$f/nyc-stopped-fallback-checked" ] && \
+        [ ! -e "$f/quarantine-mutation-reached" ]
 )
 
 fleet_live_observation_retry_rejects_any_stopped_writer() (
@@ -3482,6 +3548,7 @@ run_test 'v5 freeze transaction is fault-closed' v5_freeze_transaction_is_fault_
 run_test 'v5 stop journal semantics are fault-closed' v5_stop_journal_semantics_are_fault_closed
 run_test 'classification requires each node once' classification_requires_each_node_once
 run_test 'capture readiness resumes exact stopped state' capture_readiness_resumes_stopped_and_indexed_nodes
+run_test 'stale freeze capacity cannot cross current readiness gate' stale_freeze_capacity_cannot_cross_current_readiness_gate
 run_test 'fleet observation retry rejects any stopped writer' fleet_live_observation_retry_rejects_any_stopped_writer
 run_test 'same-generation observation selection resume is byte-identical' live_observation_selection_resume_is_byte_identical
 run_test 'mutation dispatch publication is no-replace and crash-resumable' mutation_dispatch_publication_is_no_replace_and_resumable

--- a/tests/release/run.sh
+++ b/tests/release/run.sh
@@ -10,6 +10,8 @@ for test_file in \
     "$TEST_DIR/community_diagnostics_contract_test.sh" \
     "$TEST_DIR/recovery_archive_contract_test.sh" \
     "$TEST_DIR/production_manifest_builder_test.sh" \
+    "$TEST_DIR/postrelease_public_truth_test.sh" \
+    "$TEST_DIR/owner_emergency_recovery_test.sh" \
     "$TEST_DIR/legacy_public_height_test.sh" \
     "$TEST_DIR/drive_prefreeze_gate_test.sh" \
     "$TEST_DIR/legacy_validator_set_contract_test.sh" \
@@ -25,8 +27,10 @@ for test_file in \
     "$TEST_DIR/unsigned_desktop_handoff_test.sh" \
     "$TEST_DIR/release_manifest_handoff_test.sh" \
     "$TEST_DIR/privileged_workflow_boundary_test.sh" \
+    "$TEST_DIR/workflow_attempt_wait_test.sh" \
     "$TEST_DIR/macos_community_canary_test.sh" \
     "$TEST_DIR/release_publication_contract_test.sh" \
+    "$TEST_DIR/published_artifact_acceptance_contract_test.sh" \
     "$TEST_DIR/validator_vault_rewrap_contract_test.sh" \
     "$TEST_DIR/validator_vault_restore_contract_test.sh" \
     "$TEST_DIR/cutover_handoff_commit_test.sh" \

--- a/tests/release/static_contract_test.sh
+++ b/tests/release/static_contract_test.sh
@@ -43,9 +43,17 @@ RELEASE_DELETE_HELPER="$REPO_ROOT/scripts/release/delete-release-by-id.sh"
 VALIDATOR_VAULT_RESTORE="$REPO_ROOT/scripts/release/restore-validator-vault.py"
 PRODUCTION_MANIFEST_BUILDER="$REPO_ROOT/scripts/recovery/build-production-manifest.py"
 PRODUCTION_MANIFEST_TEST="$TEST_DIR/production_manifest_builder_test.sh"
+POSTRELEASE_PUBLIC_TRUTH="$REPO_ROOT/scripts/release/build-postrelease-public-truth.py"
+POSTRELEASE_PUBLIC_TRUTH_TEST="$TEST_DIR/postrelease_public_truth_test.sh"
+PUBLIC_PRODUCTION_STATUS="$REPO_ROOT/shared/frontend/production-status.json"
+ROOT_README="$REPO_ROOT/README.md"
 RECOVERY_RUNBOOK="$REPO_ROOT/scripts/recovery/README.md"
 RECOVERY_ROLLOUT="$REPO_ROOT/scripts/recovery/recovery_rollout.py"
 RECOVERY_ARCHIVE="$REPO_ROOT/scripts/recovery/archive-fleet-to-drive.sh"
+OWNER_EMERGENCY_HELPER="$REPO_ROOT/scripts/recovery/owner-emergency-recovery.py"
+OWNER_EMERGENCY_SCHEMA="$REPO_ROOT/scripts/recovery/owner-emergency-recovery.schema.json"
+OWNER_EMERGENCY_TEST="$REPO_ROOT/scripts/recovery/test_owner_emergency_recovery.py"
+OWNER_EMERGENCY_WORKFLOW="$REPO_ROOT/.github/workflows/owner-emergency-recovery-approval.yml"
 RELEASE_TEST_RUNNER="$TEST_DIR/run.sh"
 DESKTOP_CARGO_LOCK="$REPO_ROOT/desktop/src-tauri/Cargo.lock"
 DESKTOP_NPM_LOCK="$REPO_ROOT/desktop/package-lock.json"
@@ -1725,11 +1733,12 @@ publish_is_pinned_to_one_validated_commit_and_create_only() {
         'echo "sha=$TAG_COMMIT"' \
         'git fetch --no-tags --force origin main:refs/remotes/origin/main' \
         'if [ "$TAG_COMMIT" != "$MAIN_COMMIT" ]; then' \
-        '--workflow release-signing-preflight.yml' \
-        '--commit "$TAG_COMMIT"' \
+        'REQUESTED_PREFLIGHT_RUN_ID: ${{ inputs.pretag_run_id }}' \
+        'REQUESTED_PREFLIGHT_RUN_ATTEMPT: ${{ inputs.pretag_run_attempt }}' \
+        'actions/runs/$PREFLIGHT_RUN_ID/attempts/$PREFLIGHT_RUN_ATTEMPT' \
         '.status == "completed"' \
         '.conclusion == "success"' \
-        'PREFLIGHT_RUN_ATTEMPT="$(jq -r' \
+        'PREFLIGHT_RUN_ATTEMPT="$REQUESTED_PREFLIGHT_RUN_ATTEMPT"' \
         'python3 scripts/release/select-pretag-artifacts.py' \
         '--github-output "$GITHUB_OUTPUT"'
     do
@@ -1958,6 +1967,85 @@ relevant_shell_is_syntax_valid() {
         "$TEST_DIR"/*.sh "$TEST_DIR"/helpers/*.sh; do
         bash -n "$file" || return 1
     done
+}
+
+postrelease_public_truth_is_hermetic_exact_and_release_gated() {
+    local required
+    [ -x "$POSTRELEASE_PUBLIC_TRUTH" ] || {
+        printf 'post-release public-truth builder is missing or not executable\n'
+        return 1
+    }
+    [ -x "$POSTRELEASE_PUBLIC_TRUTH_TEST" ] || {
+        printf 'post-release public-truth test wrapper is missing or not executable\n'
+        return 1
+    }
+    grep -Fq 'postrelease_public_truth_test.sh' "$RELEASE_TEST_RUNNER" || {
+        printf 'post-release public-truth tests are not wired into the release runner\n'
+        return 1
+    }
+    python3 -m py_compile "$POSTRELEASE_PUBLIC_TRUTH" \
+        "$TEST_DIR/test_postrelease_public_truth.py" || return 1
+    for required in \
+        'REWARD_SCHEMA = "arc.recovery.reward-evidence.v3"' \
+        '"arc-node-linux-arm64"' \
+        '"arc-cli-linux-arm64"' \
+        'PROTOCOL_VERSION_RE.fullmatch(checkpoint["protocolVersion"])' \
+        'len(sources) != 12' \
+        'frontend source identities and endpoints must be unique' \
+        'legacy forks do not share one sealed capture' \
+        'REWARD_PER_RECEIPT_BASE = 2_500_000_000' \
+        '"canonical_cutoff"' \
+        'object_pairs_hook=reject_duplicate_keys' \
+        'parse_constant=reject_nonfinite_number' \
+        'os.O_NOFOLLOW' \
+        'os.O_EXCL' \
+        'output_dir.mkdir(mode=0o700, parents=False, exist_ok=False)'
+    do
+        grep -Fq -- "$required" "$POSTRELEASE_PUBLIC_TRUTH" || {
+            printf 'post-release public-truth builder omits: %s\n' "$required"
+            return 1
+        }
+    done
+    if grep -Fq -- 'arc-node-linux-aarch64' "$POSTRELEASE_PUBLIC_TRUTH" \
+        || grep -Fq -- 'arc-cli-linux-aarch64' "$POSTRELEASE_PUBLIC_TRUTH"; then
+        printf 'post-release public-truth builder uses noncanonical Linux ARM asset names\n'
+        return 1
+    fi
+    python3 - "$ROOT_README" "$PUBLIC_PRODUCTION_STATUS" <<'PY' || return 1
+import json
+import pathlib
+import sys
+
+readme = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+begin = "<!-- ARC_PUBLIC_TRUTH_BEGIN -->"
+end = "<!-- ARC_PUBLIC_TRUTH_END -->"
+if readme.count(begin) != 1 or readme.count(end) != 1 or readme.index(begin) >= readme.index(end):
+    raise SystemExit("README public-truth markers are not one ordered pair")
+
+def unique_pairs(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON key: {key}")
+        value[key] = item
+    return value
+
+status = json.loads(
+    pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"),
+    object_pairs_hook=unique_pairs,
+)
+if status.get("schema") != "arc.public-production-status.v1":
+    raise SystemExit("public production status has the wrong schema")
+if status.get("state") == "maintenance":
+    if set(status) != {"schema", "state", "notice"} or not isinstance(status["notice"], str) or not status["notice"].strip():
+        raise SystemExit("maintenance public status is not the exact fail-closed shape")
+elif status.get("state") == "recovered":
+    required = {"acceptance", "checkpoint", "fleet", "network", "pages", "release", "rewards", "schema", "services", "state"}
+    if set(status) != required:
+        raise SystemExit("recovered public status does not have the exact generated shape")
+else:
+    raise SystemExit("public production status state is unsupported")
+PY
 }
 
 production_manifest_builder_is_release_gated() {
@@ -2732,6 +2820,105 @@ macos_pretag_community_canary_is_exact_private_and_fail_closed() {
     }
 }
 
+owner_emergency_recovery_authorization_is_durable_and_exact() {
+    local required
+    for required in \
+        'RECEIPT_SCHEMA = "arc.recovery.owner-emergency-recovery.v2"' \
+        'REPOSITORY = "FerrumVir/arc-chain"' \
+        'WORKFLOW_PATH = ".github/workflows/owner-emergency-recovery-approval.yml"' \
+        'AUTHORIZATION_KIND = "owner_emergency_recovery"' \
+        'authenticated by an exact GitHub' \
+        'REASON_CODE = "legacy_fleet_divergence_history_preserving_v080_cutover"' \
+        'SOURCE_HEIGHT = 137_145' \
+        'TRANSITION_HEIGHT = 137_146' \
+        'RECOVERY_EPOCH = 1' \
+        'VALIDATOR_SET_ID = 1' \
+        'SIGNATURES_REQUIRED = 5' \
+        'AUTHORIZED_SIGNER_ORDER' \
+        'UNUSED_RECOVERY_MEMBER' \
+        'approval run actor' \
+        'approval run triggering actor' \
+        'approval exact-attempt jobs do not contain exactly one authorization job' \
+        'approval artifact API identity differs from the exact run attempt' \
+        'downloaded approval artifact differs from the GitHub server digest' \
+        'approval artifact must contain only' \
+        'fail(f"create-only {label} already exists")' \
+        'owner emergency-recovery receipt is stale' \
+        'exact_modes={0o400}' \
+        'SAFE_PATH_COMPONENT_RE' \
+        'os.O_EXCL' \
+        'os.O_NOFOLLOW'
+    do
+        grep -Fq -- "$required" "$OWNER_EMERGENCY_HELPER" || {
+            printf 'owner emergency-recovery helper omits: %s\n' "$required"
+            return 1
+        }
+    done
+    for required in \
+        '"const": "arc.recovery.owner-emergency-recovery.v2"' \
+        '"const": ".github/workflows/owner-emergency-recovery-approval.yml"' \
+        '"const": "workflow_dispatch"' \
+        '"const": "owner_emergency_recovery"' \
+        '"const": "legacy_fleet_divergence_history_preserving_v080_cutover"' \
+        '"const": 137145' \
+        '"const": 137146' \
+        '"const": 5' \
+        '"const": 40000000' \
+        '"const": "FerrumVir"' \
+        '"const": 111036403'
+    do
+        grep -Fq -- "$required" "$OWNER_EMERGENCY_SCHEMA" || {
+            printf 'owner emergency-recovery schema omits: %s\n' "$required"
+            return 1
+        }
+    done
+    for required in \
+        'ACTOR_LOGIN: ${{ github.actor }}' \
+        'ACTOR_ID: ${{ github.actor_id }}' \
+        'TRIGGERING_ACTOR_LOGIN: ${{ github.triggering_actor }}' \
+        '[ "$ACTOR_LOGIN" = FerrumVir ]' \
+        '[ "$ACTOR_ID" = 111036403 ]' \
+        '[ "$TRIGGERING_ACTOR_LOGIN" = FerrumVir ]' \
+        'actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT' \
+        '.actor.login == "FerrumVir" and .actor.id == 111036403' \
+        '.triggering_actor.login == "FerrumVir"' \
+        'overwrite: false' \
+        'retention-days: 90'
+    do
+        grep -Fq -- "$required" "$OWNER_EMERGENCY_WORKFLOW" || {
+            printf 'owner-authentication workflow omits: %s\n' "$required"
+            return 1
+        }
+    done
+    if grep -Fq 'secrets.' "$OWNER_EMERGENCY_WORKFLOW" \
+        || grep -Eq '^[[:space:]]+(contents|actions|packages|deployments|id-token): write' \
+            "$OWNER_EMERGENCY_WORKFLOW"; then
+        printf 'owner-authentication workflow acquired a secret or mutation authority\n'
+        return 1
+    fi
+    python3 -m py_compile "$OWNER_EMERGENCY_HELPER" "$OWNER_EMERGENCY_TEST" || return 1
+    python3 - "$OWNER_EMERGENCY_SCHEMA" <<'PY' || return 1
+import json, pathlib, sys
+schema = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+if schema.get("type") != "object" or schema.get("additionalProperties") is not False:
+    raise SystemExit("owner emergency-recovery receipt schema is not closed")
+PY
+    grep -Fq -- 'owner_emergency_recovery_test.sh' "$RELEASE_TEST_RUNNER" || {
+        printf 'release harness does not run the owner emergency-recovery contract\n'
+        return 1
+    }
+    grep -Fq -- 'test_cli_verifies_exact_owner_attempt_and_materializes_create_only_pair' \
+        "$OWNER_EMERGENCY_TEST" || {
+        printf 'owner emergency-recovery behavioral test is missing\n'
+        return 1
+    }
+    if grep -Fq -- 'checkpoint_approval_phrase=' "$RECOVERY_RUNBOOK" \
+        || grep -Fq -- 'After all six operators compare it out of band' "$RECOVERY_RUNBOOK"; then
+        printf 'recovery signing still relies on the ceremonial six-operator phrase\n'
+        return 1
+    fi
+}
+
 run_test 'required headless assets are built and gate the sole publisher' required_assets_are_built_and_gated
 run_test 'locked Rust and JavaScript Tauri packages are release-compatible' desktop_tauri_packages_are_release_compatible
 run_test 'desktop packages the exact canonical release seed list' packaged_desktop_network_resources_match_release
@@ -2765,9 +2952,11 @@ run_test 'Windows desktop shutdown is private, authenticated, and uses the full 
 run_test 'signing-key backups are encrypted, create-only, and restore-tested' signing_key_backup_is_encrypted_create_only_and_restore_tested
 run_test 'validator-vault restore/install is profile-bound, offline-proof gated, and create-only' validator_vault_restore_and_install_are_fail_closed
 run_test 'production manifest builder is hermetic, sealed, documented, and release-gated' production_manifest_builder_is_release_gated
+run_test 'post-release public truth is hermetic, exact-evidence bound, and release-gated' postrelease_public_truth_is_hermetic_exact_and_release_gated
 run_test 'production recovery plan streams probes without persistent remote helpers' recovery_plan_remote_transport_is_read_only
 run_test 'archive transport credentials and temp roots are invocation-scoped' archive_transport_configuration_is_invocation_scoped
 run_test 'macOS pre-tag community canary is exact, private, SIGTERM-only, and preservation-safe' macos_pretag_community_canary_is_exact_private_and_fail_closed
+run_test 'owner emergency recovery is canonical, create-only, fresh, and exact-input bound' owner_emergency_recovery_authorization_is_durable_and_exact
 run_test 'release-related shell scripts pass bash syntax validation' relevant_shell_is_syntax_valid
 
 finish_tests

--- a/tests/release/test_macos_community_canary.py
+++ b/tests/release/test_macos_community_canary.py
@@ -461,6 +461,32 @@ class MacosCommunityCanaryTests(unittest.TestCase):
         self.assertEqual("SIGTERM", signals[0][2])
         self.assertFalse(any("SIGKILL" in part for args in self.fake.commands for part in args))
 
+    def test_acceptance_receipt_binds_exact_running_worker_and_is_create_only(self) -> None:
+        self.install()
+        self.controller.start()
+        self.controller.accept()
+        path = self.controller.paths.acceptance_receipt
+        first = path.read_bytes()
+        receipt = json.loads(first)
+        config = self.controller._load_config()
+        self.assertEqual(
+            "arc.macos.pretag-community-canary.acceptance.v1",
+            receipt["schema"],
+        )
+        self.assertEqual("0x" + self.fake.public_address, receipt["worker"])
+        self.assertEqual(canary.sha256(self.controller.paths.config), receipt["config_sha256"])
+        self.assertEqual(config["pretag"]["artifact_id"], receipt["pretag"]["artifact_id"])
+        self.assertTrue(receipt["process"]["exact_executable_argv_and_listeners_proved"])
+        self.controller.accept()
+        self.assertEqual(first, path.read_bytes())
+
+        hostile = json.loads(first)
+        hostile["worker"] = "0x" + "9" * 64
+        path.write_bytes(canary.canonical_json(hostile))
+        path.chmod(0o600)
+        with self.assertRaisesRegex(canary.CanaryError, "validated canary config"):
+            self.controller.status()
+
     def test_argv_mismatch_fails_before_any_signal_or_disable(self) -> None:
         self.install()
         self.controller.start()

--- a/tests/release/test_postrelease_public_truth.py
+++ b/tests/release/test_postrelease_public_truth.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import os
+import stat
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).parents[2]
+SCRIPT = ROOT / "scripts/release/build-postrelease-public-truth.py"
+PUBLISHED_SCRIPT = ROOT / "scripts/release/published-artifact-acceptance.py"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+TRUTH = load_module("arc_postrelease_truth", SCRIPT)
+PUBLISHED = load_module("arc_published_acceptance", PUBLISHED_SCRIPT)
+
+
+def write_json(path: Path, value: object, *, canonical: bool = True) -> bytes:
+    raw = (
+        TRUTH.canonical_json(value)
+        if canonical
+        else (json.dumps(value, indent=2) + "\n").encode("utf-8")
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(raw)
+    return raw
+
+
+def digest(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+class Fixture:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.source_sha = "a" * 40
+        self.frontend_sha = "b" * 40
+        self.release_run_id = 10
+        self.release_run_attempt = 1
+        self.acceptance_run_id = 14
+        self.acceptance_run_attempt = 1
+        self.readme = root / "README.md"
+        self.readme.write_text(
+            "# ARC\n\n"
+            + TRUTH.BEGIN_MARKER
+            + "\n> **Source-freeze snapshot:** not live.\n"
+            + TRUTH.END_MARKER
+            + "\n\n## The claim\nkept verbatim\n",
+            encoding="utf-8",
+        )
+
+        self.manifest = {
+            "mode": "production",
+            "provenance": {"source_main_commit": self.source_sha},
+            "checks": {
+                "reward": {
+                    "mode": "receipt",
+                    "expected_reward_base": 2_500_000_000,
+                    "expected_worker": "0x" + "c" * 64,
+                }
+            },
+        }
+        self.manifest_path = root / "manifest.json"
+        manifest_raw = write_json(self.manifest_path, self.manifest)
+        self.manifest_path.chmod(0o400)
+        self.manifest_sidecar = root / "manifest.json.sha256"
+        self.manifest_sidecar.write_text(
+            f"{digest(manifest_raw)}  manifest.json\n", encoding="ascii"
+        )
+        self.manifest_sidecar.chmod(0o400)
+        self.reward = {
+            "schema": TRUTH.REWARD_SCHEMA,
+            "rollout_sha256": digest(manifest_raw),
+            "earnings_baseline": {
+                "worker": "0x" + "c" * 64,
+                "confirmed_receipt_count": 0,
+                "confirmed_gross_earnings_base": 0,
+                "confirmed_receipts": [],
+            },
+            "receipts": [
+                {
+                    "tx_hash": "0x" + tx * 64,
+                    "job_id": "0x" + job * 64,
+                    "worker": "0x" + "c" * 64,
+                }
+                for tx, job in (("d", "e"), ("f", "1"))
+            ],
+            "canonical_cutoff": {
+                "block_height": 137148,
+                "block_hash": "0x" + "7" * 64,
+                "index": 1,
+            },
+        }
+        self.reward_path = root / "reward.json"
+        write_json(self.reward_path, self.reward)
+
+        sources = [
+            {
+                "id": f"v3-{name}",
+                "name": f"ARC v3 {name.upper()}",
+                "region": name.upper(),
+                "kind": "v3",
+                "baseUrl": f"https://{host}",
+                "enabled": True,
+                "replicaGroup": "rollout",
+            }
+            for name, host in TRUTH.PRODUCTION_FLEET
+        ]
+        sources.extend(
+            {
+                "id": f"legacy-fork-{name}",
+                "name": f"Preserved legacy fork · {name.upper()}",
+                "region": name.upper(),
+                "kind": "legacy-fork",
+                "baseUrl": f"https://{host}/legacy/{name}",
+                "enabled": True,
+                "replicaGroup": "legacy-capture-" + "a" * 64,
+                "description": "Explicit immutable historical fork; diagnostic only and never canonical.",
+                "archive": {
+                    "schema": "arc.legacy-archive.source.v1",
+                    "readOnly": True,
+                    "classification": "valid_noncanonical_fork",
+                    "captureId": "a" * 64,
+                    "node": name,
+                    "rolloutManifestSha256": "b" * 64,
+                    "archiveManifestSha256": "c" * 64,
+                    "completeSha256": "d" * 64,
+                    "bundleSha256": "e" * 64,
+                    "inventorySha256": "f" * 64,
+                    "bindingIndexSha256": "1" * 64,
+                    "bindingSha256": "2" * 64,
+                    "checkpointSha256": "3" * 64,
+                    "checkpointManifestHash": "4" * 64,
+                    "checkpointPayloadHash": "5" * 64,
+                    "canonicalCheckpointHeight": 137145,
+                    "sourceHeight": 141000,
+                    "sourceBlockHash": "6" * 64,
+                    "sourceStateRoot": "7" * 64,
+                    "provenancePath": "/provenance",
+                },
+            }
+            for name, host in TRUTH.PRODUCTION_FLEET
+        )
+        self.config = {
+            "schema": TRUTH.NETWORK_SCHEMA,
+            "state": "recovered",
+            "network": {"name": "ARC Testnet", "chainId": TRUTH.CHAIN_ID},
+            "checkpoint": {
+                "height": 137145,
+                "recoveryHeight": 137146,
+                "legacyPublicMaxHeight": 141000,
+                "blockHash": "2" * 64,
+                "stateRoot": "3" * 64,
+                "manifestHash": "4" * 64,
+                "boundaryBlockHash": "5" * 64,
+                "boundaryStateRoot": "6" * 64,
+                "recoveryEpoch": 1,
+                "validatorSetId": 1,
+                "protocolVersion": "3.0.0",
+                "recoveryDomain": "7" * 64,
+                "legacySourceId": "v3-nyc",
+                "v3SourceId": "v3-nyc",
+            },
+            "sources": sources,
+            "services": {
+                "maintenanceInterlock": {
+                    "schema": "arc.frontend.maintenance-interlock.v1",
+                    "path": "/maintenance/status",
+                    "sourceMainCommit": self.source_sha,
+                    "observedCutoffHeight": 141000,
+                    "sourceSetSha256": "8" * 64,
+                    "boundarySha256": "9" * 64,
+                    "toolSha256": "a" * 64,
+                    "requiredHealthyReplicas": 6,
+                    "maxStalenessSeconds": 90,
+                }
+            },
+            "notices": ["Recovered production network."],
+        }
+        self.config_path = root / "config.json"
+        config_raw = write_json(self.config_path, self.config)
+        self.deployed_commit = root / "deployed-commit.txt"
+        self.deployed_commit.write_text(self.frontend_sha + "\n", encoding="ascii")
+        self.deployed_sums = root / "deployed-SHA256SUMS"
+        self.deployed_sums.write_text(
+            f"{digest(self.deployed_commit.read_bytes())}  ./deployed-commit.txt\n"
+            f"{digest(config_raw)}  ./shared/frontend/arc-network.json\n",
+            encoding="ascii",
+        )
+        self._build_pages_evidence()
+
+        self.installer_sha = digest(b"published installer bytes\n")
+        self.assets = {
+            name: {
+                "id": 1000 + index,
+                "sha256": self.installer_sha if name == "install.sh" else digest(name.encode()),
+                "size": 32 + index,
+            }
+            for index, name in enumerate(sorted(PUBLISHED.EXPECTED_RELEASE_ASSETS))
+        }
+        self.release = {
+            "id": 99,
+            "tag_name": TRUTH.TAG,
+            "target_commitish": self.source_sha,
+            "draft": False,
+            "prerelease": False,
+            "immutable": True,
+            "author": {"login": "github-actions[bot]"},
+            "html_url": f"https://github.com/{TRUTH.REPOSITORY}/releases/tag/{TRUTH.TAG}",
+            "published_at": "2026-09-06T01:02:03Z",
+            "assets": [
+                {
+                    "id": row["id"],
+                    "name": name,
+                    "digest": "sha256:" + row["sha256"],
+                    "state": "uploaded",
+                    "size": row["size"],
+                    "uploader": {"login": "github-actions[bot]"},
+                    "browser_download_url": (
+                        f"https://github.com/{TRUTH.REPOSITORY}/releases/download/"
+                        f"{TRUTH.TAG}/{name}"
+                    ),
+                }
+                for name, row in sorted(self.assets.items())
+            ],
+        }
+        self.release_path = root / "release.json"
+        write_json(self.release_path, self.release, canonical=False)
+        self._build_published_evidence()
+
+    def _build_pages_evidence(self) -> None:
+        self.pages_workflow = self.root / "pages-workflow.json"
+        write_json(self.pages_workflow, {"id": 11, "name": "Deploy ARC public console", "path": TRUTH.PAGES_WORKFLOW_PATH, "state": "active"}, canonical=False)
+        self.pages_run = self.root / "pages-run.json"
+        write_json(self.pages_run, {"id": 12, "run_attempt": 2, "workflow_id": 11, "head_repository": {"full_name": TRUTH.REPOSITORY}, "path": TRUTH.PAGES_WORKFLOW_PATH, "event": "push", "head_branch": "main", "head_sha": self.frontend_sha, "status": "completed", "conclusion": "success"}, canonical=False)
+        self.pages_jobs_value = [{"id": 120 + index, "name": name, "run_id": 12, "run_attempt": 2, "head_sha": self.frontend_sha, "status": "completed", "conclusion": "success"} for index, name in enumerate(sorted(TRUTH.PAGES_JOB_NAMES))]
+        self.pages_jobs = self.root / "pages-jobs.json"
+        write_json(self.pages_jobs, self.pages_jobs_value, canonical=False)
+        self.pages_api = self.root / "pages-api.json"
+        write_json(self.pages_api, {"build_type": "workflow", "html_url": TRUTH.PUBLIC_CONSOLE}, canonical=False)
+        self.pages_deployments = self.root / "pages-deployments.json"
+        write_json(self.pages_deployments, [{"id": 13, "sha": self.frontend_sha, "ref": "main", "environment": "github-pages", "task": "deploy"}], canonical=False)
+        self.pages_statuses_value = [{"id": 130, "state": "success", "environment": "github-pages", "environment_url": TRUTH.PUBLIC_CONSOLE}, {"id": 129, "state": "in_progress", "environment": "github-pages", "environment_url": TRUTH.PUBLIC_CONSOLE}]
+        self.pages_statuses = self.root / "pages-statuses.json"
+        write_json(self.pages_statuses, self.pages_statuses_value, canonical=False)
+
+    def _build_published_evidence(self) -> None:
+        self.published_workflow = self.root / "published-workflow.json"
+        write_json(self.published_workflow, {"id": 13, "name": "Published artifact acceptance", "path": TRUTH.PUBLISHED_WORKFLOW_PATH, "state": "active"}, canonical=False)
+        self.published_run = self.root / "published-run.json"
+        write_json(self.published_run, {"id": self.acceptance_run_id, "run_attempt": self.acceptance_run_attempt, "workflow_id": 13, "head_repository": {"full_name": TRUTH.REPOSITORY}, "path": TRUTH.PUBLISHED_WORKFLOW_PATH, "event": "workflow_dispatch", "head_branch": TRUTH.TAG, "head_sha": self.source_sha, "status": "completed", "conclusion": "success"}, canonical=False)
+        self.published_jobs_value = [{"id": 140 + index, "name": name, "run_id": self.acceptance_run_id, "run_attempt": self.acceptance_run_attempt, "head_sha": self.source_sha, "status": "completed", "conclusion": "success"} for index, name in enumerate(sorted(TRUTH.PUBLISHED_JOB_NAMES))]
+        self.published_jobs = self.root / "published-jobs.json"
+        write_json(self.published_jobs, self.published_jobs_value, canonical=False)
+        self.artifact_root = self.root / "published-artifact"
+        self.artifact_root.mkdir(mode=0o700)
+        evidence_root = self.artifact_root / "evidence"
+        payloads = {name: f"evidence for {name}\n".encode() for name in TRUTH.PUBLISHED_EVIDENCE_FILES}
+        for name, raw in payloads.items():
+            path = evidence_root / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(raw)
+        evidence_hashes = {name: {"sha256": digest(raw), "size": len(raw)} for name, raw in sorted(payloads.items())}
+        release_jobs_sha = evidence_hashes["release/release-attempt-jobs.json"]["sha256"]
+        release_published_sha = evidence_hashes["release/release-published.json"]["sha256"]
+        published_metadata_sha = evidence_hashes["release/published-evidence-artifact.json"]["sha256"]
+        binding = {
+            "assets": self.assets,
+            "commit": self.source_sha,
+            "legacy_source": PUBLISHED.LEGACY_SOURCE,
+            "published_evidence": {"artifact_digest": "sha256:" + evidence_hashes["release/published-evidence.zip"]["sha256"], "artifact_id": 88, "artifact_metadata_sha256": published_metadata_sha, "artifact_name": f"arc-release-published-evidence-{self.source_sha}-{self.release_run_id}-{self.release_run_attempt}-99-{release_published_sha}", "artifact_size": 111, "release_published_sha256": release_published_sha},
+            "release": {"id": 99, "immutable": True},
+            "release_workflow": {"event": "workflow_dispatch", "head_branch": "main", "head_sha": self.source_sha, "id": 7, "jobs_sha256": release_jobs_sha, "path": ".github/workflows/release.yml", "run_attempt": self.release_run_attempt, "run_id": self.release_run_id},
+            "repository": TRUTH.REPOSITORY,
+            "schema": "arc.published-release-binding.v1",
+            "tag": TRUTH.TAG,
+        }
+        binding_path = self.artifact_root / "release-binding.json"
+        binding_sha = digest(write_json(binding_path, binding))
+        component_artifacts = {"schema": "arc.published-artifact-component-binding.v1", "repository": TRUTH.REPOSITORY, "acceptance_run_id": self.acceptance_run_id, "acceptance_run_attempt": self.acceptance_run_attempt, "artifacts": {}}
+        platforms = sorted(PUBLISHED.EXPECTED_COMPONENTS)
+        for index, platform in enumerate(platforms):
+            component_artifacts["artifacts"][platform] = {"name": f"arc-published-acceptance-{platform}-{self.acceptance_run_id}-attempt-{self.acceptance_run_attempt}", "id": 200 + index, "digest": "sha256:" + digest(platform.encode()), "size": 100 + index, "expired": False, "workflow_run_id": self.acceptance_run_id, "head_sha": self.source_sha}
+        component_artifacts_path = self.artifact_root / "component-artifacts.json"
+        component_artifacts_raw = write_json(component_artifacts_path, component_artifacts)
+        component_receipts = self.root / "component-receipts"
+        component_receipts.mkdir()
+        for platform in platforms:
+            checks = dict(PUBLISHED.REQUIRED_CHECKS[platform])
+            if platform == "windows-x86_64":
+                checks["embedded_app_product_version"] = "0.8.0"
+            component = {"acceptance_run_attempt": self.acceptance_run_attempt, "acceptance_run_id": self.acceptance_run_id, "assets": {name: self.assets[name] for name in PUBLISHED.EXPECTED_COMPONENTS[platform]}, "binding_sha256": binding_sha, "checks": checks, "commit": self.source_sha, "platform": platform, "release_id": 99, "release_run_attempt": self.release_run_attempt, "release_run_id": self.release_run_id, "repository": TRUTH.REPOSITORY, "schema": "arc.published-artifact-acceptance-component.v1", "tag": TRUTH.TAG}
+            component_path = component_receipts / f"{platform}.json"
+            write_json(component_path, component)
+            os.link(component_path, self.artifact_root / f"{platform}.json")
+        evidence_manifest = {"acceptance_run_attempt": self.acceptance_run_attempt, "acceptance_run_id": self.acceptance_run_id, "binding_sha256": binding_sha, "component_artifact_binding_sha256": digest(component_artifacts_raw), "files": evidence_hashes, "repository": TRUTH.REPOSITORY, "schema": "arc.published-artifact-evidence-manifest.v1"}
+        evidence_manifest_path = self.artifact_root / TRUTH.PUBLISHED_EVIDENCE_MANIFEST
+        write_json(evidence_manifest_path, evidence_manifest)
+        PUBLISHED.command_aggregate(argparse.Namespace(binding=binding_path, component_artifacts=component_artifacts_path, components=component_receipts, evidence_manifest=evidence_manifest_path, evidence_root=evidence_root, acceptance_run_id=self.acceptance_run_id, acceptance_run_attempt=self.acceptance_run_attempt, output=self.artifact_root / TRUTH.PUBLISHED_ACCEPTANCE_RECEIPT))
+        self.rebuild_published_zip()
+
+    def rebuild_published_zip(self) -> None:
+        sums_path = self.artifact_root / TRUTH.PUBLISHED_ACCEPTANCE_SUMS
+        sums_path.write_text("".join(f"{digest(path.read_bytes())}  ./{path.relative_to(self.artifact_root).as_posix()}\n" for path in sorted(self.artifact_root.rglob("*")) if path.is_file() and path != sums_path), encoding="ascii")
+        self.published_zip = self.root / "published-acceptance.zip"
+        with zipfile.ZipFile(self.published_zip, "w", zipfile.ZIP_DEFLATED) as archive:
+            for path in sorted(self.artifact_root.rglob("*")):
+                if path.is_file():
+                    archive.write(path, path.relative_to(self.artifact_root).as_posix())
+        self.published_artifact_metadata = self.root / "published-artifact-metadata.json"
+        write_json(self.published_artifact_metadata, {"id": 15, "name": f"arc-published-artifact-acceptance-{TRUTH.TAG}-{self.source_sha}-{self.acceptance_run_id}-attempt-{self.acceptance_run_attempt}", "size_in_bytes": self.published_zip.stat().st_size, "digest": "sha256:" + digest(self.published_zip.read_bytes()), "expired": False, "workflow_run": {"id": self.acceptance_run_id, "head_sha": self.source_sha}}, canonical=False)
+
+    def args(self, output: Path, **overrides: object) -> argparse.Namespace:
+        values: dict[str, object] = {"readme": self.readme, "release_api": self.release_path, "pages_workflow": self.pages_workflow, "pages_run": self.pages_run, "pages_jobs": self.pages_jobs, "pages_api": self.pages_api, "pages_deployments": self.pages_deployments, "pages_statuses": self.pages_statuses, "frontend_config": self.config_path, "deployed_commit": self.deployed_commit, "deployed_sha256sums": self.deployed_sums, "published_workflow": self.published_workflow, "published_run": self.published_run, "published_jobs": self.published_jobs, "published_artifact_metadata": self.published_artifact_metadata, "published_artifact_zip": self.published_zip, "reward_evidence": self.reward_path, "rollout_manifest": self.manifest_path, "output_dir": output}
+        values.update(overrides)
+        return argparse.Namespace(**values)
+
+
+class PublicTruthTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.fixture = Fixture(self.root)
+        self.recovery_calls: list[tuple[Path, Path]] = []
+
+        def verified(manifest, reward, manifest_raw, reward_raw, temporary_root):
+            self.recovery_calls.append((manifest, reward))
+            return {"manifestSha256": digest(manifest_raw), "rewardEvidenceSha256": digest(reward_raw), "stdoutSha256": "9" * 64, "verifierPath": TRUTH.RECOVERY_VERIFIER_RELATIVE.as_posix(), "verifierSha256": "8" * 64}
+
+        self.recovery_patch = mock.patch.object(TRUTH, "run_recovery_verify", side_effect=verified)
+        self.recovery_patch.start()
+
+    def tearDown(self) -> None:
+        self.recovery_patch.stop()
+        self.temporary.cleanup()
+
+    def test_builds_v2_receipt_and_claims_from_raw_evidence(self) -> None:
+        output = self.root / "output"
+        readme_path, status_path = TRUTH.build(self.fixture.args(output))
+        acceptance_path = output / "POST-RELEASE-ACCEPTANCE.json"
+        self.assertEqual({path.name for path in output.iterdir()}, {"README.md", "production-status.json", "POST-RELEASE-ACCEPTANCE.json"})
+        for path in (readme_path, status_path, acceptance_path):
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o400)
+        readme = readme_path.read_text(encoding="utf-8")
+        self.assertIn("published Linux x86_64 component proved", readme)
+        self.assertIn(f"ARC_INSTALL_SHA256={self.fixture.installer_sha}", readme)
+        acceptance_raw = acceptance_path.read_bytes()
+        acceptance = json.loads(acceptance_raw)
+        self.assertEqual(acceptance["schema"], "arc.post-release-acceptance.v2")
+        self.assertNotIn("pages_jobs_succeeded", acceptance)
+        self.assertEqual(acceptance["publishedAcceptance"]["componentReceiptSha256"]["linux-x86_64"], digest((self.fixture.artifact_root / "linux-x86_64.json").read_bytes()))
+        status = json.loads(status_path.read_bytes())
+        self.assertEqual(status["acceptance"]["receiptSha256"], digest(acceptance_raw))
+        self.assertEqual(status["acceptance"]["receipt"], acceptance)
+        self.assertEqual(
+            digest(TRUTH.canonical_json(status["acceptance"]["receipt"])),
+            status["acceptance"]["receiptSha256"],
+        )
+        self.assertEqual(
+            status["acceptance"]["receipt"]["publishedAcceptance"]["artifactId"],
+            15,
+        )
+        self.assertEqual(
+            status["acceptance"]["receipt"]["publishedAcceptance"]["runId"],
+            self.fixture.acceptance_run_id,
+        )
+        self.assertEqual(status["pages"]["acceptedConfigCommit"], self.fixture.frontend_sha)
+        self.assertEqual(status["rewards"]["demonstratedGrossBase"], 5_000_000_000)
+        self.assertEqual(self.recovery_calls, [(self.fixture.manifest_path, self.fixture.reward_path)])
+
+    def test_rejects_wrong_attempt_job_even_if_run_says_success(self) -> None:
+        jobs = copy.deepcopy(self.fixture.pages_jobs_value)
+        jobs[0]["run_attempt"] = 1
+        path = self.root / "bad-pages-jobs.json"
+        write_json(path, jobs, canonical=False)
+        with self.assertRaisesRegex(TRUTH.TruthError, "exact successful attempt"):
+            TRUTH.build(self.fixture.args(self.root / "bad-jobs-output", pages_jobs=path))
+        self.assertFalse(self.recovery_calls)
+
+    def test_rejects_stale_pages_success_and_tampered_cdn_commit(self) -> None:
+        statuses = list(reversed(self.fixture.pages_statuses_value))
+        statuses_path = self.root / "stale-statuses.json"
+        write_json(statuses_path, statuses, canonical=False)
+        with self.assertRaisesRegex(TRUTH.TruthError, "latest exact Pages"):
+            TRUTH.build(self.fixture.args(self.root / "stale-output", pages_statuses=statuses_path))
+        commit_path = self.root / "attacker-commit.txt"
+        commit_path.write_text("c" * 40 + "\n", encoding="ascii")
+        with self.assertRaisesRegex(TRUTH.TruthError, "deployed-commit"):
+            TRUTH.build(self.fixture.args(self.root / "cdn-output", deployed_commit=commit_path))
+
+    def test_rejects_artifact_metadata_digest_or_rehashed_component_forgery(self) -> None:
+        metadata = json.loads(self.fixture.published_artifact_metadata.read_text())
+        metadata["digest"] = "sha256:" + "0" * 64
+        metadata_path = self.root / "wrong-artifact-metadata.json"
+        write_json(metadata_path, metadata, canonical=False)
+        with self.assertRaisesRegex(TRUTH.TruthError, "ZIP bytes differ"):
+            TRUTH.build(self.fixture.args(self.root / "wrong-artifact-output", published_artifact_metadata=metadata_path))
+        linux_path = self.fixture.artifact_root / "linux-x86_64.json"
+        linux = json.loads(linux_path.read_text())
+        linux["assets"]["install.sh"]["sha256"] = "0" * 64
+        write_json(linux_path, linux)
+        self.fixture.rebuild_published_zip()
+        with self.assertRaisesRegex(TRUTH.TruthError, "component linux-x86_64 hash"):
+            TRUTH.build(self.fixture.args(self.root / "forged-component-output"))
+
+    def test_rejects_zip_traversal_or_uncovered_member(self) -> None:
+        unsafe_zip = self.root / "unsafe.zip"
+        with zipfile.ZipFile(unsafe_zip, "w") as archive:
+            for path in self.fixture.artifact_root.rglob("*"):
+                if path.is_file():
+                    archive.write(path, path.relative_to(self.fixture.artifact_root).as_posix())
+            archive.writestr("../escape", b"attack")
+        metadata = json.loads(self.fixture.published_artifact_metadata.read_text())
+        metadata["size_in_bytes"] = unsafe_zip.stat().st_size
+        metadata["digest"] = "sha256:" + digest(unsafe_zip.read_bytes())
+        metadata_path = self.root / "unsafe-metadata.json"
+        write_json(metadata_path, metadata, canonical=False)
+        with self.assertRaisesRegex(TRUTH.TruthError, "exact canonical file set"):
+            TRUTH.build(self.fixture.args(self.root / "unsafe-output", published_artifact_zip=unsafe_zip, published_artifact_metadata=metadata_path))
+
+    def test_live_recovery_verifier_failure_creates_no_output(self) -> None:
+        self.recovery_patch.stop()
+        output = self.root / "verify-failed-output"
+        with mock.patch.object(TRUTH, "run_recovery_verify", side_effect=TRUTH.TruthError("live convergence failed")):
+            with self.assertRaisesRegex(TRUTH.TruthError, "live convergence failed"):
+                TRUTH.build(self.fixture.args(output))
+        self.recovery_patch.start()
+        self.assertFalse(output.exists())
+
+    def test_rejects_mutable_release_duplicate_reward_and_existing_output(self) -> None:
+        release = copy.deepcopy(self.fixture.release)
+        release["immutable"] = False
+        release_path = self.root / "mutable-release.json"
+        write_json(release_path, release, canonical=False)
+        with self.assertRaisesRegex(TRUTH.TruthError, "immutable"):
+            TRUTH.build(self.fixture.args(self.root / "mutable-output", release_api=release_path))
+        reward = copy.deepcopy(self.fixture.reward)
+        reward["receipts"][1]["tx_hash"] = reward["receipts"][0]["tx_hash"]
+        reward_path = self.root / "duplicate-reward.json"
+        write_json(reward_path, reward)
+        with self.assertRaisesRegex(TRUTH.TruthError, "distinct"):
+            TRUTH.build(self.fixture.args(self.root / "reward-output", reward_evidence=reward_path))
+        existing = self.root / "existing"
+        existing.mkdir()
+        with self.assertRaisesRegex(TRUTH.TruthError, "cannot create"):
+            TRUTH.build(self.fixture.args(existing))
+
+    def test_rejects_noncanonical_or_symlink_inputs(self) -> None:
+        noncanonical = self.root / "noncanonical-config.json"
+        write_json(noncanonical, self.fixture.config, canonical=False)
+        with self.assertRaisesRegex(TRUTH.TruthError, "not canonical"):
+            TRUTH.build(self.fixture.args(self.root / "noncanonical-output", frontend_config=noncanonical))
+        linked = self.root / "linked-readme.md"
+        linked.symlink_to(self.fixture.readme)
+        with self.assertRaisesRegex(TRUTH.TruthError, "cannot read README"):
+            TRUTH.build(self.fixture.args(self.root / "linked-output", readme=linked))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/release/test_privileged_workflow_boundaries.py
+++ b/tests/release/test_privileged_workflow_boundaries.py
@@ -835,6 +835,36 @@ class PrivilegedWorkflowBoundaryTests(unittest.TestCase):
         validate_secret_workflows(self.texts)
         validate_publish_authority(self.texts["release"])
 
+    def test_privileged_artifact_selection_pins_exact_workflow_attempts(self) -> None:
+        preflight = self.texts["preflight"]
+        release = self.texts["release"]
+        for literal in (
+            "signing_backup_run_id:",
+            "signing_backup_run_attempt:",
+            'actions/runs/$backup_run_id/attempts/$backup_run_attempt',
+            "arc-signing-backup-$main_sha-$backup_run_id-$backup_run_attempt-",
+        ):
+            self.assertIn(literal, preflight)
+        self.assertNotIn("backup_run_id=\"$(gh run list", preflight)
+        for literal in (
+            "pretag_run_id:",
+            "pretag_run_attempt:",
+            'actions/runs/$PREFLIGHT_RUN_ID/attempts/$PREFLIGHT_RUN_ATTEMPT',
+            'actions/runs/$SELECTED_PREFLIGHT_RUN_ID/attempts/$SELECTED_PREFLIGHT_RUN_ATTEMPT',
+        ):
+            self.assertIn(literal, release)
+        self.assertNotIn("current_preflight_id=", release)
+        self.assertNotIn('PREFLIGHT_RUN_ID="$(gh run list', release)
+        verifier = (
+            REPO_ROOT / "scripts/release/verify-pretag-run-and-artifacts.sh"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            'actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT', verifier
+        )
+        self.assertNotIn(
+            'gh api "repos/$REPOSITORY/actions/runs/$RUN_ID"', verifier
+        )
+
     def test_backup_manifest_public_key_canonicalizer(self) -> None:
         text = self.texts["preflight"]
         self.assertIn(

--- a/tests/release/test_protected_pretag_artifact.py
+++ b/tests/release/test_protected_pretag_artifact.py
@@ -613,6 +613,10 @@ class ProtectedArtifactTests(unittest.TestCase):
                     ["preflight workflow", "preflight run", "Actions artifact set", "protected main"],
                     [label for _, label in calls],
                 )
+                self.assertEqual(
+                    f"/repos/{provenance.REPOSITORY}/actions/runs/{RUN_ID}/attempts/{RUN_ATTEMPT}",
+                    calls[1][0],
+                )
                 self.assertIn("?per_page=100", calls[2][0])
                 initial_bytes = tuple(
                     verified.provenance_bytes for verified in verified_set.artifacts

--- a/tests/release/test_published_artifact_acceptance.py
+++ b/tests/release/test_published_artifact_acceptance.py
@@ -1,0 +1,656 @@
+#!/usr/bin/env python3
+"""Adversarial tests for the public post-release artifact boundary."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import tempfile
+import unittest
+import zipfile
+from argparse import Namespace
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "release" / "published-artifact-acceptance.py"
+SPEC = importlib.util.spec_from_file_location("published_artifact_acceptance", MODULE_PATH)
+assert SPEC and SPEC.loader
+acceptance = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(acceptance)
+
+
+class PublishedArtifactAcceptanceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.commit = "a" * 40
+        self.repository = "FerrumVir/arc-chain"
+        self.run_id = 987654
+        self.run_attempt = 3
+        self.original_legacy = copy.deepcopy(acceptance.LEGACY_SOURCE)
+        self.addCleanup(self.restore_legacy)
+
+        self.asset_bytes = {
+            name: f"public bytes for {name}\n".encode()
+            for name in acceptance.EXPECTED_RELEASE_ASSETS
+        }
+        self.release = {
+            "id": 777,
+            "tag_name": "v0.8.0",
+            "target_commitish": self.commit,
+            "draft": False,
+            "prerelease": False,
+            "immutable": True,
+            "author": {"login": "github-actions[bot]"},
+            "assets": [
+                {
+                    "id": index + 1000,
+                    "name": name,
+                    "size": len(self.asset_bytes[name]),
+                    "digest": "sha256:"
+                    + hashlib.sha256(self.asset_bytes[name]).hexdigest(),
+                    "state": "uploaded",
+                    "uploader": {"login": "github-actions[bot]"},
+                    "browser_download_url": (
+                        f"https://github.com/{self.repository}/releases/download/"
+                        f"v0.8.0/{name}"
+                    ),
+                }
+                for index, name in enumerate(sorted(self.asset_bytes))
+            ],
+        }
+
+        legacy_bytes = b"real fixture stand-in selected by immutable server id\n"
+        acceptance.LEGACY_SOURCE = copy.deepcopy(acceptance.LEGACY_SOURCE)
+        acceptance.LEGACY_SOURCE["asset"] = {
+            "id": 432306066,
+            "name": "arc-node-linux-x86_64",
+            "size": len(legacy_bytes),
+            "sha256": hashlib.sha256(legacy_bytes).hexdigest(),
+        }
+        self.legacy_bytes = legacy_bytes
+        self.legacy_release = {
+            "id": acceptance.LEGACY_SOURCE["release_id"],
+            "tag_name": "v0.7.7",
+            "assets": [
+                {
+                    "id": acceptance.LEGACY_SOURCE["asset"]["id"],
+                    "name": "arc-node-linux-x86_64",
+                    "size": len(legacy_bytes),
+                    "digest": "sha256:" + hashlib.sha256(legacy_bytes).hexdigest(),
+                    "state": "uploaded",
+                    "browser_download_url": (
+                        f"https://github.com/{self.repository}/releases/download/"
+                        "v0.7.7/arc-node-linux-x86_64"
+                    ),
+                }
+            ],
+        }
+        self.jobs = [
+            {
+                "id": 5000 + index,
+                "name": name,
+                "run_id": self.run_id,
+                "run_attempt": self.run_attempt,
+                "head_sha": self.commit,
+                "status": "completed",
+                "conclusion": (
+                    "skipped" if name == acceptance.SKIPPED_RELEASE_JOB else "success"
+                ),
+            }
+            for index, name in enumerate(
+                sorted(
+                    set(acceptance.EXPECTED_RELEASE_JOBS)
+                    | {acceptance.SKIPPED_RELEASE_JOB}
+                )
+            )
+        ]
+        self.published_evidence_bytes = json.dumps(
+            self.release, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        self.published_download = self.root / "published-download"
+        self.published_download.mkdir()
+        self.published_zip = self.published_download / "published-evidence.zip"
+        self.write_published_zip()
+        self.write_api_documents()
+
+    def restore_legacy(self) -> None:
+        acceptance.LEGACY_SOURCE = self.original_legacy
+
+    def write_json(self, name: str, value: object) -> Path:
+        path = self.root / name
+        path.write_text(json.dumps(value), encoding="utf-8")
+        return path
+
+    def write_published_zip(self, extra_member: bool = False) -> None:
+        with zipfile.ZipFile(self.published_zip, "w", zipfile.ZIP_STORED) as archive:
+            archive.writestr(
+                acceptance.PUBLISHED_EVIDENCE_MEMBER, self.published_evidence_bytes
+            )
+            if extra_member:
+                archive.writestr("unexpected.txt", b"unexpected")
+
+    def published_artifact(self) -> dict[str, object]:
+        evidence_sha = hashlib.sha256(self.published_evidence_bytes).hexdigest()
+        return {
+            "id": 5555,
+            "name": (
+                f"arc-release-published-evidence-{self.commit}-{self.run_id}-"
+                f"{self.run_attempt}-{self.release['id']}-{evidence_sha}"
+            ),
+            "digest": "sha256:" + hashlib.sha256(self.published_zip.read_bytes()).hexdigest(),
+            "size_in_bytes": self.published_zip.stat().st_size,
+            "expired": False,
+            "workflow_run": {"id": self.run_id, "head_sha": self.commit},
+        }
+
+    def write_api_documents(self) -> None:
+        self.workflow_json = self.write_json(
+            "workflow.json",
+            {"id": 123, "path": ".github/workflows/release.yml", "state": "active"},
+        )
+        self.run_json = self.write_json(
+            "run.json",
+            {
+                "id": self.run_id,
+                "run_attempt": self.run_attempt,
+                "workflow_id": 123,
+                "head_repository": {"full_name": self.repository},
+                "path": ".github/workflows/release.yml",
+                "event": "workflow_dispatch",
+                "head_branch": "main",
+                "head_sha": self.commit,
+                "status": "completed",
+                "conclusion": "success",
+            },
+        )
+        self.jobs_json = self.write_json(
+            "jobs.json", {"total_count": len(self.jobs), "jobs": self.jobs}
+        )
+        self.tag_ref_json = self.write_json(
+            "tag-ref.json",
+            {
+                "ref": "refs/tags/v0.8.0",
+                "object": {"type": "commit", "sha": self.commit},
+            },
+        )
+        self.release_json = self.write_json("release.json", self.release)
+        self.legacy_ref_json = self.write_json(
+            "legacy-ref.json",
+            {
+                "ref": "refs/tags/v0.7.7",
+                "object": {
+                    "type": "commit",
+                    "sha": acceptance.LEGACY_SOURCE["commit"],
+                },
+            },
+        )
+        self.legacy_release_json = self.write_json(
+            "legacy-release.json", self.legacy_release
+        )
+        self.published_artifact_json = self.write_json(
+            "published-evidence-artifact.json", self.published_artifact()
+        )
+
+    def bind(self) -> Path:
+        output = self.root / "binding.json"
+        self.jobs_output = self.root / "release-attempt-jobs.json"
+        self.published_evidence_output = self.root / "release-published.json"
+        self.published_evidence_zip_output = self.root / "retained-published-evidence.zip"
+        self.published_artifact_output = self.root / "published-evidence-selection.json"
+        acceptance.command_bind(
+            Namespace(
+                repository=self.repository,
+                tag="v0.8.0",
+                commit=self.commit,
+                release_run_id=self.run_id,
+                release_run_attempt=self.run_attempt,
+                workflow_json=self.workflow_json,
+                run_json=self.run_json,
+                jobs_json=self.jobs_json,
+                tag_ref_json=self.tag_ref_json,
+                release_json=self.release_json,
+                published_evidence_artifact_json=self.published_artifact_json,
+                published_evidence_download_root=self.published_download,
+                legacy_tag_ref_json=self.legacy_ref_json,
+                legacy_release_json=self.legacy_release_json,
+                jobs_output=self.jobs_output,
+                published_evidence_output=self.published_evidence_output,
+                published_evidence_zip_output=self.published_evidence_zip_output,
+                published_evidence_artifact_output=self.published_artifact_output,
+                output=output,
+            )
+        )
+        return output
+
+    def test_binds_exact_successful_attempt_immutable_release_and_legacy_id(self) -> None:
+        binding = json.loads(self.bind().read_text(encoding="utf-8"))
+        self.assertEqual(binding["release_workflow"]["run_id"], self.run_id)
+        self.assertEqual(binding["release_workflow"]["run_attempt"], 3)
+        self.assertEqual(
+            binding["release_workflow"]["jobs_sha256"],
+            acceptance.sha256_file(self.jobs_output),
+        )
+        self.assertEqual(binding["release"], {"id": 777, "immutable": True})
+        self.assertEqual(binding["published_evidence"]["artifact_id"], 5555)
+        self.assertEqual(
+            binding["published_evidence"]["artifact_digest"],
+            self.published_artifact()["digest"],
+        )
+        self.assertEqual(
+            binding["published_evidence"]["release_published_sha256"],
+            hashlib.sha256(self.published_evidence_bytes).hexdigest(),
+        )
+        self.assertEqual(
+            self.published_evidence_zip_output.read_bytes(), self.published_zip.read_bytes()
+        )
+        self.assertEqual(
+            binding["legacy_source"]["asset"]["id"],
+            acceptance.LEGACY_SOURCE["asset"]["id"],
+        )
+        self.assertEqual(set(binding["assets"]), acceptance.EXPECTED_RELEASE_ASSETS)
+
+    def test_selects_only_one_exact_attempt_publication_evidence_artifact(self) -> None:
+        artifacts_json = self.write_json(
+            "artifacts.json",
+            {
+                "artifacts": [
+                    {**self.published_artifact(), "id": 5554, "name": "unrelated"},
+                    self.published_artifact(),
+                ]
+            },
+        )
+        output = self.root / "selected-published-evidence.json"
+        arguments = Namespace(
+            commit=self.commit,
+            release_run_id=self.run_id,
+            release_run_attempt=self.run_attempt,
+            release_json=self.release_json,
+            artifacts_json=artifacts_json,
+            output=output,
+        )
+        acceptance.command_select_published_evidence(arguments)
+        self.assertEqual(json.loads(output.read_text())["id"], 5555)
+
+        duplicate = self.published_artifact()
+        duplicate["id"] = 5556
+        artifacts_json.write_text(
+            json.dumps({"artifacts": [self.published_artifact(), duplicate]}),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(acceptance.AcceptanceError, "exactly one"):
+            acceptance.command_select_published_evidence(arguments)
+
+    def test_rejects_rerun_release_replacement_and_moved_legacy_tag(self) -> None:
+        cases = (
+            (self.run_json, "run_attempt", 4, "release run attempt mismatch"),
+            (self.release_json, "immutable", False, "release immutable state mismatch"),
+        )
+        for path, field, replacement, message in cases:
+            value = json.loads(path.read_text(encoding="utf-8"))
+            original = value[field]
+            value[field] = replacement
+            path.write_text(json.dumps(value), encoding="utf-8")
+            with self.assertRaisesRegex(acceptance.AcceptanceError, message):
+                self.bind()
+            value[field] = original
+            path.write_text(json.dumps(value), encoding="utf-8")
+
+        ref = json.loads(self.legacy_ref_json.read_text(encoding="utf-8"))
+        ref["object"]["sha"] = "b" * 40
+        self.legacy_ref_json.write_text(json.dumps(ref), encoding="utf-8")
+        with self.assertRaisesRegex(acceptance.AcceptanceError, "v0.7.7 tag commit"):
+            self.bind()
+
+    def test_rejects_partial_or_nonterminal_exact_release_attempt_jobs(self) -> None:
+        original = {"total_count": len(self.jobs), "jobs": copy.deepcopy(self.jobs)}
+        mutations = []
+
+        missing = copy.deepcopy(original)
+        missing["jobs"].pop()
+        mutations.append(("missing job", missing, "captured count"))
+
+        duplicate = copy.deepcopy(original)
+        duplicate["jobs"][1]["name"] = duplicate["jobs"][0]["name"]
+        mutations.append(("duplicate job", duplicate, "duplicate release-attempt job"))
+
+        failed = copy.deepcopy(original)
+        required = next(
+            job
+            for job in failed["jobs"]
+            if job["name"] != acceptance.SKIPPED_RELEASE_JOB
+        )
+        required["conclusion"] = "failure"
+        mutations.append(("failed required job", failed, "conclusion mismatch"))
+
+        cleanup_success = copy.deepcopy(original)
+        cleanup = next(
+            job
+            for job in cleanup_success["jobs"]
+            if job["name"] == acceptance.SKIPPED_RELEASE_JOB
+        )
+        cleanup["conclusion"] = "success"
+        mutations.append(("cleanup ran", cleanup_success, "conclusion mismatch"))
+
+        wrong_attempt = copy.deepcopy(original)
+        wrong_attempt["jobs"][0]["run_attempt"] = self.run_attempt - 1
+        mutations.append(("wrong attempt", wrong_attempt, "run attempt mismatch"))
+
+        wrong_sha = copy.deepcopy(original)
+        wrong_sha["jobs"][0]["head_sha"] = "b" * 40
+        mutations.append(("wrong SHA", wrong_sha, "commit mismatch"))
+
+        truncated = copy.deepcopy(original)
+        truncated["total_count"] += 1
+        mutations.append(("truncated page", truncated, "total_count mismatch"))
+
+        for label, value, message in mutations:
+            with self.subTest(label=label):
+                self.jobs_json.write_text(json.dumps(value), encoding="utf-8")
+                with self.assertRaisesRegex(acceptance.AcceptanceError, message):
+                    self.bind()
+        self.jobs_json.write_text(json.dumps(original), encoding="utf-8")
+
+    def test_rejects_unbound_or_tampered_published_evidence_artifact(self) -> None:
+        original = self.published_artifact()
+        mutations = []
+
+        expired = copy.deepcopy(original)
+        expired["expired"] = True
+        mutations.append(("expired", expired, "expiration mismatch"))
+
+        wrong_run = copy.deepcopy(original)
+        wrong_run["workflow_run"]["id"] = self.run_id + 1
+        mutations.append(("wrong run", wrong_run, "run id mismatch"))
+
+        wrong_sha = copy.deepcopy(original)
+        wrong_sha["workflow_run"]["head_sha"] = "b" * 40
+        mutations.append(("wrong SHA", wrong_sha, "commit mismatch"))
+
+        wrong_digest = copy.deepcopy(original)
+        wrong_digest["digest"] = "sha256:" + "f" * 64
+        mutations.append(("wrong ZIP digest", wrong_digest, "ZIP digest mismatch"))
+
+        wrong_name = copy.deepcopy(original)
+        wrong_name["name"] = str(wrong_name["name"]).replace(
+            f"-{self.run_attempt}-", f"-{self.run_attempt + 1}-", 1
+        )
+        mutations.append(("wrong attempt name", wrong_name, "not exact-attempt bound"))
+
+        for label, value, message in mutations:
+            with self.subTest(label=label):
+                self.published_artifact_json.write_text(
+                    json.dumps(value), encoding="utf-8"
+                )
+                with self.assertRaisesRegex(acceptance.AcceptanceError, message):
+                    self.bind()
+        self.published_artifact_json.write_text(json.dumps(original), encoding="utf-8")
+
+    def test_rejects_unsafe_or_noncausal_published_evidence_zip(self) -> None:
+        self.write_published_zip(extra_member=True)
+        self.published_artifact_json.write_text(
+            json.dumps(self.published_artifact()), encoding="utf-8"
+        )
+        with self.assertRaisesRegex(acceptance.AcceptanceError, "exactly"):
+            self.bind()
+
+        with zipfile.ZipFile(self.published_zip, "w", zipfile.ZIP_STORED) as archive:
+            archive.writestr("../release-published.json", self.published_evidence_bytes)
+        self.published_artifact_json.write_text(
+            json.dumps(self.published_artifact()), encoding="utf-8"
+        )
+        with self.assertRaisesRegex(acceptance.AcceptanceError, "unsafe or invalid"):
+            self.bind()
+
+        self.published_evidence_bytes = json.dumps(
+            {**self.release, "name": "different captured evidence"},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        self.write_published_zip()
+        stale_name = self.published_artifact()
+        stale_name["name"] = self.published_artifact()["name"].rsplit("-", 1)[0] + "-" + "0" * 64
+        self.published_artifact_json.write_text(json.dumps(stale_name), encoding="utf-8")
+        with self.assertRaisesRegex(acceptance.AcceptanceError, "content-name digest"):
+            self.bind()
+
+    def test_rejects_asset_digest_id_url_and_name_set_tampering(self) -> None:
+        mutations = (
+            ("digest", "sha256:not-a-digest", "malformed SHA-256"),
+            ("id", 0, "positive integer"),
+            ("browser_download_url", "https://example.invalid/a", "URL mismatch"),
+        )
+        for field, replacement, message in mutations:
+            release = copy.deepcopy(self.release)
+            original = release["assets"][0][field]
+            release["assets"][0][field] = replacement
+            self.release_json.write_text(json.dumps(release), encoding="utf-8")
+            with self.assertRaisesRegex(acceptance.AcceptanceError, message):
+                self.bind()
+            release["assets"][0][field] = original
+        self.release_json.write_text(json.dumps(self.release), encoding="utf-8")
+        release = copy.deepcopy(self.release)
+        release["assets"].pop()
+        self.release_json.write_text(json.dumps(release), encoding="utf-8")
+        with self.assertRaisesRegex(acceptance.AcceptanceError, "asset set mismatch"):
+            self.bind()
+
+    def test_windows_receipt_distinguishes_exact_msi_and_embedded_versions(self) -> None:
+        checks = dict(acceptance.REQUIRED_CHECKS["windows-x86_64"])
+        checks["embedded_app_product_version"] = "0.8.0.0"
+        acceptance.validate_platform_checks("windows-x86_64", checks)
+        for replacement in ("0.8.0-beta", "0.8.0.1"):
+            with self.subTest(embedded=replacement):
+                checks["embedded_app_product_version"] = replacement
+                with self.assertRaisesRegex(
+                    acceptance.AcceptanceError, "embedded_app_product_version"
+                ):
+                    acceptance.validate_platform_checks("windows-x86_64", checks)
+        checks["embedded_app_product_version"] = "0.8.0"
+        checks["msi_product_version"] = "0.8.0.1"
+        with self.assertRaisesRegex(acceptance.AcceptanceError, "msi_product_version"):
+            acceptance.validate_platform_checks("windows-x86_64", checks)
+
+    def test_download_verifier_and_aggregate_fail_closed(self) -> None:
+        binding_path = self.bind()
+        binding = json.loads(binding_path.read_text(encoding="utf-8"))
+        downloads = self.root / "downloads"
+        downloads.mkdir()
+        for name in acceptance.EXPECTED_COMPONENTS["linux-x86_64"]:
+            (downloads / name).write_bytes(self.asset_bytes[name])
+        files_receipt = self.root / "files.json"
+        acceptance.command_verify_files(
+            Namespace(
+                binding=binding_path,
+                directory=downloads,
+                asset=sorted(acceptance.EXPECTED_COMPONENTS["linux-x86_64"]),
+                output=files_receipt,
+            )
+        )
+        self.assertEqual(
+            set(json.loads(files_receipt.read_text())["assets"]),
+            acceptance.EXPECTED_COMPONENTS["linux-x86_64"],
+        )
+        (downloads / "install.sh").write_bytes(b"tampered")
+        with self.assertRaisesRegex(acceptance.AcceptanceError, "downloaded size"):
+            acceptance.command_verify_files(
+                Namespace(
+                    binding=binding_path,
+                    directory=downloads,
+                    asset=["install.sh"],
+                    output=files_receipt,
+                )
+            )
+
+        component_dir = self.root / "components"
+        component_dir.mkdir()
+        binding_sha = acceptance.sha256_file(binding_path)
+        for platform, names in acceptance.EXPECTED_COMPONENTS.items():
+            checks = dict(acceptance.REQUIRED_CHECKS[platform])
+            if platform == "windows-x86_64":
+                checks["embedded_app_product_version"] = "0.8.0"
+            component = {
+                "acceptance_run_attempt": 2,
+                "acceptance_run_id": 2468,
+                "assets": {name: binding["assets"][name] for name in sorted(names)},
+                "binding_sha256": binding_sha,
+                "checks": checks,
+                "commit": binding["commit"],
+                "platform": platform,
+                "release_id": binding["release"]["id"],
+                "release_run_attempt": binding["release_workflow"]["run_attempt"],
+                "release_run_id": binding["release_workflow"]["run_id"],
+                "repository": binding["repository"],
+                "schema": "arc.published-artifact-acceptance-component.v1",
+                "tag": binding["tag"],
+            }
+            (component_dir / f"{platform}.json").write_text(
+                json.dumps(component), encoding="utf-8"
+            )
+        component_artifacts = self.root / "component-artifacts.json"
+        component_artifacts.write_text(
+            json.dumps(
+                {
+                    "schema": "arc.published-artifact-component-binding.v1",
+                    "repository": self.repository,
+                    "acceptance_run_id": 2468,
+                    "acceptance_run_attempt": 2,
+                    "artifacts": {
+                        platform: {
+                            "name": (
+                                f"arc-published-acceptance-{platform}-2468-attempt-2"
+                            ),
+                            "id": 9000 + index,
+                            "digest": "sha256:" + f"{index + 1:064x}",
+                            "size": 100 + index,
+                            "expired": False,
+                            "workflow_run_id": 2468,
+                            "head_sha": binding["commit"],
+                        }
+                        for index, platform in enumerate(
+                            sorted(acceptance.EXPECTED_COMPONENTS)
+                        )
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        evidence_root = self.root / "evidence"
+        for relative in acceptance.EXPECTED_EVIDENCE_FILES:
+            path = evidence_root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(f"retained evidence: {relative}\n".encode("utf-8"))
+        (evidence_root / "release/release-attempt-jobs.json").write_bytes(
+            self.jobs_output.read_bytes()
+        )
+        (evidence_root / "release/release-published.json").write_bytes(
+            self.published_evidence_output.read_bytes()
+        )
+        (evidence_root / "release/published-evidence.zip").write_bytes(
+            self.published_evidence_zip_output.read_bytes()
+        )
+        (evidence_root / "release/published-evidence-artifact.json").write_bytes(
+            self.published_artifact_output.read_bytes()
+        )
+        evidence_manifest = self.root / "EVIDENCE-MANIFEST.json"
+        acceptance.command_evidence_manifest(
+            Namespace(
+                binding=binding_path,
+                component_artifacts=component_artifacts,
+                evidence_root=evidence_root,
+                acceptance_run_id=2468,
+                acceptance_run_attempt=2,
+                output=evidence_manifest,
+            )
+        )
+        output = self.root / "accepted.json"
+        acceptance.command_aggregate(
+            Namespace(
+                binding=binding_path,
+                component_artifacts=component_artifacts,
+                components=component_dir,
+                evidence_manifest=evidence_manifest,
+                evidence_root=evidence_root,
+                acceptance_run_id=2468,
+                acceptance_run_attempt=2,
+                output=output,
+            )
+        )
+        final = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(final["schema"], "arc.published-artifact-acceptance.v1")
+        self.assertEqual(final["verified_platforms"], sorted(acceptance.EXPECTED_COMPONENTS))
+        self.assertEqual(final["evidence_file_count"], len(acceptance.EXPECTED_EVIDENCE_FILES))
+        self.assertEqual(
+            final["evidence_manifest_sha256"],
+            acceptance.sha256_file(evidence_manifest),
+        )
+
+        identities = json.loads(component_artifacts.read_text(encoding="utf-8"))
+        identities["artifacts"]["macos-arm64"]["digest"] = "sha256:mutable"
+        component_artifacts.write_text(json.dumps(identities), encoding="utf-8")
+        with self.assertRaisesRegex(acceptance.AcceptanceError, "artifact digest"):
+            acceptance.command_aggregate(
+                Namespace(
+                    binding=binding_path,
+                    component_artifacts=component_artifacts,
+                    components=component_dir,
+                    evidence_manifest=evidence_manifest,
+                    evidence_root=evidence_root,
+                    acceptance_run_id=2468,
+                    acceptance_run_attempt=2,
+                    output=output,
+                )
+            )
+        identities["artifacts"]["macos-arm64"]["digest"] = "sha256:" + f"{2:064x}"
+        component_artifacts.write_text(json.dumps(identities), encoding="utf-8")
+
+        linux_path = component_dir / "linux-x86_64.json"
+        linux = json.loads(linux_path.read_text(encoding="utf-8"))
+        linux["checks"]["legacy_history_preserved"] = False
+        linux_path.write_text(json.dumps(linux), encoding="utf-8")
+        with self.assertRaisesRegex(acceptance.AcceptanceError, "legacy_history_preserved"):
+            acceptance.command_aggregate(
+                Namespace(
+                    binding=binding_path,
+                    component_artifacts=component_artifacts,
+                    components=component_dir,
+                    evidence_manifest=evidence_manifest,
+                    evidence_root=evidence_root,
+                    acceptance_run_id=2468,
+                    acceptance_run_attempt=2,
+                    output=output,
+                )
+            )
+
+        linux["checks"]["legacy_history_preserved"] = True
+        linux_path.write_text(json.dumps(linux), encoding="utf-8")
+        evidence_path = evidence_root / "macos-arm64/desktop.stdout"
+        original_evidence = evidence_path.read_bytes()
+        evidence_path.write_bytes(b"tampered after the evidence manifest was sealed")
+        with self.assertRaisesRegex(acceptance.AcceptanceError, "file manifest mismatch"):
+            acceptance.command_aggregate(
+                Namespace(
+                    binding=binding_path,
+                    component_artifacts=component_artifacts,
+                    components=component_dir,
+                    evidence_manifest=evidence_manifest,
+                    evidence_root=evidence_root,
+                    acceptance_run_id=2468,
+                    acceptance_run_attempt=2,
+                    output=output,
+                )
+            )
+
+        evidence_path.write_bytes(original_evidence)
+        symlink = evidence_root / "macos-arm64/unexpected-link"
+        symlink.symlink_to(evidence_path)
+        with self.assertRaisesRegex(acceptance.AcceptanceError, "only regular files"):
+            acceptance.collect_evidence_files(evidence_root)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/release/workflow_attempt_wait_test.sh
+++ b/tests/release/workflow_attempt_wait_test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TEST_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$TEST_DIR/../.." && pwd)"
+HELPER="$REPO_ROOT/scripts/release/wait-workflow-attempt.sh"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/arc-workflow-attempt.XXXXXX")"
+cleanup() {
+    rm -rf -- "$WORKDIR"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$WORKDIR/bin"
+cat > "$WORKDIR/bin/gh" <<'MOCK'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+[ "$1" = api ]
+[ "$2" = repos/FerrumVir/arc-chain/actions/runs/123/attempts/2 ]
+count=0
+[ ! -f "$ARC_TEST_COUNT" ] || count="$(cat "$ARC_TEST_COUNT")"
+count=$((count + 1))
+printf '%s\n' "$count" > "$ARC_TEST_COUNT"
+if [ "$count" -eq 1 ]; then
+  status=in_progress
+  conclusion=null
+else
+  status=completed
+  conclusion='"success"'
+fi
+printf '{"id":123,"run_attempt":2,"workflow_id":9,"path":".github/workflows/release.yml","event":"workflow_dispatch","head_branch":"main","head_sha":"%040d","head_repository":{"full_name":"FerrumVir/arc-chain"},"status":"%s","conclusion":%s}\n' 0 "$status" "$conclusion"
+MOCK
+chmod +x "$WORKDIR/bin/gh"
+
+export ARC_TEST_COUNT="$WORKDIR/count"
+export GH_TOKEN=test-token
+export ARC_WORKFLOW_WAIT_MAX_POLLS=2
+export ARC_WORKFLOW_WAIT_INTERVAL_SECONDS=0
+PATH="$WORKDIR/bin:$PATH" "$HELPER" FerrumVir/arc-chain 123 2 success \
+    > "$WORKDIR/result.json"
+jq -e '.id == 123 and .run_attempt == 2 and .status == "completed"
+  and .conclusion == "success"' "$WORKDIR/result.json" >/dev/null
+[ "$(cat "$ARC_TEST_COUNT")" -eq 2 ]
+
+if PATH="$WORKDIR/bin:$PATH" "$HELPER" FerrumVir/arc-chain 123 1 success \
+    >"$WORKDIR/wrong.out" 2>"$WORKDIR/wrong.err"; then
+    printf 'helper accepted a different attempt than the exact requested endpoint\n' >&2
+    exit 1
+fi
+grep -Fq 'cannot read selected run attempt 123/1' "$WORKDIR/wrong.err"
+
+if grep -Fq 'actions/runs/$RUN_ID"' "$HELPER"; then
+    printf 'helper contains a moving latest-attempt endpoint\n' >&2
+    exit 1
+fi
+
+printf 'exact workflow-attempt wait contract passed\n'


### PR DESCRIPTION
Completes the v0.8.0 production recovery and release-hardening path: exact accepted-worker reward canaries, owner-bound emergency checkpoint authorization, immutable run/attempt/artifact verification, real published-package acceptance on Linux/macOS/Windows, evidence-derived public status, and the executable history-preserving fleet runbook.

Local verification completed:
- cargo fmt and full workspace tests
- clippy with warnings denied
- desktop build plus 221 Playwright tests (4 expected live skips)
- dashboard contracts
- full release/recovery suite including 50 archive, 34 production-manifest, 48 installer, public-truth, owner, release, migration, and workflow adversarial gates
- actionlint and diff checks

The checked-in public state remains maintenance until the immutable release, six-validator cutover, real inference/reward receipts, package acceptance, and Pages proof all pass.