### PR TITLE
Harden archive sentinel cleanup during group drain

### DIFF
--- a/scripts/recovery/archive-fleet-to-drive.sh
+++ b/scripts/recovery/archive-fleet-to-drive.sh
@@ -12855,6 +12855,15 @@ archive_terminate_guardian_job() {
     return 0
 }
 
+archive_sentinel_atomic_move() {
+    # The guardian drains the phase group that also contains this sentinel. It
+    # excludes the sentinel shell itself, but an external mv is a separate group
+    # member and can be killed during escalation. Drain-time callers put this
+    # helper in an explicit failure-tolerant list and rely on their existing
+    # receipt handshakes to retry or fail closed.
+    /bin/mv -f "$1" "$2"
+}
+
 archive_dispatch_sentinel() {
     local supervisor_pid="$1" phase_pid="$2" gate="$3" phase_pgid="$4" stop_token="$5"
     local fifo="$gate/sentinel.fifo" request_token request_verb request_argument
@@ -12897,8 +12906,9 @@ archive_dispatch_sentinel() {
                     if builtin kill -s "$request_argument" -- "-$sentinel_pgid" 2>/dev/null; then
                         (umask 077; printf '%s\n' "$stop_token" \
                             > "$gate/signal.$request_argument.ack.partial") && \
-                            /bin/mv -f "$gate/signal.$request_argument.ack.partial" \
-                                "$gate/signal.$request_argument.ack"
+                            archive_sentinel_atomic_move \
+                                "$gate/signal.$request_argument.ack.partial" \
+                                "$gate/signal.$request_argument.ack" || true
                     fi
                     ;;
                 ARM:)
@@ -12918,8 +12928,8 @@ archive_dispatch_sentinel() {
             if [ "$request_verb" = FINALIZE ]; then
                 (umask 077; printf '%s\n' "$stop_token" \
                     > "$gate/sentinel.finalize.ack.partial") && \
-                    /bin/mv -f "$gate/sentinel.finalize.ack.partial" \
-                        "$gate/sentinel.finalize.ack"
+                    archive_sentinel_atomic_move "$gate/sentinel.finalize.ack.partial" \
+                        "$gate/sentinel.finalize.ack" || true
             fi
         fi
 
@@ -13062,7 +13072,8 @@ archive_dispatch_sentinel() {
             [ -f "$gate/watchdog.ready" ] && [ ! -L "$gate/watchdog.ready" ]; then
             (umask 077; printf '%s\t%s\n' "$watchdog_pid" "$stop_token" \
                 > "$gate/guardian.finalize.partial") && \
-                /bin/mv -f "$gate/guardian.finalize.partial" "$gate/guardian.finalize"
+                archive_sentinel_atomic_move "$gate/guardian.finalize.partial" \
+                    "$gate/guardian.finalize" || true
         fi
     done
 }

--- a/tests/release/fixtures/archive_dispatch_signal_probe.sh
+++ b/tests/release/fixtures/archive_dispatch_signal_probe.sh
@@ -123,3 +123,20 @@ if [ "${ARC_SIGNAL_GATE_REMOVE_FAIL_ONCE:-false}" = true ]; then
         [ ! -e "$gate" ] && [ ! -L "$gate" ]
     }
 fi
+
+if [ "${ARC_SIGNAL_SENTINEL_MOVE_FAIL_ONCE:-false}" = true ]; then
+    # Model the guardian killing the sentinel's external mv child during
+    # escalation. The sentinel shell must survive the 137 and retry through the
+    # existing FINALIZE handshake instead of abandoning the credential gate.
+    archive_sentinel_atomic_move() {
+        local source="$1" destination="$2"
+        if [ "${ARC_SIGNAL_SENTINEL_MOVE_HAS_FAILED:-false}" = false ] && \
+            [ "${destination##*/}" = sentinel.finalize.ack ]; then
+            ARC_SIGNAL_SENTINEL_MOVE_HAS_FAILED=true
+            (umask 077; printf 'injected move exit 137\n' \
+                > "$ARC_SIGNAL_CASE_DIR/sentinel-move-failed-once")
+            return 137
+        fi
+        /bin/mv -f "$source" "$destination"
+    }
+fi

--- a/tests/release/recovery_archive_contract_test.sh
+++ b/tests/release/recovery_archive_contract_test.sh
@@ -2685,6 +2685,8 @@ command = [
     'overrides=capture_phase; '
     '[ "${ARC_SIGNAL_GATE_REMOVE_FAIL_ONCE:-false}" = true ] && '
     'overrides="capture_phase archive_remove_dispatch_gate"; '
+    '[ "${ARC_SIGNAL_SENTINEL_MOVE_FAIL_ONCE:-false}" = true ] && '
+    'overrides="$overrides archive_sentinel_atomic_move"; '
     'export ARC_ARCHIVE_DISPATCH_TEST_OVERRIDE_NAMES="$overrides"; '
     'dispatch_archive_command capture_phase',
     "archive-dispatch-signal-test", str(orchestrator), str(probe),
@@ -2692,23 +2694,24 @@ command = [
 signals = (("HUP", signal.SIGHUP, 129), ("INT", signal.SIGINT, 130),
            ("TERM", signal.SIGTERM, 143))
 cases = [
-    (f"{label}_STRESS_{index:02d}", sent, status, False, False, 0, False)
+    (f"{label}_STRESS_{index:02d}", sent, status, False, False, 0, False, False)
     for index in range(50)
     for label, sent, status in (signals[index % len(signals)],)
 ]
 cases.extend((
-    ("HUP_IGNORING_CHILD", signal.SIGHUP, 129, True, False, 0, False),
-    ("INT_IGNORING_CHILD", signal.SIGINT, 130, True, False, 0, False),
-    ("TERM_IGNORING_CHILD", signal.SIGTERM, 143, True, False, 0, False),
-    ("TERM_RESURRECTING_CHILD", signal.SIGTERM, 143, False, True, 0, False),
-    ("TERM_SLOW_EXIT_CLEANUP", signal.SIGTERM, 143, False, False, 10, False),
-    ("TERM_GATE_SWEEP_RETRY", signal.SIGTERM, 143, False, False, 0, True),
-    ("KILL", signal.SIGKILL, 137, False, False, 0, False),
+    ("HUP_IGNORING_CHILD", signal.SIGHUP, 129, True, False, 0, False, False),
+    ("INT_IGNORING_CHILD", signal.SIGINT, 130, True, False, 0, False, False),
+    ("TERM_IGNORING_CHILD", signal.SIGTERM, 143, True, False, 0, False, False),
+    ("TERM_RESURRECTING_CHILD", signal.SIGTERM, 143, False, True, 0, False, False),
+    ("TERM_SLOW_EXIT_CLEANUP", signal.SIGTERM, 143, False, False, 10, False, False),
+    ("TERM_GATE_SWEEP_RETRY", signal.SIGTERM, 143, False, False, 0, True, False),
+    ("TERM_SENTINEL_MOVE_RETRY", signal.SIGTERM, 143, False, False, 0, False, True),
+    ("KILL", signal.SIGKILL, 137, False, False, 0, False, False),
 ))
 
 fast_teardowns = []
 for (name, sent_signal, expected_status, child_ignores, child_resurrects,
-     cleanup_delay, gate_remove_fails) in cases:
+     cleanup_delay, gate_remove_fails, sentinel_move_fails) in cases:
     case = fixture / name.lower()
     runtime = case / "runtime"
     case.mkdir(mode=0o700)
@@ -2724,6 +2727,7 @@ for (name, sent_signal, expected_status, child_ignores, child_resurrects,
         "ARC_SIGNAL_BACKGROUND_RESURRECTS": "true" if child_resurrects else "false",
         "ARC_SIGNAL_CLEANUP_DELAY_SECONDS": str(cleanup_delay),
         "ARC_SIGNAL_GATE_REMOVE_FAIL_ONCE": "true" if gate_remove_fails else "false",
+        "ARC_SIGNAL_SENTINEL_MOVE_FAIL_ONCE": "true" if sentinel_move_fails else "false",
     })
     stdout_path = case / "supervisor.stdout"
     stderr_path = case / "supervisor.stderr"
@@ -2872,6 +2876,8 @@ for (name, sent_signal, expected_status, child_ignores, child_resurrects,
                 if "FATAL guardian retaining and retrying private dispatch gate" not in \
                         stderr_path.read_text(encoding="utf-8"):
                     raise AssertionError(f"{name} cleanup handoff failure was not loud")
+            if sentinel_move_fails and not (case / "sentinel-move-failed-once").is_file():
+                raise AssertionError(f"{name} did not inject the sentinel move failure")
             if (not child_ignores and not child_resurrects and not cleanup_delay
                     and name != "KILL" and not cleanup.is_file()):
                 time.sleep(0.2)

--- a/tests/release/recovery_archive_contract_test.sh
+++ b/tests/release/recovery_archive_contract_test.sh
@@ -2820,7 +2820,7 @@ for (name, sent_signal, expected_status, child_ignores, child_resurrects,
                 raw_status = process.wait(timeout=wait_budget)
             except subprocess.TimeoutExpired as error:
                 # Name the case AND say where it is stuck. A bare
-                # TimeoutExpired traceback gives no clue which of the 57 cases
+                # TimeoutExpired traceback gives no clue which of the 58 cases
                 # hung, nor why, which is most of the debugging.
                 diagnosis = [f"{name} did not exit within {wait_budget}s of {sent_signal}"]
                 try:

--- a/tests/release/static_contract_test.sh
+++ b/tests/release/static_contract_test.sh
@@ -2627,6 +2627,24 @@ sentinel_body = text[
     text.index("archive_dispatch_sentinel() {"):
     text.index("archive_dispatch_parent_watchdog() {")
 ]
+sentinel_move_body = text[
+    text.index("archive_sentinel_atomic_move() {"):
+    text.index("archive_dispatch_sentinel() {")
+]
+if '/bin/mv -f "$1" "$2"' not in sentinel_move_body:
+    raise SystemExit("sentinel atomic publication no longer uses the fixed mv path")
+normalized_sentinel = " ".join(sentinel_body.replace("\\\n", " ").split())
+# The guardian may kill an external mv child in the phase group while preserving
+# the sentinel shell itself. Each publication that can overlap that drain must
+# tolerate the child failure; its existing receipt handshake retries or retains
+# the private gate fail closed.
+for required in (
+    'archive_sentinel_atomic_move "$gate/signal.$request_argument.ack.partial" "$gate/signal.$request_argument.ack" || true',
+    'archive_sentinel_atomic_move "$gate/sentinel.finalize.ack.partial" "$gate/sentinel.finalize.ack" || true',
+    'archive_sentinel_atomic_move "$gate/guardian.finalize.partial" "$gate/guardian.finalize" || true',
+):
+    if required not in normalized_sentinel:
+        raise SystemExit(f"sentinel drain-time publication can abort its sweeper: {required}")
 # REGRESSION GUARD (credential leak). The sentinel runs inside phase_pgid, so
 # any call it makes to archive_process_group_has_members_except forks a /bin/ps
 # child INTO the very group being counted; that child is not in the exclusion


### PR DESCRIPTION
## Why

Under heavy TERM contention, the archive guardian can drain the sentinel process group while the sentinel is publishing a receipt through an external mv child. If that mv is killed, inherited errexit can terminate the sentinel before it removes its private credential-bearing gate.

## Fix

- route the three drain-time atomic publications through an explicit helper
- tolerate only those publication failures, whose receipt handshakes already retry or fail closed
- add a deterministic one-shot exit-137 regression case for sentinel.finalize.ack
- statically require every drain-time publication to remain retry-safe

## Validation

- recovery archive contracts: 51/51
- static release contracts: 39/39
- two Linux 120-TERM stress matrices: 240/240
- deterministic killed-mv regression fails without the guard and passes with it
- Bash 3.2 focused signal matrix passed
- bash syntax, ShellCheck warning gate, and git diff check passed

This is intentionally separate from PR #86 so its production recovery behavior and review evidence remain independently auditable.