### PR TITLE
Harden macOS canary graceful stop proof

### DIFF
--- a/docs/MACOS-PRETAG-COMMUNITY-CANARY.md
+++ b/docs/MACOS-PRETAG-COMMUNITY-CANARY.md
@@ -101,12 +101,31 @@ proof after all large copies and immediately before publishing runnable state.
   kickstarts or replaces that running process.
 - `stop` disables the label, re-proves the same process, and asks launchd to
   send only the node-supported `SIGTERM`. It waits up to 4,420 seconds for the
-  admitted 4,000-second work window and WAL barrier. It never sends a force
-  signal and never boots out a live process.
-- If a loaded job has no exact provable PID, `stop` disables the label and
-  leaves the job loaded for review. It neither signals nor issues `bootout`
-  across that racy no-PID observation; cleanup consequently preserves the
-  LaunchAgent plist as well.
+  admitted 4,000-second work window and WAL barrier. A dedicated drain proof
+  keeps requiring the same launchd PID, executable, hash, and complete argv.
+  Its listening TCP set may be exactly the sole loopback RPC listener or
+  empty, UDP must remain empty, and RPC may never reopen after the first empty
+  observation. Already-established local RPC or outbound HTTPS connections may
+  finish during the bounded drain; no new listener is permitted. Closing RPC
+  is not treated as process death or WAL completion.
+  The controller waits for both launchd ownership and the original PID to
+  disappear, then takes three one-second-apart observations plus a final
+  recheck requiring the exact loaded definition to report `active count = 0`,
+  `state = not running`, and `last exit code = 0` before `bootout`.
+  It never sends a force signal and never boots out a live process.
+- If an enabled loaded job has no exact provable PID, the first `stop` disables
+  it and leaves it loaded for review; it neither signals nor issues `bootout`
+  across that racy observation. A later `stop` can recover only an already
+  disabled, cleanly exited job whose exact path, program, ProgramArguments,
+  working directory, log paths, umask, and launchd definition remain stable.
+  It requires three one-second-apart `active count = 0`,
+  `state = not running`, no-PID observations plus a final recheck, scans the
+  process table for the exact canary env/runner/node commands, revalidates all
+  installed bytes, and requires the normalized definition hash to remain
+  unchanged. Only then does it unregister the inert label without signaling
+  and append explicit recovery evidence. Any PID, process, definition, state,
+  or exit-code change leaves the disabled job loaded for review; cleanup
+  consequently preserves the LaunchAgent plist as well.
 
 Runtime paths must contain no whitespace or shell metacharacters because the
 controller compares macOS `ps` output to one unambiguous complete argv. Move a

--- a/scripts/release/macos-community-canary.py
+++ b/scripts/release/macos-community-canary.py
@@ -38,6 +38,8 @@ RUST_TARGET = "aarch64-apple-darwin"
 LABEL = "network.arc.pretag-community-canary"
 RPC = "127.0.0.1:19944"
 STOP_BUDGET_SECONDS = 4_420
+NO_PID_STABILITY_OBSERVATIONS = 3
+NO_PID_STABILITY_INTERVAL_SECONDS = 1
 # The native runner re-hashes the 4 GB GGUF before exec, and the node then loads
 # the complete integer model before opening RPC.  Real Apple Silicon startup has
 # taken about 130 seconds end-to-end, so keep a bounded but practical proof
@@ -131,6 +133,10 @@ class CanaryError(RuntimeError):
 
 class CanaryUnexpectedSockets(CanaryError):
     """An exact node opened sockets outside its final canary contract."""
+
+
+class CanaryProcessObservationLost(CanaryError):
+    """The admitted process exited between two proof-tool observations."""
 
 
 def fail(message: str) -> NoReturn:
@@ -2123,12 +2129,38 @@ class CanaryController:
             ("launchctl", "print", self._service_target()), check=False
         )
 
+    def _launchctl_service_not_found(
+        self, result: subprocess.CompletedProcess[str]
+    ) -> bool:
+        expected_stderr = (
+            "Bad request.\n"
+            f'Could not find service "{LABEL}" in domain for user gui: {self.uid}\n'
+        )
+        return (
+            result.returncode == 113
+            and result.stdout == ""
+            and result.stderr == expected_stderr
+        )
+
+    def _classify_launchctl_print(
+        self, result: subprocess.CompletedProcess[str]
+    ) -> bool:
+        if result.returncode == 0:
+            return True
+        if self._launchctl_service_not_found(result):
+            return False
+        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic"
+        fail(
+            "launchctl service-state proof returned an unexpected error "
+            f"(rc={result.returncode}): {detail}"
+        )
+
     def is_loaded(self) -> bool:
-        return self._launchctl_print().returncode == 0
+        return self._classify_launchctl_print(self._launchctl_print())
 
     def _service_pid(self) -> int | None:
         result = self._launchctl_print()
-        if result.returncode != 0:
+        if not self._classify_launchctl_print(result):
             return None
         matches = re.findall(r"(?m)^\s*pid = ([1-9][0-9]*)\s*$", result.stdout)
         if len(matches) > 1:
@@ -2139,14 +2171,35 @@ class CanaryController:
         result = self.platform.run(
             ("ps", "-p", str(pid), "-o", "pid="), check=False
         )
-        if result.returncode != 0:
+        if result.returncode == 0:
+            exact_pid_row = re.fullmatch(
+                rf"[ \t]*{pid}[ \t]*\n",
+                result.stdout,
+            )
+            if exact_pid_row is not None and result.stderr == "":
+                return True
+            fail(f"ps returned an ambiguous live-process proof for PID {pid}")
+        if result.returncode == 1 and result.stdout == "" and result.stderr == "":
             return False
-        return result.stdout.strip() == str(pid)
+        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic"
+        fail(
+            "ps process-existence proof returned an unexpected error "
+            f"for PID {pid} (rc={result.returncode}): {detail}"
+        )
 
     def _process_command(self, pid: int) -> str:
