### PR TITLE
Fix signing-backup verifier key-comment canonicalization

### DIFF
--- a/scripts/release/verify-signing-key-backup.sh
+++ b/scripts/release/verify-signing-key-backup.sh
@@ -12,6 +12,29 @@ die() {
     exit 1
 }
 
+# OpenSSH preserves an optional private-key comment in `ssh-keygen -y`
+# output. Comments are metadata rather than key identity, so compare the
+# validated algorithm and key blob only. Keep this parser identical to the
+# protected preflight policy: exactly one Ed25519 record, with either no
+# comment or the provisioned manifest-key comment, is accepted.
+canonicalize_manifest_public_key() {
+    local input_path="$1"
+    local output_path="$2"
+    awk '
+        BEGIN { valid = 0 }
+        NR != 1 { exit 1 }
+        {
+            if (NF != 2 && NF != 3) exit 1
+            if ($1 != "ssh-ed25519") exit 1
+            if ($2 !~ /^[A-Za-z0-9+\/]+={0,2}$/) exit 1
+            if (NF == 3 && $3 != "arc-release-manifest-v1") exit 1
+            print $1 " " $2
+            valid = 1
+        }
+        END { if (NR != 1 || valid != 1) exit 1 }
+    ' "$input_path" > "$output_path"
+}
+
 [ "$#" -eq 3 ] || die 'usage: verify-signing-key-backup.sh /absolute/backup.tar.gpg EXPECTED_MAIN_SHA EXPECTED_CIPHERTEXT_SHA256'
 BACKUP="$1"
 EXPECTED_MAIN_SHA="$2"
@@ -132,11 +155,21 @@ tar -xf "$WORK_DIR/signing-keys.tar" -C "$WORK_DIR/restored" \
 
 ssh-keygen -y -f "$WORK_DIR/restored/release-manifest-ed25519" \
     > "$WORK_DIR/derived-manifest.pub"
-cmp -s "$WORK_DIR/derived-manifest.pub" "$WORK_DIR/restored/release-manifest-ed25519.pub" \
+canonicalize_manifest_public_key \
+    "$WORK_DIR/derived-manifest.pub" "$WORK_DIR/derived-manifest.canonical" \
+    || die 'restored manifest private key emitted an invalid public-key record'
+canonicalize_manifest_public_key \
+    "$WORK_DIR/restored/release-manifest-ed25519.pub" \
+    "$WORK_DIR/restored-manifest.canonical" \
+    || die 'restored manifest public key is invalid'
+cmp -s "$WORK_DIR/derived-manifest.canonical" "$WORK_DIR/restored-manifest.canonical" \
     || die 'restored manifest private and public keys disagree'
 awk '{print $3 " " $4}' "$REPO_ROOT/release/arc-release-allowed-signers" \
     > "$WORK_DIR/allowed-manifest.pub"
-cmp -s "$WORK_DIR/derived-manifest.pub" "$WORK_DIR/allowed-manifest.pub" \
+canonicalize_manifest_public_key \
+    "$WORK_DIR/allowed-manifest.pub" "$WORK_DIR/allowed-manifest.canonical" \
+    || die 'committed release trust root is invalid'
+cmp -s "$WORK_DIR/derived-manifest.canonical" "$WORK_DIR/allowed-manifest.canonical" \
     || die 'restored manifest key does not match the committed release trust root'
 
 printf '%s\n' 'ARC downloaded-backup manifest canary v1' > "$WORK_DIR/manifest-canary"

--- a/tests/release/signing_key_backup_behavior_test.sh
+++ b/tests/release/signing_key_backup_behavior_test.sh
@@ -34,6 +34,69 @@ new_fixture() {
     NEW_FIXTURE="$fixture"
 }
 
