### PR TITLE
Fix macOS pre-tag canary runtime proof

### DIFF
--- a/crates/arc-node/src/main.rs
+++ b/crates/arc-node/src/main.rs
@@ -6805,9 +6805,15 @@ async fn main() -> Result<()> {
         drop(outbound_tx);
         drop(inbound_tx);
         drop(outbound_rx);
-        tracing::warn!(
-            "Chain P2P/consensus is OFF while genesis validator migration is pending; community HTTP inference remains active"
-        );
+        if migration_observer {
+            tracing::warn!(
+                "Chain P2P/consensus is OFF while genesis validator migration is pending; community HTTP inference remains active"
+            );
+        } else {
+            tracing::info!(
+                "Chain P2P/consensus is OFF for this stake-zero community worker; community HTTP inference remains active"
+            );
+        }
     }
 
     // ── Start ETH JSON-RPC server (MetaMask, Hardhat, Foundry) ──────────

--- a/docs/MACOS-PRETAG-COMMUNITY-CANARY.md
+++ b/docs/MACOS-PRETAG-COMMUNITY-CANARY.md
@@ -29,16 +29,14 @@ proof after all large copies and immediately before publishing runnable state.
   executable and full argv have been proved, such a listener also disables the
   label and gracefully quarantines the exact process with `SIGTERM`; it never
   leaves a rejected listener eligible for restart and never force-kills it.
-- The node's authenticated QUIC transport necessarily owns exactly one UDP
-  socket even with `--p2p-port 0`; source semantics bind that OS-assigned port
-  to IPv4 loopback. The proof therefore also requires exactly one
-  `127.0.0.1:<nonzero-ephemeral-port>` UDP socket. Missing, wildcard, external,
-  malformed, or multiple UDP sockets fail closed.
+- A stake-zero community worker has no consensus/P2P role, even with a complete
+  production genesis. The proof therefore requires **zero UDP sockets**. Any
+  UDP socket fails closed; opening an otherwise-unused QUIC transport would
+  contradict the node's role separation rather than prove readiness.
 - The node runs with `--stake 0 --community-mode --full-integer-worker`, no
-  `--peers`, no seeds file, and `--p2p-port 0`. A stake-zero runtime takes no
-  consensus role, and its OS-assigned QUIC socket is loopback-only, so it does
-  not expose an inbound public P2P listener or require a public IP, firewall
-  rule, or port forwarding.
+  `--peers`, no seeds file, and `--p2p-port 0`. It takes no consensus role and
+  opens no QUIC socket, so it does not expose an inbound public P2P listener or
+  require a public IP, firewall rule, or port forwarding.
 - The only community endpoints are six repeated `--community-rpc-url`
   arguments: `https://149.28.32.76`, `https://140.82.16.112`,
   `https://136.244.109.1`, `https://104.238.171.11`,
@@ -79,6 +77,16 @@ proof after all large copies and immediately before publishing runnable state.
   runner defensively unsets the same hook families again before executing the
   hash-proved node. The exact root-owned `/usr/bin/env`, `/bin/sh`, `stat`,
   `shasum`, and `cut` paths are proved before lifecycle operations.
+- `start` recognizes only the same launchd PID moving through the exact
+  `/usr/bin/env` invocation, exact `/bin/sh <managed-runner>` invocation, and
+  final hash-bound node invocation. The env/shell runner and an initializing
+  node must own no TCP or UDP sockets. The final node must own exactly the
+  loopback RPC listener and no UDP sockets. Any argv/executable near miss, PID
+  change, or premature socket fails closed.
+- The proof window is bounded at 300 seconds. This includes re-hashing the 4 GB
+  managed GGUF immediately before `exec`, loading its full integer model, and
+  opening RPC. A trusted phase that does not become ready in that window is
+  disabled and left loaded for review without a signal or bootout.
 - The LaunchAgent is not `RunAtLoad`, has no `KeepAlive`, has no updater, and
   sets `ExitTimeOut=4420`. Before status or shutdown, the controller proves the
   exact launchd PID, executable path and hash, and complete argv.
@@ -86,6 +94,11 @@ proof after all large copies and immediately before publishing runnable state.
   but deliberately leaves the loaded job intact for review. It does not issue
   `bootout` across a racy no-PID observation that could hide a just-starting
   process.
+- If an earlier failed proof left an already-running exact node loaded but its
+  label disabled, a later `start` first repeats the complete PID, executable,
+  argv, hash, TCP, and zero-UDP proof. Only then does it re-enable the label,
+  re-prove the same PID, and append explicit recovery evidence. It never
+  kickstarts or replaces that running process.
 - `stop` disables the label, re-proves the same process, and asks launchd to
   send only the node-supported `SIGTERM`. It waits up to 4,420 seconds for the
   admitted 4,000-second work window and WAL barrier. It never sends a force