-        command = self.platform.run(
-            ("ps", "-ww", "-p", str(pid), "-o", "command=")
-        ).stdout.rstrip("\n")
+        result = self.platform.run(
+            ("ps", "-ww", "-p", str(pid), "-o", "command="),
+            check=False,
+        )
+        if result.returncode != 0:
+            if not self._process_exists(pid):
+                raise CanaryProcessObservationLost(
+                    f"canary PID {pid} exited during command proof"
+                )
+            detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic"
+            fail(f"ps command proof failed for live canary PID {pid}: {detail}")
+        command = result.stdout.rstrip("\n")
         if not command or "\n" in command:
             fail("ps did not return exactly one complete command for the canary PID")
         return command
@@ -2156,9 +2209,22 @@ class CanaryController:
 
         for _ in range(3):
             before = self._process_command(pid)
-            executable_text = self.platform.run(
-                ("ps", "-ww", "-p", str(pid), "-o", "comm=")
-            ).stdout.rstrip("\n")
+            executable_result = self.platform.run(
+                ("ps", "-ww", "-p", str(pid), "-o", "comm="),
+                check=False,
+            )
+            if executable_result.returncode != 0:
+                if not self._process_exists(pid):
+                    raise CanaryProcessObservationLost(
+                        f"canary PID {pid} exited during executable proof"
+                    )
+                detail = (
+                    executable_result.stderr.strip()
+                    or executable_result.stdout.strip()
+                    or "no diagnostic"
+                )
+                fail(f"ps executable proof failed for live canary PID {pid}: {detail}")
+            executable_text = executable_result.stdout.rstrip("\n")
             if not executable_text or "\n" in executable_text:
                 fail("ps did not return exactly one executable for the canary PID")
             executable_path = Path(executable_text)
@@ -2168,9 +2234,18 @@ class CanaryController:
                 executable = executable_path.resolve(strict=True)
             except OSError as error:
                 fail(f"canary PID executable cannot be resolved: {error}")
-            lsof = self.platform.run(
-                ("lsof", "-a", "-p", str(pid), "-d", "txt", "-Fn")
-            ).stdout.splitlines()
+            lsof_result = self.platform.run(
+                ("lsof", "-a", "-p", str(pid), "-d", "txt", "-Fn"),
+                check=False,
+            )
+            if lsof_result.returncode != 0:
+                if not self._process_exists(pid):
+                    raise CanaryProcessObservationLost(
+                        f"canary PID {pid} exited during lsof executable proof"
+                    )
+                detail = lsof_result.stderr.strip() or lsof_result.stdout.strip() or "no diagnostic"
+                fail(f"lsof executable proof failed for live canary PID {pid}: {detail}")
+            lsof = lsof_result.stdout.splitlines()
             pid_rows = [line[1:] for line in lsof if line.startswith("p")]
             if pid_rows != [str(pid)]:
                 fail("lsof executable proof did not bind exactly the canary PID")
@@ -2315,6 +2390,40 @@ class CanaryController:
         self._prove_pid_base_identity(config, pid)
         self._prove_pid_listeners(pid)
 
+    def _prove_pid_graceful_drain(
+        self,
+        config: dict[str, Any],
+        pid: int,
+        *,
+        rpc_listener_closed: bool,
+    ) -> bool:
+        """Prove one exact, monotonic network state after SIGTERM.
+
+        A proved ready node may retain its sole RPC listener briefly while it
+        drains admitted work.  Once that listener closes, it may never reopen;
+        already-established TCP connections may finish, while UDP remains
+        forbidden.  The executable, complete argv, hash, and launchd PID are
+        re-proved by the caller on every live observation.
+        """
+
+        self._prove_pid_base_identity(config, pid)
+        listener_names, udp_names = self._pid_socket_names(pid)
+        if udp_names:
+            fail(
+                "gracefully draining stake-zero canary must own no UDP sockets: "
+                f"{udp_names!r}"
+            )
+        if listener_names == [RPC]:
+            if rpc_listener_closed:
+                fail("gracefully draining canary reopened its loopback RPC listener")
+            return False
+        if listener_names:
+            fail(
+                "gracefully draining canary TCP listeners are outside the exact "
+                f"RPC-to-zero transition: {listener_names!r}"
+            )
+        return True
+
     def _prove_process(self, config: dict[str, Any], expected_pid: int | None = None) -> int:
         pid = self._service_pid()
         if pid is None:
@@ -2337,6 +2446,155 @@ class CanaryController:
         if len(matches) > 1:
             fail("launchctl reported more than one disabled-state row for the canary")
         return bool(matches and matches[0] in {"true", "disabled"})