+canonicalize_with_verifier() {
+    local input_path="$1"
+    local output_path="$2"
+    local function_source
+    function_source="$(sed -n \
+        '/^canonicalize_manifest_public_key() {$/,/^}$/p' \
+        "$VERIFY_SCRIPT")"
+    [ -n "$function_source" ] || {
+        printf 'manifest public-key canonicalizer is unavailable\n'
+        return 1
+    }
+    {
+        printf '%s\n' "$function_source"
+        printf '%s\n' 'canonicalize_manifest_public_key "$1" "$2"'
+    } | /bin/bash -s -- "$input_path" "$output_path"
+}
+
+manifest_public_key_comments_do_not_change_identity() {
+    local fixture commented_key no_comment_key commented_raw uncommented_raw
+    local no_comment_raw unexpected_comment_raw commented_canonical
+    local uncommented_canonical no_comment_canonical
+    new_fixture
+    fixture="$NEW_FIXTURE"
+    commented_key="$fixture/commented-manifest-key"
+    no_comment_key="$fixture/no-comment-manifest-key"
+    commented_raw="$fixture/commented.pub"
+    uncommented_raw="$fixture/uncommented.pub"
+    no_comment_raw="$fixture/no-comment.pub"
+    unexpected_comment_raw="$fixture/unexpected-comment.pub"
+    commented_canonical="$fixture/commented.canonical"
+    uncommented_canonical="$fixture/uncommented.canonical"
+    no_comment_canonical="$fixture/no-comment.canonical"
+
+    ssh-keygen -q -t ed25519 -N '' \
+        -C 'arc-release-manifest-v1' -f "$commented_key"
+    ssh-keygen -q -t ed25519 -N '' -C '' -f "$no_comment_key"
+    ssh-keygen -y -f "$commented_key" > "$commented_raw"
+    awk '{print $1 " " $2}' "$commented_raw" > "$uncommented_raw"
+    awk '{print $1 " " $2 " unexpected-comment"}' "$commented_raw" \
+        > "$unexpected_comment_raw"
+    ssh-keygen -y -f "$no_comment_key" > "$no_comment_raw"
+
+    canonicalize_with_verifier "$commented_raw" "$commented_canonical" \
+        || return 1
+    canonicalize_with_verifier "$uncommented_raw" "$uncommented_canonical" \
+        || return 1
+    canonicalize_with_verifier "$no_comment_raw" "$no_comment_canonical" \
+        || return 1
+    cmp -s "$commented_canonical" "$uncommented_canonical" || {
+        printf 'public-key comment changed the canonical key identity\n'
+        return 1
+    }
+    if cmp -s "$commented_canonical" "$no_comment_canonical"; then
+        printf 'different manifest keys collapsed to one canonical identity\n'
+        return 1
+    fi
+    if canonicalize_with_verifier \
+        "$unexpected_comment_raw" "$fixture/unexpected-comment.canonical"; then
+        printf 'unexpected manifest key comment passed strict canonicalization\n'
+        return 1
+    fi
+}
+
 encrypted_backup_round_trips_and_cleans_plaintext() {
     local fixture output restored members expected leftovers
     new_fixture
@@ -138,6 +201,8 @@ inherited_xtrace_never_discloses_passphrase() {
 
 run_test 'encrypted signing-key backup round-trips and removes plaintext workdirs' \
     encrypted_backup_round_trips_and_cleans_plaintext
+run_test 'manifest key comments are ignored without weakening key identity' \
+    manifest_public_key_comments_do_not_change_identity
 run_test 'wrong passphrase and truncated ciphertext fail closed' \
     wrong_passphrase_and_truncation_fail_closed
 run_test 'existing ciphertext is create-only and never replaced' \

--- a/tests/release/static_contract_test.sh
+++ b/tests/release/static_contract_test.sh
@@ -2309,6 +2309,7 @@ signing_key_backup_is_encrypted_create_only_and_restore_tested() {
         'decrypted archive membership differs from the four-file contract' \
         'shasum -a 256 -c KEY-SHA256SUMS' \
         'release/arc-release-allowed-signers' \
+        'canonicalize_manifest_public_key' \
         'awk '\''{print $3 " " $4}'\'' "$REPO_ROOT/release/arc-release-allowed-signers"' \
         'EXPECTED_CIPHERTEXT_SHA256' \
         'git -C "$REPO_ROOT" diff --quiet "$EXPECTED_MAIN_SHA"' \


### PR DESCRIPTION
## Summary
- canonicalize restored and allowed manifest public keys to Ed25519 algorithm + key blob before identity comparison
- retain the same strict optional-comment policy as the protected preflight
- add regression coverage for provisioned comments, no-comment keys, unexpected comments, and distinct-key mismatch

## Root cause
`ssh-keygen -y` preserves the private key comment. The verifier raw-compared that commented output to a two-field allowed key, producing a false trust-root mismatch even when the algorithm and key blob matched.

## Verification
- `bash tests/release/run.sh`
- `bash tests/release/signing_key_backup_behavior_test.sh` (5/5)
- `bash tests/release/static_contract_test.sh` (39/39)
- `shellcheck -S warning` on all changed shell files
- `bash -n` on all changed shell files
- `git diff --check`

No trust root or GitHub secret is changed.