@@ -191,8 +204,10 @@ scripts/release/macos-community-canary.py accept
 ```
 
 `start` succeeds only after launchd, `ps`, and `lsof` prove the exact PID,
-executable, hash, size, argv, and sole loopback listener. While it runs, read local status without
-exposing the RPC listener:
+executable, hash, size, argv, sole loopback TCP listener, and absence of UDP.
+It can remain quiet for roughly two minutes while the exact runner hashes the
+managed model and the node loads it; the hard proof deadline is 300 seconds.
+While it runs, read local status without exposing the RPC listener:
 
 ```bash
 curl -fsS http://127.0.0.1:19944/health | python3 -m json.tool

--- a/scripts/release/macos-community-canary.py
+++ b/scripts/release/macos-community-canary.py
@@ -38,7 +38,11 @@ RUST_TARGET = "aarch64-apple-darwin"
 LABEL = "network.arc.pretag-community-canary"
 RPC = "127.0.0.1:19944"
 STOP_BUDGET_SECONDS = 4_420
-START_PROOF_SECONDS = 60
+# The native runner re-hashes the 4 GB GGUF before exec, and the node then loads
+# the complete integer model before opening RPC.  Real Apple Silicon startup has
+# taken about 130 seconds end-to-end, so keep a bounded but practical proof
+# window around both exact, non-networked initialization phases.
+START_PROOF_SECONDS = 300
 CANONICAL_GENESIS_SHA256 = (
     "8394894aaf32aff64df5c6988186e4802cb77a62daf259d8f5cab11d818ed269"
 )
@@ -123,6 +127,10 @@ RUNNER_ENV_UNSET = (
 
 class CanaryError(RuntimeError):
     pass
+
+
+class CanaryUnexpectedSockets(CanaryError):
+    """An exact node opened sockets outside its final canary contract."""
 
 
 def fail(message: str) -> NoReturn:
@@ -2135,60 +2143,173 @@ class CanaryController:
             return False
         return result.stdout.strip() == str(pid)
 
-    def _prove_pid_base_identity(self, config: dict[str, Any], pid: int) -> None:
-        expected_command = " ".join(config["runtime"]["argv"])
+    def _process_command(self, pid: int) -> str:
         command = self.platform.run(
             ("ps", "-ww", "-p", str(pid), "-o", "command=")
         ).stdout.rstrip("\n")
+        if not command or "\n" in command:
+            fail("ps did not return exactly one complete command for the canary PID")
+        return command
+
+    def _pid_identity_snapshot(self, pid: int) -> tuple[str, Path, tuple[str, ...]]:
+        """Read one stable command/executable view across an expected exec edge."""
+
+        for _ in range(3):
+            before = self._process_command(pid)
+            executable_text = self.platform.run(
+                ("ps", "-ww", "-p", str(pid), "-o", "comm=")
+            ).stdout.rstrip("\n")
+            if not executable_text or "\n" in executable_text:
+                fail("ps did not return exactly one executable for the canary PID")
+            executable_path = Path(executable_text)
+            if not executable_path.is_absolute():
+                fail("ps reported a non-absolute executable for the canary PID")
+            try:
+                executable = executable_path.resolve(strict=True)
+            except OSError as error:
+                fail(f"canary PID executable cannot be resolved: {error}")
+            lsof = self.platform.run(
+                ("lsof", "-a", "-p", str(pid), "-d", "txt", "-Fn")
+            ).stdout.splitlines()
+            pid_rows = [line[1:] for line in lsof if line.startswith("p")]
+            if pid_rows != [str(pid)]:
+                fail("lsof executable proof did not bind exactly the canary PID")
+            text_paths = tuple(line[1:] for line in lsof if line.startswith("n"))
+            after = self._process_command(pid)
+            if before == after:
+                return before, executable, text_paths
+        fail("canary PID identity changed repeatedly during startup proof")
+
+    def _prove_snapshot_executable(
+        self,
+        snapshot: tuple[str, Path, tuple[str, ...]],
+        expected: Path,
+        description: str,
+    ) -> None:
+        _, executable, text_paths = snapshot
+        expected_resolved = expected.resolve(strict=True)
+        if executable != expected_resolved:
+            fail(f"canary PID executable differs from the exact {description}")
+        # Darwin may report additional `txt` mappings (for example its logging
+        # plist cache).  `ps comm` identifies the executable; lsof must
+        # independently corroborate that exact path, but unrelated text maps do
+        # not make the executable ambiguous.
+        if str(expected) not in text_paths and str(expected_resolved) not in text_paths:
+            fail(f"lsof did not corroborate the exact {description} executable")
+
+    def _prove_pid_base_identity(self, config: dict[str, Any], pid: int) -> None:
+        expected_command = " ".join(config["runtime"]["argv"])
+        snapshot = self._pid_identity_snapshot(pid)
+        command = snapshot[0]
         if command != expected_command:
             fail("canary PID argv differs from the exact hash-bound runtime argv")
-        lsof = self.platform.run(
-            ("lsof", "-a", "-p", str(pid), "-d", "txt", "-Fn")
-        ).stdout.splitlines()
-        executable_paths = [line[1:] for line in lsof if line.startswith("n")]
-        if len(executable_paths) != 1:
-            fail("lsof did not return exactly one executable for the canary PID")
-        executable = Path(executable_paths[0]).resolve(strict=True)
-        if executable != self.paths.node.resolve(strict=True):
-            fail("canary PID executable differs from the exact preflight node")
+        self._prove_snapshot_executable(snapshot, self.paths.node, "preflight node")
+        executable = snapshot[1]
         node = config["node"]
         metadata = regular_file(executable, "running preflight node")
         if metadata.st_size != node["size_bytes"] or sha256(executable) != node["sha256"]:
             fail("running canary executable failed its exact hash/size proof")
 
-    def _prove_pid_listeners(self, pid: int) -> None:
-        listeners = self.platform.run(
+    def _lsof_socket_names(self, pid: int, *arguments: str) -> list[str]:
+        result = self.platform.run(
             (
                 "lsof",
                 "-nP",
                 "-a",
                 "-p",
                 str(pid),
-                "-iTCP",
-                "-sTCP:LISTEN",
+                *arguments,
                 "-Fn",
-            )
-        ).stdout.splitlines()
-        listener_names = [line[1:] for line in listeners if line.startswith("n")]
+            ),
+            check=False,
+        )
+        if result.returncode == 1 and not result.stdout.strip() and not result.stderr.strip():
+            return []
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic"
+            fail(f"lsof socket proof failed for PID {pid}: {detail}")
+        lines = result.stdout.splitlines()
+        pid_rows = [line[1:] for line in lines if line.startswith("p")]
+        if pid_rows != [str(pid)]:
+            fail("lsof socket proof did not bind exactly the canary PID")
+        return [line[1:] for line in lines if line.startswith("n")]
+
+    def _pid_socket_names(self, pid: int) -> tuple[list[str], list[str]]:
+        return (
+            self._lsof_socket_names(pid, "-iTCP", "-sTCP:LISTEN"),
+            self._lsof_socket_names(pid, "-iUDP"),
+        )
+
+    def _pid_all_network_names(self, pid: int) -> tuple[list[str], list[str]]:
+        return (
+            self._lsof_socket_names(pid, "-iTCP"),
+            self._lsof_socket_names(pid, "-iUDP"),
+        )
+
+    def _prove_pid_listeners(self, pid: int) -> None:
+        listener_names, udp_names = self._pid_socket_names(pid)
         if listener_names != [RPC]:
             fail(
                 "canary TCP listeners differ from the sole loopback RPC contract: "
                 f"{listener_names!r}"
             )