+
+    @staticmethod
+    def _launchctl_single_field(output: str, field: str) -> str:
+        matches = re.findall(
+            rf"(?m)^\s*{re.escape(field)} = ([^\n]+?)\s*$",
+            output,
+        )
+        if len(matches) != 1:
+            fail(f"launchctl did not report exactly one {field!r} field")
+        return matches[0]
+
+    @staticmethod
+    def _launchctl_arguments(output: str) -> list[str]:
+        lines = output.splitlines()
+        starts = [index for index, line in enumerate(lines) if line.strip() == "arguments = {"]
+        if len(starts) != 1:
+            fail("launchctl did not report exactly one arguments definition")
+        values: list[str] = []
+        for line in lines[starts[0] + 1 :]:
+            value = line.strip()
+            if value == "}":
+                return values
+            if not value:
+                fail("launchctl reported a blank ProgramArguments entry")
+            values.append(value)
+        fail("launchctl arguments definition is unterminated")
+
+    def _matching_managed_process_pids(self, config: dict[str, Any]) -> list[int]:
+        launch_arguments = plistlib.loads(plist_bytes(self.paths))["ProgramArguments"]
+        exact_commands = {
+            " ".join(launch_arguments),
+            f"/bin/sh {self.paths.runner}",
+            " ".join(config["runtime"]["argv"]),
+        }
+        result = self.platform.run(("ps", "-ww", "-axo", "pid=,command="))
+        matches: list[int] = []
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            parsed = re.fullmatch(r"\s*([1-9][0-9]*)\s+(\S(?:.*\S)?)\s*", line)
+            if parsed is None:
+                fail("ps process-table proof returned a malformed row")
+            if parsed.group(2) in exact_commands:
+                matches.append(int(parsed.group(1)))
+        return sorted(matches)
+
+    def _prove_loaded_disabled_no_process_snapshot(self, config: dict[str, Any]) -> str:
+        """Prove one exact loaded definition has no launchd-owned process."""
+
+        result = self._launchctl_print()
+        if result.returncode != 0:
+            fail("loaded-disabled canary disappeared during no-PID recovery proof")
+        if not self._service_disabled():
+            fail("loaded canary became enabled during no-PID recovery proof")
+        output = result.stdout
+        header = output.splitlines()[0].strip() if output.splitlines() else ""
+        if header != f"{self._service_target()} = {{":
+            fail("launchctl loaded definition has an unexpected service target")
+        pid_rows = re.findall(r"(?m)^\s*pid = ([1-9][0-9]*)\s*$", output)
+        if pid_rows:
+            fail("canary PID appeared during loaded-disabled no-PID recovery proof")
+        expected_arguments = plistlib.loads(plist_bytes(self.paths))["ProgramArguments"]
+        definition = {
+            "active_count": self._launchctl_single_field(output, "active count"),
+            "path": self._launchctl_single_field(output, "path"),
+            "type": self._launchctl_single_field(output, "type"),
+            "state": self._launchctl_single_field(output, "state"),
+            "program": self._launchctl_single_field(output, "program"),
+            "arguments": self._launchctl_arguments(output),
+            "working_directory": self._launchctl_single_field(output, "working directory"),
+            "stdout_path": self._launchctl_single_field(output, "stdout path"),
+            "stderr_path": self._launchctl_single_field(output, "stderr path"),
+            "umask": self._launchctl_single_field(output, "umask"),
+            "runs": self._launchctl_single_field(output, "runs"),
+            "last_exit_code": self._launchctl_single_field(output, "last exit code"),
+            "properties": self._launchctl_single_field(output, "properties"),
+        }
+        expected_definition = {
+            "active_count": "0",
+            "path": str(self.paths.launch_agent),
+            "type": "LaunchAgent",
+            "state": "not running",
+            "program": "/usr/bin/env",
+            "arguments": expected_arguments,
+            "working_directory": str(self.paths.root),
+            "stdout_path": str(self.paths.log),
+            "stderr_path": str(self.paths.log),
+            "umask": "77",
+            "last_exit_code": "0",
+            "properties": "inferred program",
+        }
+        if {key: definition[key] for key in expected_definition} != expected_definition:
+            fail(
+                "loaded-disabled canary launchd definition/process state differs "
+                "from the exact clean-exit contract"
+            )
+        if not definition["runs"].isdigit() or int(definition["runs"]) < 1:
+            fail("loaded-disabled canary has no successful prior launchd run")
+        matching_pids = self._matching_managed_process_pids(config)
+        if matching_pids:
+            fail(
+                "loaded-disabled canary still has matching runner/node processes: "
+                f"{matching_pids!r}"
+            )
+        return sha256_bytes(canonical_json(definition))
+
+    def _prove_stable_loaded_disabled_no_pid(
+        self, config: dict[str, Any]
+    ) -> tuple[str, int]:
+        """Return the stable exact launchd definition hash and observation count."""
+
+        snapshots: list[str] = []
+        for observation in range(NO_PID_STABILITY_OBSERVATIONS):
+            snapshots.append(self._prove_loaded_disabled_no_process_snapshot(config))
+            if observation + 1 < NO_PID_STABILITY_OBSERVATIONS:
+                self.platform.sleep(NO_PID_STABILITY_INTERVAL_SECONDS)
+        # Re-prove every immutable on-disk input and then the complete service
+        # condition immediately before bootout.  The disabled label cannot
+        # launch a new instance, and bootout therefore only unregisters the
+        # stably inert job.
+        self._validate_installation(require_launch_agent=True)
+        snapshots.append(self._prove_loaded_disabled_no_process_snapshot(config))
+        if len(set(snapshots)) != 1:
+            fail("loaded-disabled canary definition changed during stable idle proof")
+        return snapshots[-1], len(snapshots)
+
+    def _recover_loaded_disabled_no_pid(self, config: dict[str, Any]) -> None:
+        """Unregister one stably inert disabled label without sending a signal."""
+
+        snapshot_sha256, observation_count = (
+            self._prove_stable_loaded_disabled_no_pid(config)
+        )
+        self.platform.run(("launchctl", "bootout", self._service_target()))
+        if self.is_loaded():
+            fail("stably inert canary LaunchAgent remained loaded after bootout")
+        self._write_evidence(
+            "stop",
+            {
+                "pid": None,
+                "signal_sent": False,
+                "recovered_loaded_disabled_no_pid": True,
+                "stable_no_pid_observations": observation_count,
+                "service_snapshot_sha256": snapshot_sha256,
+            },
+        )
+        print(
+            "Recovered stably inert loaded-disabled canary and unregistered it; "
+            "no signal was sent."
+        )
 
     @lifecycle_transaction
     def start(self) -> None:
@@ -2396,6 +2654,8 @@ class CanaryController:
                     # an unexpected listener using SIGTERM only, then preserve the
                     # original proof failure for the operator.
                     self.platform.run(("launchctl", "disable", self._service_target()))
+                    if not self._service_disabled():
+                        fail("launchctl did not disable the rejected canary label")
                     self._prove_pid_base_identity(config, pid)
                     self.platform.run(
                         ("launchctl", "kill", "SIGTERM", self._service_target())
@@ -2531,17 +2791,25 @@ class CanaryController:
             fail("refusing to control a loaded canary without its exact LaunchAgent plist")
         pid = self._service_pid()
         if pid is None:
-            self.platform.run(("launchctl", "disable", self._service_target()))
-            if self._service_pid() is not None:
-                fail("canary PID appeared after the label was disabled")
-            fail(
-                "loaded canary has no provable PID; the label is disabled and "
-                "the job remains loaded for review; bootout was not attempted "
-                "across a racy no-PID observation"
-            )
+            if not self._service_disabled():
+                self.platform.run(("launchctl", "disable", self._service_target()))
+                if not self._service_disabled():
+                    fail("launchctl did not disable the no-PID canary label")
+                if self._service_pid() is not None:
+                    fail("canary PID appeared after the label was disabled")
+                fail(
+                    "loaded canary has no provable PID; it was newly disabled and "
+                    "remains loaded for review; repeat stop only after the disabled "
+                    "no-process state can be proved stable"
+                )
+            self._recover_loaded_disabled_no_pid(config)
+            return
 
         pid = self._prove_process(config, pid)
         self.platform.run(("launchctl", "disable", self._service_target()))
+        if not self._service_disabled():
+            fail("launchctl did not disable the canary label before graceful stop")
+        signal_sent = False
         current = self._service_pid()
         if current is None:
             if self._process_exists(pid):
@@ -2551,6 +2819,8 @@ class CanaryController:
             self.platform.run(
                 ("launchctl", "kill", "SIGTERM", self._service_target())
             )
+            signal_sent = True
+            rpc_listener_closed = False
             for _ in range(self.stop_budget_seconds):
                 current = self._service_pid()
                 alive = self._process_exists(pid)
@@ -2559,7 +2829,23 @@ class CanaryController:
                 if current is not None and current != pid:
                     fail("canary PID changed during graceful SIGTERM drain")
                 if alive:
-                    self._prove_pid_identity(config, pid)
+                    if current is None:
+                        fail(
+                            "launchd lost ownership while the exact canary PID "
+                            "remained alive during graceful drain"
+                        )
+                    try:
+                        rpc_listener_closed = self._prove_pid_graceful_drain(
+                            config,
+                            pid,
+                            rpc_listener_closed=rpc_listener_closed,
+                        )
+                    except CanaryProcessObservationLost:
+                        # Exiting between ps/lsof reads is an allowed terminal
+                        # edge only when both launchd and ps now prove death.
+                        if self._service_pid() is None and not self._process_exists(pid):
+                            break
+                        raise
                 self.platform.sleep(1)
             else:
                 fail(
@@ -2568,11 +2854,28 @@ class CanaryController:
                 )
         if self._service_pid() is not None or self._process_exists(pid):
             fail("canary death is not proven after graceful SIGTERM")
+        stopped_snapshot_sha256, stopped_observation_count = (
+            self._prove_stable_loaded_disabled_no_pid(config)
+        )
         self.platform.run(("launchctl", "bootout", self._service_target()))
         if self.is_loaded():
             fail("canary LaunchAgent remained loaded after proven process death")
-        self._write_evidence("stop", {"pid": pid, "signal": "SIGTERM"})
-        print(f"Stopped exact canary PID {pid} gracefully; no force signal was used.")
+        self._write_evidence(
+            "stop",
+            {
+                "pid": pid,
+                "signal": "SIGTERM" if signal_sent else None,
+                "signal_sent": signal_sent,
+                "recovered_loaded_disabled_no_pid": False,
+                "stable_no_pid_observations": stopped_observation_count,
+                "service_snapshot_sha256": stopped_snapshot_sha256,
+            },
+        )
+        signal_summary = "SIGTERM sent" if signal_sent else "process exited before SIGTERM"
+        print(
+            f"Stopped exact canary PID {pid} gracefully ({signal_summary}); "
+            "no force signal was used."
+        )
 
     @lifecycle_transaction
     def cleanup(self) -> None:

--- a/tests/release/static_contract_test.sh
+++ b/tests/release/static_contract_test.sh
@@ -2712,6 +2712,8 @@ macos_pretag_community_canary_is_exact_private_and_fail_closed() {
     for required in \
         'STOP_BUDGET_SECONDS = 4_420' \
         'START_PROOF_SECONDS = 300' \
+        'NO_PID_STABILITY_OBSERVATIONS = 3' \
+        'NO_PID_STABILITY_INTERVAL_SECONDS = 1' \
         'CANONICAL_MODEL_SIZE_BYTES = 4_081_004_224' \
         '08a5566d61d7cb6b420c3e4387a39e0078e1f2fe5f055f3a03887385304d4bfa' \
         '8394894aaf32aff64df5c6988186e4802cb77a62daf259d8f5cab11d818ed269' \
@@ -2746,6 +2748,8 @@ macos_pretag_community_canary_is_exact_private_and_fail_closed() {
         'protected canary runner tool is unsafe' \
         '("ps", "-ww", "-p", str(pid), "-o", "command=")' \
         '("ps", "-ww", "-p", str(pid), "-o", "comm=")' \
+        'result.returncode == 1 and result.stdout == "" and result.stderr == ""' \
+        'ps process-existence proof returned an unexpected error' \
         '("lsof", "-a", "-p", str(pid), "-d", "txt", "-Fn")' \
         '"-sTCP:LISTEN"' \
         'listener_names != [RPC]' \
@@ -2753,8 +2757,21 @@ macos_pretag_community_canary_is_exact_private_and_fail_closed() {
         'udp_names' \
         'must own no UDP sockets' \
         'print-disabled' \
+        'result.returncode == 113' \
+        'Could not find service' \
+        '_classify_launchctl_print' \
         'recovered_loaded_disabled' \
         '_classify_start_phase' \
+        '_prove_pid_graceful_drain' \
+        'listener_names == [RPC]' \
+        'rpc_listener_closed' \
+        'gracefully draining canary reopened its loopback RPC listener' \
+        '("ps", "-ww", "-axo", "pid=,command=")' \
+        'active count' \
+        'last exit code' \
+        'recovered_loaded_disabled_no_pid' \
+        'stable_no_pid_observations' \
+        'service_snapshot_sha256' \
         'failed-start canary did not exit within the graceful' \
         'bootout was not attempted across a racy no-PID observation' \
         'loaded canary has no provable PID' \
@@ -2811,6 +2828,9 @@ macos_pretag_community_canary_is_exact_private_and_fail_closed() {
         'no seeds file' \
         '`--peers`' \
         'never sends a force' \
+        'not treated as process death or WAL completion.' \
+        'three one-second-apart' \
+        'unregister the inert label without signaling' \
         'delete the GGUF, dedicated key, chain data' \
         'raw exact-ID GitHub'
     do

--- a/tests/release/test_macos_community_canary.py
+++ b/tests/release/test_macos_community_canary.py
@@ -43,13 +43,20 @@ class FakePlatform(canary.PlatformCommands):
         self.loaded = False
         self.alive = False
         self.disabled = False
+        self.disable_takes_effect = True
         self.exit_on_term = True
         self.pid = 4242
         self.expected_command = ""
         self.expected_executable: Path | None = None
         self.reported_command: str | None = None
+        self.drain_reported_command: str | None = None
+        self.drain_executable: Path | None = None
         self.listener_names = [canary.RPC]
+        self.all_tcp_names: list[str] | None = None
         self.udp_names: list[str] = []
+        self.drain_listener_names: list[str] | None = None
+        self.drain_all_tcp_names: list[str] | None = None
+        self.drain_udp_names: list[str] | None = None
         self.extra_text_paths: list[str] = []
         self.lsof_pid: int | None = None
         self.empty_socket_rc1 = False
@@ -57,6 +64,22 @@ class FakePlatform(canary.PlatformCommands):
         self.startup_phase = 0
         self.pid_changes_on_sleep: list[int] = []
         self.start_on_kick = True
+        self.term_sent = False
+        self.exit_after_term_sleeps: int | None = None
+        self.term_sleep_calls = 0
+        self.orphan_processes: dict[int, str] = {}
+        self.ps_missing_returncode = 1
+        self.ps_missing_stdout = ""
+        self.ps_missing_stderr = ""
+        self.launch_agent_path: Path | None = None
+        self.working_directory: Path | None = None
+        self.log_path: Path | None = None
+        self.launch_arguments: list[str] = []
+        self.launch_runs = 1
+        self.launch_last_exit_code = 0
+        self.launch_properties = "inferred program"
+        self.unloaded_print_returncode = 113
+        self.unloaded_print_stderr: str | None = None
         self.commands: list[tuple[str, ...]] = []
         self.sleep_calls = 0
         self.public_address = "b" * 64
@@ -85,9 +108,45 @@ class FakePlatform(canary.PlatformCommands):
             target = args[2]
             if target.endswith(f"/{canary.LABEL}"):
                 if not self.loaded:
-                    return completed(args, 113, stderr="service not found")
-                pid = f"\n    pid = {self.pid}\n" if self.alive else "\n"
-                return completed(args, stdout=f"service = {{{pid}}}\n")
+                    stderr = self.unloaded_print_stderr or (
+                        "Bad request.\n"
+                        f'Could not find service "{canary.LABEL}" in domain for '
+                        f"user gui: {self.uid}\n"
+                    )
+                    return completed(
+                        args,
+                        self.unloaded_print_returncode,
+                        stderr=stderr,
+                    )
+                active_count = 1 if self.alive else 0
+                state = "running" if self.alive else "not running"
+                pid = f"    pid = {self.pid}\n" if self.alive else ""
+                arguments = "".join(
+                    f"        {value}\n" for value in self.launch_arguments
+                )
+                return completed(
+                    args,
+                    stdout=(
+                        f"{target} = {{\n"
+                        f"    active count = {active_count}\n"
+                        f"    path = {self.launch_agent_path}\n"
+                        "    type = LaunchAgent\n"
+                        f"    state = {state}\n"
+                        "    program = /usr/bin/env\n"
+                        "    arguments = {\n"
+                        f"{arguments}"
+                        "    }\n"
+                        f"    working directory = {self.working_directory}\n"
+                        f"    stdout path = {self.log_path}\n"
+                        f"    stderr path = {self.log_path}\n"
+                        "    umask = 77\n"
+                        f"    runs = {self.launch_runs}\n"
+                        f"    last exit code = {self.launch_last_exit_code}\n"
+                        f"    properties = {self.launch_properties}\n"
+                        f"{pid}"
+                        "}\n"
+                    ),
+                )
             return completed(args, stdout="domain = { active = true }\n")
         if args[:2] == ("launchctl", "print-disabled"):
             state = "disabled" if self.disabled else "enabled"
@@ -103,7 +162,8 @@ class FakePlatform(canary.PlatformCommands):
             self.disabled = False
             return completed(args)
         if args[:2] == ("launchctl", "disable"):
-            self.disabled = True
+            if self.disable_takes_effect:
+                self.disabled = True
             return completed(args)
         if args[:2] == ("launchctl", "bootstrap"):
             if self.loaded:
@@ -122,6 +182,8 @@ class FakePlatform(canary.PlatformCommands):
                 return completed(args, 3, stderr="bad signal target")
             if self.exit_on_term:
                 self.alive = False
+            self.term_sent = True
+            self.term_sleep_calls = 0
             return completed(args)
         if args[:2] == ("launchctl", "bootout"):
             if self.alive:
@@ -130,20 +192,42 @@ class FakePlatform(canary.PlatformCommands):
             return completed(args)
         if args[:2] == ("ps", "-p") and args[3:] == ("-o", "pid="):
             if self.alive and int(args[2]) == self.pid:
-                return completed(args, stdout=f"{self.pid}\n")
-            return completed(args, 1)
+                return completed(args, stdout=f"{self.pid:5d}\n")
+            return completed(
+                args,
+                self.ps_missing_returncode,
+                stdout=self.ps_missing_stdout,
+                stderr=self.ps_missing_stderr,
+            )
+        if args == ("ps", "-ww", "-axo", "pid=,command="):
+            rows = dict(self.orphan_processes)
+            if self.alive:
+                rows[self.pid] = self.reported_command or str(
+                    self._phase().get("command", self.expected_command)
+                )
+            return completed(
+                args,
+                stdout="".join(f"{pid:6d} {command}\n" for pid, command in sorted(rows.items())),
+            )
         if args[:3] == ("ps", "-ww", "-p") and args[4:] == ("-o", "command="):
             if self.alive and int(args[3]) == self.pid:
                 phase = self._phase()
-                command = self.reported_command or str(
-                    phase.get("command", self.expected_command)
+                command = (
+                    self.drain_reported_command
+                    if self.term_sent and self.drain_reported_command is not None
+                    else self.reported_command
+                    or str(phase.get("command", self.expected_command))
                 )
                 return completed(args, stdout=f"{command}\n")
             return completed(args, 1)
         if args[:3] == ("ps", "-ww", "-p") and args[4:] == ("-o", "comm="):
             if self.alive and int(args[3]) == self.pid:
                 phase = self._phase()
-                executable = phase.get("executable", self.expected_executable)
+                executable = (
+                    self.drain_executable
+                    if self.term_sent and self.drain_executable is not None
+                    else phase.get("executable", self.expected_executable)
+                )
                 if executable is None:
                     return completed(args, 1, stderr="no executable")
                 return completed(args, stdout=f"{executable}\n")
@@ -151,11 +235,29 @@ class FakePlatform(canary.PlatformCommands):
         if args[:3] == ("lsof", "-nP", "-a"):
             if self.alive:
                 phase = self._phase()
-                selected = (
-                    phase.get("udp", self.udp_names)
-                    if "-iUDP" in args
-                    else phase.get("tcp", self.listener_names)
-                )
+                if "-iUDP" in args:
+                    selected = (
+                        self.drain_udp_names
+                        if self.term_sent and self.drain_udp_names is not None
+                        else phase.get("udp", self.udp_names)
+                    )
+                elif "-sTCP:LISTEN" in args:
+                    selected = (
+                        self.drain_listener_names
+                        if self.term_sent and self.drain_listener_names is not None
+                        else phase.get("tcp", self.listener_names)
+                    )
+                else:
+                    selected = (
+                        self.drain_all_tcp_names
+                        if self.term_sent and self.drain_all_tcp_names is not None
+                        else phase.get(
+                            "all_tcp",
+                            self.all_tcp_names
+                            if self.all_tcp_names is not None
+                            else phase.get("tcp", self.listener_names),
+                        )
+                    )
                 if self.empty_socket_rc1 and not selected:
                     return completed(args, 1)
                 names = "".join(f"n{value}\n" for value in selected)
@@ -164,7 +266,11 @@ class FakePlatform(canary.PlatformCommands):
         if args[:2] == ("lsof", "-a"):
             if self.alive and self.expected_executable is not None:
                 phase = self._phase()
-                executable = phase.get("executable", self.expected_executable)
+                executable = (
+                    self.drain_executable
+                    if self.term_sent and self.drain_executable is not None
+                    else phase.get("executable", self.expected_executable)
+                )
                 extras = "".join(
                     f"ftxt\nn{value}\n" for value in self.extra_text_paths
                 )
@@ -198,6 +304,10 @@ class FakePlatform(canary.PlatformCommands):
 
     def sleep(self, seconds: float) -> None:
         self.sleep_calls += 1
+        if self.term_sent:
+            self.term_sleep_calls += 1
+            if self.exit_after_term_sleeps == self.term_sleep_calls:
+                self.alive = False
         if self.pid_changes_on_sleep:
             self.pid = self.pid_changes_on_sleep.pop(0)
         if self.startup_phases and self.startup_phase + 1 < len(self.startup_phases):
@@ -447,6 +557,12 @@ class MacosCommunityCanaryTests(unittest.TestCase):
         config = self.controller._load_config()
         self.fake.expected_command = " ".join(config["runtime"]["argv"])
         self.fake.expected_executable = self.controller.paths.node
+        self.fake.launch_agent_path = self.controller.paths.launch_agent
+        self.fake.working_directory = self.controller.paths.root
+        self.fake.log_path = self.controller.paths.log
+        self.fake.launch_arguments = plistlib.loads(
+            self.controller.paths.launch_agent.read_bytes()
+        )["ProgramArguments"]
 
     def exact_startup_phases(self) -> list[dict[str, object]]:
         launch_arguments = plistlib.loads(
@@ -850,6 +966,378 @@ class MacosCommunityCanaryTests(unittest.TestCase):
             any(args[:2] == ("launchctl", "kill") for args in new_commands)
         )
         self.assertFalse(any("SIGKILL" in part for args in new_commands for part in args))
+
+    def test_stop_allows_exact_rpc_to_zero_socket_drain_before_clean_exit(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.exit_on_term = False
+        self.fake.drain_listener_names = []
+        self.fake.drain_all_tcp_names = [
+            "127.0.0.1:53123->149.28.32.76:443"
+        ]
+        self.fake.drain_udp_names = []
+        self.fake.exit_after_term_sleeps = 1
+        command_count = len(self.fake.commands)
+
+        self.controller.stop()
+
+        new_commands = self.fake.commands[command_count:]
+        self.assertFalse(self.fake.loaded)
+        self.assertFalse(self.fake.alive)
+        self.assertIn(
+            ("launchctl", "kill", "SIGTERM", self.controller._service_target()),
+            new_commands,
+        )
+        self.assertIn(
+            ("launchctl", "bootout", self.controller._service_target()),
+            new_commands,
+        )
+        evidence = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in self.controller.paths.evidence_dir.glob("*-stop-*.json")
+        ]
+        self.assertEqual(1, len(evidence))
+        self.assertFalse(evidence[0]["recovered_loaded_disabled_no_pid"])
+        self.assertRegex(evidence[0]["service_snapshot_sha256"], r"^[0-9a-f]{64}$")
+
+    def test_graceful_drain_rejects_additional_tcp_listener(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.exit_on_term = False
+        self.fake.drain_listener_names = [canary.RPC, "*:19945"]
+        self.fake.drain_all_tcp_names = [
+            canary.RPC,
+            "*:19945",
+        ]
+        command_count = len(self.fake.commands)
+
+        with self.assertRaisesRegex(canary.CanaryError, "RPC-to-zero transition"):
+            self.controller.stop()
+
+        new_commands = self.fake.commands[command_count:]
+        self.assertTrue(self.fake.loaded)
+        self.assertTrue(self.fake.alive)
+        self.assertTrue(self.fake.disabled)
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "bootout") for args in new_commands)
+        )
+
+    def test_graceful_drain_rejects_udp_socket(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.exit_on_term = False
+        self.fake.drain_listener_names = []
+        self.fake.drain_all_tcp_names = []
+        self.fake.drain_udp_names = ["127.0.0.1:55331"]
+
+        with self.assertRaisesRegex(canary.CanaryError, "must own no UDP"):
+            self.controller.stop()
+
+        self.assertTrue(self.fake.loaded)
+        self.assertTrue(self.fake.alive)
+        self.assertTrue(self.fake.disabled)
+
+    def test_graceful_drain_rejects_rpc_reopen_after_zero_socket_state(self) -> None:
+        self.install()
+        self.controller.start()
+        config = self.controller._load_config()
+        self.fake.term_sent = True
+        self.fake.drain_listener_names = []
+        self.fake.drain_all_tcp_names = []
+        closed = self.controller._prove_pid_graceful_drain(
+            config,
+            self.fake.pid,
+            rpc_listener_closed=False,
+        )
+        self.assertTrue(closed)
+        self.fake.drain_listener_names = [canary.RPC]
+        self.fake.drain_all_tcp_names = [canary.RPC]
+        with self.assertRaisesRegex(canary.CanaryError, "reopened"):
+            self.controller._prove_pid_graceful_drain(
+                config,
+                self.fake.pid,
+                rpc_listener_closed=closed,
+            )
+
+    def test_graceful_drain_rejects_argv_or_pid_change_without_bootout(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.exit_on_term = False
+        self.fake.drain_listener_names = []
+        self.fake.drain_all_tcp_names = []
+        self.fake.drain_reported_command = "/tmp/not-the-canary --stake 0"
+        command_count = len(self.fake.commands)
+        with self.assertRaisesRegex(canary.CanaryError, "argv differs"):
+            self.controller.stop()
+        self.assertTrue(self.fake.loaded)
+        self.assertTrue(self.fake.alive)
+        self.assertTrue(self.fake.disabled)
+        self.assertFalse(
+            any(
+                args[:2] == ("launchctl", "bootout")
+                for args in self.fake.commands[command_count:]
+            )
+        )
+
+    def test_graceful_drain_rejects_executable_change(self) -> None:
+        self.install()
+        self.controller.start()
+        config = self.controller._load_config()
+        self.fake.term_sent = True
+        self.fake.drain_listener_names = []
+        self.fake.drain_executable = Path("/bin/sh")
+
+        with self.assertRaisesRegex(canary.CanaryError, "executable differs"):
+            self.controller._prove_pid_graceful_drain(
+                config,
+                self.fake.pid,
+                rpc_listener_closed=False,
+            )
+
+    def test_graceful_drain_rejects_launchd_pid_change(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.exit_on_term = False
+        self.fake.drain_listener_names = []
+        self.fake.drain_all_tcp_names = []
+        self.fake.pid_changes_on_sleep = [self.fake.pid + 1]
+        command_count = len(self.fake.commands)
+
+        with self.assertRaisesRegex(canary.CanaryError, "PID changed"):
+            self.controller.stop()
+
+        self.assertTrue(self.fake.loaded)
+        self.assertTrue(self.fake.disabled)
+        self.assertFalse(
+            any(
+                args[:2] == ("launchctl", "bootout")
+                for args in self.fake.commands[command_count:]
+            )
+        )
+
+    def test_graceful_drain_requires_clean_launchd_exit_before_bootout(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.launch_last_exit_code = 9
+        command_count = len(self.fake.commands)
+
+        with self.assertRaisesRegex(canary.CanaryError, "clean-exit contract"):
+            self.controller.stop()
+
+        new_commands = self.fake.commands[command_count:]
+        self.assertTrue(self.fake.loaded)
+        self.assertFalse(self.fake.alive)
+        self.assertTrue(self.fake.disabled)
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "bootout") for args in new_commands)
+        )
+        self.assertFalse(
+            any(self.controller.paths.evidence_dir.glob("*-stop-*.json"))
+        )
+
+    def test_post_bootout_unexpected_launchctl_error_cannot_seal_stop(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.unloaded_print_returncode = 1
+        self.fake.unloaded_print_stderr = "operation not permitted\n"
+
+        with self.assertRaisesRegex(canary.CanaryError, "unexpected error"):
+            self.controller.stop()
+
+        self.assertFalse(self.fake.loaded)
+        self.assertFalse(
+            any(self.controller.paths.evidence_dir.glob("*-stop-*.json"))
+        )
+
+    def test_unexpected_ps_absence_error_cannot_bootout_or_seal_stop(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.ps_missing_returncode = 2
+        self.fake.ps_missing_stderr = "operation not permitted\n"
+        command_count = len(self.fake.commands)
+
+        with self.assertRaisesRegex(canary.CanaryError, "process-existence proof"):
+            self.controller.stop()
+
+        new_commands = self.fake.commands[command_count:]
+        self.assertTrue(self.fake.loaded)
+        self.assertFalse(self.fake.alive)
+        self.assertTrue(self.fake.disabled)
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "bootout") for args in new_commands)
+        )
+        self.assertFalse(
+            any(self.controller.paths.evidence_dir.glob("*-stop-*.json"))
+        )
+
+    def test_malformed_ps_live_result_cannot_bootout_or_seal_stop(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.ps_missing_returncode = 0
+        self.fake.ps_missing_stdout = "9999\n"
+        command_count = len(self.fake.commands)
+
+        with self.assertRaisesRegex(canary.CanaryError, "ambiguous live-process"):
+            self.controller.stop()
+
+        new_commands = self.fake.commands[command_count:]
+        self.assertTrue(self.fake.loaded)
+        self.assertFalse(self.fake.alive)
+        self.assertTrue(self.fake.disabled)
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "bootout") for args in new_commands)
+        )
+        self.assertFalse(
+            any(self.controller.paths.evidence_dir.glob("*-stop-*.json"))
+        )
+
+    def test_process_exists_accepts_one_native_padded_exact_pid_row(self) -> None:
+        self.fake.pid = 1
+        self.fake.alive = True
+        self.assertTrue(self.controller._process_exists(1))
+        self.fake.alive = False
+        self.assertFalse(self.controller._process_exists(1))
+
+    def test_only_exact_launchctl_missing_service_result_means_unloaded(self) -> None:
+        self.install()
+        self.fake.loaded = False
+        self.assertFalse(self.controller.is_loaded())
+        for returncode, stderr in (
+            (1, "operation not permitted\n"),
+            (113, "service not found\n"),
+            (
+                113,
+                "Bad request.\n"
+                f'Could not find service "{canary.LABEL}" in domain for user gui: 999\n',
+            ),
+        ):
+            with self.subTest(returncode=returncode, stderr=stderr):
+                self.fake.unloaded_print_returncode = returncode
+                self.fake.unloaded_print_stderr = stderr
+                with self.assertRaisesRegex(canary.CanaryError, "unexpected error"):
+                    self.controller._service_pid()
+
+    def test_stop_requires_disable_to_take_effect_before_sigterm(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.disable_takes_effect = False
+        command_count = len(self.fake.commands)
+
+        with self.assertRaisesRegex(canary.CanaryError, "before graceful stop"):
+            self.controller.stop()
+
+        new_commands = self.fake.commands[command_count:]
+        self.assertTrue(self.fake.loaded)
+        self.assertTrue(self.fake.alive)
+        self.assertFalse(self.fake.disabled)
+        self.assertFalse(any(args[:2] == ("launchctl", "kill") for args in new_commands))
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "bootout") for args in new_commands)
+        )
+
+    def test_loaded_disabled_clean_no_pid_recovery_is_stable_and_signal_free(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.disabled = True
+        self.fake.alive = False
+        command_count = len(self.fake.commands)
+
+        self.controller.stop()
+
+        new_commands = self.fake.commands[command_count:]
+        self.assertFalse(self.fake.loaded)
+        self.assertFalse(any(args[:2] == ("launchctl", "kill") for args in new_commands))
+        self.assertFalse(any(args[:2] == ("launchctl", "enable") for args in new_commands))
+        self.assertFalse(any(args[:2] == ("launchctl", "kickstart") for args in new_commands))
+        self.assertIn(
+            ("launchctl", "bootout", self.controller._service_target()),
+            new_commands,
+        )
+        evidence = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in self.controller.paths.evidence_dir.glob("*-stop-*.json")
+        ]
+        self.assertEqual(1, len(evidence))
+        self.assertTrue(evidence[0]["recovered_loaded_disabled_no_pid"])
+        self.assertFalse(evidence[0]["signal_sent"])
+        self.assertEqual(
+            canary.NO_PID_STABILITY_OBSERVATIONS + 1,
+            evidence[0]["stable_no_pid_observations"],
+        )
+
+    def test_loaded_disabled_no_pid_recovery_rejects_definition_change(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.disabled = True
+        self.fake.alive = False
+        original_sleep = self.fake.sleep
+
+        def mutate_definition(seconds: float) -> None:
+            original_sleep(seconds)
+            self.fake.launch_runs += 1
+
+        command_count = len(self.fake.commands)
+        with mock.patch.object(self.fake, "sleep", side_effect=mutate_definition):
+            with self.assertRaisesRegex(canary.CanaryError, "definition changed"):
+                self.controller.stop()
+        self.assertTrue(self.fake.loaded)
+        self.assertFalse(
+            any(
+                args[:2] == ("launchctl", "bootout")
+                for args in self.fake.commands[command_count:]
+            )
+        )
+
+    def test_loaded_disabled_no_pid_recovery_rejects_matching_orphan_process(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.disabled = True
+        self.fake.alive = False
+        self.fake.orphan_processes[9999] = self.fake.expected_command
+
+        with self.assertRaisesRegex(canary.CanaryError, "matching runner/node"):
+            self.controller.stop()
+
+        self.assertTrue(self.fake.loaded)
+        self.assertFalse(
+            any(args[:2] == ("launchctl", "bootout") for args in self.fake.commands)
+        )
+
+    def test_loaded_disabled_no_pid_recovery_aborts_if_pid_appears(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.disabled = True
+        self.fake.alive = False
+        original_sleep = self.fake.sleep
+
+        def revive_process(seconds: float) -> None:
+            original_sleep(seconds)
+            self.fake.alive = True
+
+        command_count = len(self.fake.commands)
+        with mock.patch.object(self.fake, "sleep", side_effect=revive_process):
+            with self.assertRaisesRegex(canary.CanaryError, "PID appeared"):
+                self.controller.stop()
+        self.assertTrue(self.fake.loaded)
+        self.assertTrue(self.fake.alive)
+        self.assertFalse(
+            any(
+                args[:2] == ("launchctl", "bootout")
+                for args in self.fake.commands[command_count:]
+            )
+        )
+
+    def test_loaded_disabled_no_pid_recovery_rejects_nonzero_exit(self) -> None:
+        self.install()
+        self.controller.start()
+        self.fake.disabled = True
+        self.fake.alive = False
+        self.fake.launch_last_exit_code = 1
+
+        with self.assertRaisesRegex(canary.CanaryError, "clean-exit contract"):
+            self.controller.stop()
+
+        self.assertTrue(self.fake.loaded)
 
     def test_graceful_timeout_never_escalates_or_boots_out_live_process(self) -> None:
         self.install()


### PR DESCRIPTION
## Summary

- accept the real one-way RPC listener close that occurs before a clean WAL/process exit
- preserve exact launchd PID, executable hash, full argv, no-UDP, and no-extra-listener proofs during bounded graceful drain
- recover only a repeatedly stable loaded+disabled/no-PID job with an exact definition and clean exit, without sending any signal
- distinguish exact macOS service/PID absence from transient or permission errors before sealing evidence
- document and regression-test shutdown, recovery, ambiguity, and race cases

## Why

The native macOS pre-tag canary proved startup/status, then correctly received SIGTERM and closed its RPC listener while finishing shutdown. The prior controller incorrectly required the ready listener throughout the drain and failed before it could record the subsequently clean exit. The label was preserved disabled and loaded for fail-closed recovery.

## Verification

- `python3 -m unittest tests.release.test_macos_community_canary` — 55/55
- `bash tests/release/static_contract_test.sh` — 39/39
- `bash tests/release/documentation_contract_test.sh` — 16/16
- `python3 -m py_compile scripts/release/macos-community-canary.py`
- `git diff --check`
- independent security review: approved
- actual stranded label: four-observation read-only recovery proof passed; no live mutation

Production validators remain untouched; release preflight was cancelled before environment approval/secrets when this race was observed.