-        udp = self.platform.run(
-            ("lsof", "-nP", "-a", "-p", str(pid), "-iUDP", "-Fn")
-        ).stdout.splitlines()
-        udp_names = [line[1:] for line in udp if line.startswith("n")]
-        match = (
-            re.fullmatch(r"127[.]0[.]0[.]1:([1-9][0-9]{0,4})", udp_names[0])
-            if len(udp_names) == 1
-            else None
-        )
-        if match is None or int(match.group(1)) > 65_535:
+        if udp_names:
             fail(
-                "canary UDP sockets differ from the sole ephemeral loopback "
-                f"QUIC contract: {udp_names!r}"
+                "stake-zero community canary must own no UDP sockets because it "
+                f"has no consensus/P2P role: {udp_names!r}"
             )
+
+    def _classify_start_phase(self, config: dict[str, Any], pid: int) -> str:
+        """Return `runner`, `node-initializing`, or `ready` for one exact PID."""
+
+        final_command = " ".join(config["runtime"]["argv"])
+        launch_arguments = plistlib.loads(plist_bytes(self.paths))["ProgramArguments"]
+        bootstrap = {
+            " ".join(launch_arguments): Path("/usr/bin/env"),
+            f"/bin/sh {self.paths.runner}": Path("/bin/sh"),
+        }
+        for _ in range(3):
+            snapshot = self._pid_identity_snapshot(pid)
+            listener_names = self._lsof_socket_names(pid, "-iTCP", "-sTCP:LISTEN")
+            all_tcp_names, udp_names = self._pid_all_network_names(pid)
+            if self._process_command(pid) != snapshot[0]:
+                # The exact env -> sh -> node chain uses exec and retains this
+                # launchd PID.  Retry a boundary crossed during observation.
+                continue
+            command = snapshot[0]
+            if command == final_command:
+                self._prove_snapshot_executable(snapshot, self.paths.node, "preflight node")
+                executable = snapshot[1]
+                node = config["node"]
+                metadata = regular_file(executable, "running preflight node")
+                if (
+                    metadata.st_size != node["size_bytes"]
+                    or sha256(executable) != node["sha256"]
+                ):
+                    fail("running canary executable failed its exact hash/size proof")
+                if listener_names == [RPC] and not udp_names:
+                    return "ready"
+                if not listener_names and not all_tcp_names and not udp_names:
+                    return "node-initializing"
+                raise CanaryUnexpectedSockets(
+                    "exact canary node opened sockets outside the sole loopback RPC "
+                    "contract before readiness: "
+                    f"tcp_listen={listener_names!r}, tcp_all={all_tcp_names!r}, "
+                    f"udp={udp_names!r}"
+                )
+            expected_executable = bootstrap.get(command)
+            if expected_executable is None:
+                fail("canary PID argv is outside the exact hash-bound startup chain")
+            self._prove_snapshot_executable(
+                snapshot, expected_executable, "hash-bound startup runner"
+            )
+            if all_tcp_names or udp_names:
+                fail(
+                    "hash-bound startup runner unexpectedly owns network sockets: "
+                    f"tcp={all_tcp_names!r}, udp={udp_names!r}"
+                )
+            return "runner"
+        fail("canary PID crossed startup phases too often to prove safely")
 
     def _prove_pid_identity(self, config: dict[str, Any], pid: int) -> None:
         self._prove_pid_base_identity(config, pid)
@@ -2207,38 +2328,73 @@ class CanaryController:
         if self.platform.run(("launchctl", "print", self.domain), check=False).returncode != 0:
             fail(f"interactive launchd domain is unavailable: {self.domain}")
 
+    def _service_disabled(self) -> bool:
+        result = self.platform.run(("launchctl", "print-disabled", self.domain))
+        matches = re.findall(
+            rf'(?m)^\s*"{re.escape(LABEL)}"\s*=>\s*(true|false|disabled|enabled)\s*$',
+            result.stdout,
+        )
+        if len(matches) > 1:
+            fail("launchctl reported more than one disabled-state row for the canary")
+        return bool(matches and matches[0] in {"true", "disabled"})
+
     @lifecycle_transaction
     def start(self) -> None:
         config = self._validate_installation(require_launch_agent=True)
         self._domain_available()
         if self.is_loaded():
             pid = self._prove_process(config)
+            if self._service_disabled():
+                self.platform.run(("launchctl", "enable", self._service_target()))
+                try:
+                    if self._service_disabled():
+                        fail("launchctl left the exact running canary label disabled")
+                    self._prove_process(config, pid)
+                    self._write_evidence(
+                        "start", {"pid": pid, "recovered_loaded_disabled": True}
+                    )
+                except Exception:
+                    # Recovery is not complete until both the post-enable proof
+                    # and its append-only evidence succeed.
+                    self.platform.run(
+                        ("launchctl", "disable", self._service_target()), check=False
+                    )
+                    raise
+                print(
+                    "Recovered loaded-disabled canary after exact PID/exe/argv/"
+                    f"listener proof: pid={pid}"
+                )
+                return
             print(f"Canary is already running with exact PID/exe/argv proof: pid={pid}")
             return
         self.platform.run(("launchctl", "enable", self._service_target()))
+        if self._service_disabled():
+            fail("launchctl did not enable the canary label")
         self.platform.run(
             ("launchctl", "bootstrap", self.domain, str(self.paths.launch_agent))
         )
         self.platform.run(("launchctl", "kickstart", self._service_target()))
+        expected_pid = None
+        last_phase = "waiting-for-pid"
         for _ in range(self.start_proof_seconds):
             pid = self._service_pid()
             if pid is not None:
-                try:
-                    self._prove_pid_base_identity(config, pid)
-                except CanaryError:
-                    # Prevent a restart, but never signal a PID whose identity
-                    # has not been established.
+                if expected_pid is None:
+                    expected_pid = pid
+                elif pid != expected_pid:
                     self.platform.run(
-                        ("launchctl", "disable", self._service_target()),
-                        check=False,
+                        ("launchctl", "disable", self._service_target()), check=False
                     )
-                    raise
+                    fail(
+                        f"canary LaunchAgent PID changed from {expected_pid} to {pid} "
+                        "across an exec-only startup chain"
+                    )
                 try:
-                    self._prove_pid_listeners(pid)
-                except CanaryError:
-                    # The executable and complete argv are exact. Quarantine
-                    # an unexpected listener using SIGTERM only, then preserve
-                    # the original proof failure for the operator.
+                    phase = self._classify_start_phase(config, pid)
+                except CanaryUnexpectedSockets:
+                    # The final executable and complete argv are exact. Quarantine
+                    # an unexpected listener using SIGTERM only, then preserve the
+                    # original proof failure for the operator.
                     self.platform.run(("launchctl", "disable", self._service_target()))
                     self._prove_pid_base_identity(config, pid)
                     self.platform.run(
@@ -2263,20 +2419,52 @@ class CanaryController:
                     if self.is_loaded():
                         fail("failed-start canary remained loaded after graceful quarantine")
                     raise
-                self._write_evidence("start", {"pid": pid})
-                print(f"Started exact pre-tag community canary: pid={pid}, rpc=http://{RPC}")
-                return
+                except CanaryError:
+                    # Prevent a restart, but never signal a PID whose identity
+                    # has not been established.
+                    self.platform.run(
+                        ("launchctl", "disable", self._service_target()),
+                        check=False,
+                    )
+                    raise
+                last_phase = phase
+                if phase == "ready":
+                    self._prove_process(config, pid)
+                    if self._service_disabled():
+                        fail("ready canary label became disabled during startup proof")
+                    self._write_evidence(
+                        "start", {"pid": pid, "recovered_loaded_disabled": False}
+                    )
+                    print(
+                        f"Started exact pre-tag community canary: pid={pid}, "
+                        f"rpc=http://{RPC}"
+                    )
+                    return
             self.platform.sleep(1)
         self.platform.run(
             ("launchctl", "disable", self._service_target()), check=False
         )
         if self.is_loaded():
+            if expected_pid is None:
+                fail(
+                    "LaunchAgent did not produce a provable PID within the bounded "
+                    f"{self.start_proof_seconds}-second proof window; the label is "
+                    "disabled and the job remains loaded for review; "
+                    "bootout was not attempted across a racy no-PID observation"
+                )
+            if expected_pid is not None and self._service_pid() != expected_pid:
+                fail("canary PID changed at the bounded startup timeout")
             fail(
-                "LaunchAgent did not produce a provable PID within 60 seconds; "
+                "LaunchAgent did not become ready within the bounded "
+                f"{self.start_proof_seconds}-second proof window "
+                f"(last exact phase: {last_phase}); "
                 "the label is disabled and the job remains loaded for review; "
-                "bootout was not attempted across a racy no-PID observation"
+                "no signal or bootout was attempted"
             )
-        fail("LaunchAgent did not produce a provable canary PID within 60 seconds")
+        fail(
+            "LaunchAgent did not produce a provable canary PID within the bounded "
+            f"{self.start_proof_seconds}-second proof window"
+        )
 
     @lifecycle_transaction
     def status(self) -> int:

--- a/tests/release/static_contract_test.sh
+++ b/tests/release/static_contract_test.sh
@@ -2711,6 +2711,7 @@ macos_pretag_community_canary_is_exact_private_and_fail_closed() {
     local required origin
     for required in \
         'STOP_BUDGET_SECONDS = 4_420' \
+        'START_PROOF_SECONDS = 300' \
         'CANONICAL_MODEL_SIZE_BYTES = 4_081_004_224' \
         '08a5566d61d7cb6b420c3e4387a39e0078e1f2fe5f055f3a03887385304d4bfa' \
         '8394894aaf32aff64df5c6988186e4802cb77a62daf259d8f5cab11d818ed269' \
@@ -2744,12 +2745,16 @@ macos_pretag_community_canary_is_exact_private_and_fail_closed() {
         '"-i",' \
         'protected canary runner tool is unsafe' \
         '("ps", "-ww", "-p", str(pid), "-o", "command=")' \
+        '("ps", "-ww", "-p", str(pid), "-o", "comm=")' \
         '("lsof", "-a", "-p", str(pid), "-d", "txt", "-Fn")' \
         '"-sTCP:LISTEN"' \
         'listener_names != [RPC]' \
         '"-iUDP"' \
         'udp_names' \
-        'sole ephemeral loopback' \
+        'must own no UDP sockets' \
+        'print-disabled' \
+        'recovered_loaded_disabled' \
+        '_classify_start_phase' \
         'failed-start canary did not exit within the graceful' \
         'bootout was not attempted across a racy no-PID observation' \
         'loaded canary has no provable PID' \

--- a/tests/release/test_macos_community_canary.py
+++ b/tests/release/test_macos_community_canary.py
@@ -49,7 +49,13 @@ class FakePlatform(canary.PlatformCommands):
         self.expected_executable: Path | None = None
         self.reported_command: str | None = None
         self.listener_names = [canary.RPC]
-        self.udp_names = ["127.0.0.1:54321"]
+        self.udp_names: list[str] = []
+        self.extra_text_paths: list[str] = []
+        self.lsof_pid: int | None = None
+        self.empty_socket_rc1 = False
+        self.startup_phases: list[dict[str, object]] | None = None
+        self.startup_phase = 0
+        self.pid_changes_on_sleep: list[int] = []
         self.start_on_kick = True
         self.commands: list[tuple[str, ...]] = []
         self.sleep_calls = 0
@@ -83,6 +89,16 @@ class FakePlatform(canary.PlatformCommands):
                 pid = f"\n    pid = {self.pid}\n" if self.alive else "\n"
                 return completed(args, stdout=f"service = {{{pid}}}\n")
             return completed(args, stdout="domain = { active = true }\n")
+        if args[:2] == ("launchctl", "print-disabled"):
+            state = "disabled" if self.disabled else "enabled"
+            return completed(
+                args,
+                stdout=(
+                    "disabled services = {\n"
+                    f'    "{canary.LABEL}" => {state}\n'
+                    "}\n"
+                ),
+            )
         if args[:2] == ("launchctl", "enable"):
             self.disabled = False
             return completed(args)
@@ -99,6 +115,7 @@ class FakePlatform(canary.PlatformCommands):
             if not self.loaded:
                 return completed(args, 3, stderr="not loaded")
             self.alive = self.start_on_kick
+            self.startup_phase = 0
             return completed(args)
         if args[:2] == ("launchctl", "kill"):
             if args[2] != "SIGTERM" or not self.loaded or not self.alive:
@@ -117,20 +134,46 @@ class FakePlatform(canary.PlatformCommands):
             return completed(args, 1)
         if args[:3] == ("ps", "-ww", "-p") and args[4:] == ("-o", "command="):
             if self.alive and int(args[3]) == self.pid:
-                command = self.reported_command or self.expected_command
+                phase = self._phase()
+                command = self.reported_command or str(
+                    phase.get("command", self.expected_command)
+                )
                 return completed(args, stdout=f"{command}\n")
+            return completed(args, 1)
+        if args[:3] == ("ps", "-ww", "-p") and args[4:] == ("-o", "comm="):
+            if self.alive and int(args[3]) == self.pid:
+                phase = self._phase()
+                executable = phase.get("executable", self.expected_executable)
+                if executable is None:
+                    return completed(args, 1, stderr="no executable")
+                return completed(args, stdout=f"{executable}\n")
             return completed(args, 1)
         if args[:3] == ("lsof", "-nP", "-a"):
             if self.alive:
-                selected = self.udp_names if "-iUDP" in args else self.listener_names
+                phase = self._phase()
+                selected = (
+                    phase.get("udp", self.udp_names)
+                    if "-iUDP" in args
+                    else phase.get("tcp", self.listener_names)
+                )
+                if self.empty_socket_rc1 and not selected:
+                    return completed(args, 1)
                 names = "".join(f"n{value}\n" for value in selected)
                 return completed(args, stdout=f"p{self.pid}\n{names}")
             return completed(args, 1, stderr="no listeners")
         if args[:2] == ("lsof", "-a"):
             if self.alive and self.expected_executable is not None:
+                phase = self._phase()
+                executable = phase.get("executable", self.expected_executable)
+                extras = "".join(
+                    f"ftxt\nn{value}\n" for value in self.extra_text_paths
+                )
                 return completed(
                     args,
-                    stdout=f"p{self.pid}\nftxt\nn{self.expected_executable}\n",
+                    stdout=(
+                        f"p{self.pid if self.lsof_pid is None else self.lsof_pid}\n"
+                        f"ftxt\nn{executable}\n{extras}"
+                    ),
                 )
             return completed(args, 1, stderr="no process")
         if len(args) >= 2 and args[0].endswith("arc-cli-macos-arm64"):
@@ -148,8 +191,17 @@ class FakePlatform(canary.PlatformCommands):
                 return completed(args, stdout="generated public test identity\n")
         return completed(args, 127, stderr="unexpected mock command")
 
+    def _phase(self) -> dict[str, object]:
+        if not self.startup_phases:
+            return {}
+        return self.startup_phases[self.startup_phase]
+
     def sleep(self, seconds: float) -> None:
         self.sleep_calls += 1
+        if self.pid_changes_on_sleep:
+            self.pid = self.pid_changes_on_sleep.pop(0)
+        if self.startup_phases and self.startup_phase + 1 < len(self.startup_phases):
+            self.startup_phase += 1
 
 
 class CanaryFixture:
@@ -396,6 +448,37 @@ class MacosCommunityCanaryTests(unittest.TestCase):
         self.fake.expected_command = " ".join(config["runtime"]["argv"])
         self.fake.expected_executable = self.controller.paths.node
 
+    def exact_startup_phases(self) -> list[dict[str, object]]:
+        launch_arguments = plistlib.loads(
+            self.controller.paths.launch_agent.read_bytes()
+        )["ProgramArguments"]
+        return [
+            {
+                "command": " ".join(launch_arguments),
+                "executable": Path("/usr/bin/env"),
+                "tcp": [],
+                "udp": [],
+            },
+            {
+                "command": f"/bin/sh {self.controller.paths.runner}",
+                "executable": Path("/bin/sh"),
+                "tcp": [],
+                "udp": [],
+            },
+            {
+                "command": self.fake.expected_command,
+                "executable": self.controller.paths.node,
+                "tcp": [],
+                "udp": [],
+            },
+            {
+                "command": self.fake.expected_command,
+                "executable": self.controller.paths.node,
+                "tcp": [canary.RPC],
+                "udp": [],
+            },
+        ]
+
     def live_args(
         self,
         *,
@@ -487,6 +570,176 @@ class MacosCommunityCanaryTests(unittest.TestCase):
         with self.assertRaisesRegex(canary.CanaryError, "validated canary config"):
             self.controller.status()
 
+    def test_start_allows_only_exact_same_pid_env_shell_node_chain(self) -> None:
+        self.install()
+        self.controller.start_proof_seconds = 6
+        self.fake.startup_phases = self.exact_startup_phases()
+        original_pid = self.fake.pid
+        command_count = len(self.fake.commands)
+
+        self.controller.start()
+
+        new_commands = self.fake.commands[command_count:]
+        self.assertEqual(original_pid, self.fake.pid)
+        self.assertEqual(3, self.fake.sleep_calls)
+        self.assertFalse(self.fake.disabled)
+        self.assertTrue(self.fake.loaded)
+        self.assertTrue(self.fake.alive)
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "kill") for args in new_commands)
+        )
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "bootout") for args in new_commands)
+        )
+        start_evidence = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in self.controller.paths.evidence_dir.glob("*-start-*.json")
+        ]
+        self.assertEqual(1, len(start_evidence))
+        self.assertFalse(start_evidence[0]["recovered_loaded_disabled"])
+
+    def test_start_rejects_near_miss_bootstrap_identity_without_signal(self) -> None:
+        self.install()
+        cases = (
+            ("env argv", 0, "command", " --unexpected"),
+            ("shell argv", 1, "command", ".wrong"),
+            ("env executable", 0, "executable", Path("/bin/sh")),
+        )
+        for description, phase_index, field, alteration in cases:
+            with self.subTest(description=description):
+                phases = self.exact_startup_phases()
+                if field == "command":
+                    phases[phase_index][field] = str(phases[phase_index][field]) + str(
+                        alteration
+                    )
+                else:
+                    phases[phase_index][field] = alteration
+                self.fake.startup_phases = [phases[phase_index]]
+                self.fake.loaded = False
+                self.fake.alive = False
+                self.fake.disabled = False
+                command_count = len(self.fake.commands)
+                with self.assertRaises(canary.CanaryError):
+                    self.controller.start()
+                new_commands = self.fake.commands[command_count:]
+                self.assertTrue(self.fake.disabled)
+                self.assertTrue(self.fake.loaded)
+                self.assertTrue(self.fake.alive)
+                self.assertFalse(
+                    any(args[:2] == ("launchctl", "kill") for args in new_commands)
+                )
+                self.assertFalse(
+                    any(args[:2] == ("launchctl", "bootout") for args in new_commands)
+                )
+
+    def test_transient_runner_identity_is_never_accepted_by_status_or_stop(self) -> None:
+        self.install()
+        self.fake.loaded = True
+        self.fake.alive = True
+        self.fake.startup_phases = [self.exact_startup_phases()[1]]
+        with self.assertRaisesRegex(canary.CanaryError, "argv differs"):
+            self.controller.status()
+        with self.assertRaisesRegex(canary.CanaryError, "argv differs"):
+            self.controller.stop()
+        self.assertTrue(self.fake.alive)
+        self.assertFalse(self.fake.disabled)
+
+    def test_exact_runner_timeout_disables_without_signal_bootout_or_start_evidence(self) -> None:
+        self.install()
+        self.fake.startup_phases = [self.exact_startup_phases()[1]]
+        command_count = len(self.fake.commands)
+        with self.assertRaisesRegex(canary.CanaryError, "last exact phase: runner"):
+            self.controller.start()
+        new_commands = self.fake.commands[command_count:]
+        self.assertTrue(self.fake.disabled)
+        self.assertTrue(self.fake.loaded)
+        self.assertTrue(self.fake.alive)
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "kill") for args in new_commands)
+        )
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "bootout") for args in new_commands)
+        )
+        self.assertFalse(
+            any(self.controller.paths.evidence_dir.glob("*-start-*.json"))
+        )
+
+    def test_start_rejects_runner_with_established_tcp_without_signaling(self) -> None:
+        self.install()
+        runner = self.exact_startup_phases()[1]
+        runner["tcp"] = ["127.0.0.1:49152->127.0.0.1:443"]
+        self.fake.startup_phases = [runner]
+        command_count = len(self.fake.commands)
+        with self.assertRaisesRegex(canary.CanaryError, "runner unexpectedly owns"):
+            self.controller.start()
+        new_commands = self.fake.commands[command_count:]
+        self.assertTrue(self.fake.disabled)
+        self.assertTrue(self.fake.loaded)
+        self.assertTrue(self.fake.alive)
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "kill") for args in new_commands)
+        )
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "bootout") for args in new_commands)
+        )
+
+    def test_start_rejects_pid_change_across_exec_only_chain(self) -> None:
+        self.install()
+        self.controller.start_proof_seconds = 4
+        self.fake.startup_phases = self.exact_startup_phases()
+        self.fake.pid_changes_on_sleep = [self.fake.pid + 1]
+        command_count = len(self.fake.commands)
+        with self.assertRaisesRegex(canary.CanaryError, "PID changed"):
+            self.controller.start()
+        new_commands = self.fake.commands[command_count:]
+        self.assertTrue(self.fake.disabled)
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "kill") for args in new_commands)
+        )
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "bootout") for args in new_commands)
+        )
+
+    def test_loaded_disabled_ready_node_is_reenabled_reproved_and_evidenced(self) -> None:
+        self.install()
+        self.fake.loaded = True
+        self.fake.alive = True
+        self.fake.disabled = True
+        command_count = len(self.fake.commands)
+
+        self.controller.start()
+
+        new_commands = self.fake.commands[command_count:]
+        self.assertFalse(self.fake.disabled)
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "kickstart") for args in new_commands)
+        )
+        self.assertIn(
+            ("launchctl", "enable", self.controller._service_target()), new_commands
+        )
+        start_evidence = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in self.controller.paths.evidence_dir.glob("*-start-*.json")
+        ]
+        self.assertEqual(1, len(start_evidence))
+        self.assertTrue(start_evidence[0]["recovered_loaded_disabled"])
+
+    def test_loaded_disabled_recovery_failure_restores_disabled_state(self) -> None:
+        self.install()
+        self.fake.loaded = True
+        self.fake.alive = True
+        self.fake.disabled = True
+        with mock.patch.object(
+            self.controller,
+            "_write_evidence",
+            side_effect=canary.CanaryError("injected evidence failure"),
+        ):
+            with self.assertRaisesRegex(canary.CanaryError, "evidence failure"):
+                self.controller.start()
+        self.assertTrue(self.fake.disabled)
+        self.assertTrue(self.fake.loaded)
+        self.assertTrue(self.fake.alive)
+
     def test_argv_mismatch_fails_before_any_signal_or_disable(self) -> None:
         self.install()
         self.controller.start()
@@ -509,7 +762,7 @@ class MacosCommunityCanaryTests(unittest.TestCase):
         with self.assertRaisesRegex(canary.CanaryError, "sole loopback RPC"):
             self.controller.status()
 
-    def test_udp_socket_proof_rejects_wildcard_multiple_and_malformed(self) -> None:
+    def test_stake_zero_socket_proof_accepts_no_udp_and_rejects_every_udp_socket(self) -> None:
         self.install()
         self.controller.start()
         for udp_names in (
@@ -519,12 +772,34 @@ class MacosCommunityCanaryTests(unittest.TestCase):
             ["127.0.0.1:not-a-port"],
             ["127.0.0.1:0"],
             ["127.0.0.1:65536"],
-            [],
         ):
             with self.subTest(udp_names=udp_names):
                 self.fake.udp_names = udp_names
-                with self.assertRaisesRegex(canary.CanaryError, "loopback QUIC"):
+                with self.assertRaisesRegex(canary.CanaryError, "must own no UDP"):
                     self.controller.status()
+        self.fake.udp_names = []
+        self.assertEqual(0, self.controller.status())
+
+    def test_extra_darwin_txt_mapping_does_not_make_executable_ambiguous(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.extra_text_paths = ["/Library/Preferences/Logging/.plist-cache.test"]
+        self.assertEqual(0, self.controller.status())
+
+    def test_lsof_executable_proof_requires_the_exact_pid_row(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.lsof_pid = self.fake.pid + 1
+        with self.assertRaisesRegex(canary.CanaryError, "bind exactly the canary PID"):
+            self.controller.status()
+
+    def test_lsof_rc1_with_empty_output_means_no_socket_matches(self) -> None:
+        self.install()
+        self.controller.start_proof_seconds = 6
+        self.fake.startup_phases = self.exact_startup_phases()
+        self.fake.empty_socket_rc1 = True
+        self.controller.start()
+        self.assertEqual(0, self.controller.status())
 
     def test_start_quarantines_exact_process_with_external_listener(self) -> None:
         self.install()


### PR DESCRIPTION
## Summary

- admit only the exact same-PID env → shell → node launch chain during the bounded start proof
- require zero network sockets before readiness and zero UDP for stake-zero workers
- prove executables through ps plus lsof while tolerating legitimate macOS text mappings
- recover a loaded-disabled exact node safely and record append-only evidence
- correct stake-zero runtime messaging and update the canary contract documentation

## Verification

- `python3 -m unittest tests.release.test_macos_community_canary` (36/36)
- `bash tests/release/documentation_contract_test.sh` (16/16)
- `bash tests/release/static_contract_test.sh` (39/39)
- `cargo fmt --all -- --check`
- `cargo test -p arc-node --bin arc-node stake_zero_community_worker_off -- --nocapture` (2/2)

This fixes the defect found by the real macOS arm64 pre-tag canary: the original controller rejected launchd’s legitimate long-lived hash/model-loading phases and required a UDP socket that stake-zero role separation intentionally never opens.