### PR TITLE
Accept wildcard legacy snapshot listeners

### DIFF
--- a/scripts/recovery/archive-node.sh
+++ b/scripts/recovery/archive-node.sh
@@ -4605,6 +4605,37 @@ def verify_writer():
     writers=sorted(int(path.parent.name) for path in pathlib.Path("/proc").glob("[0-9]*/comm")
                    if path.read_text(errors="replace").strip()=="arc-node")
     if writers!=[pid]:fail("host does not have exactly the sealed legacy writer")
+def ipv4_loopback_reachable_listener_inodes(raw,port):
+    listeners=[]
+    for line in raw.splitlines()[1:]:
+        fields=line.split()
+        if len(fields)<10:continue
+        local,state,inode=fields[1],fields[3],fields[9]
+        address,port_hex=local.split(":",1)
+        # An IPv4 wildcard listener is the socket selected by a connection to
+        # 127.0.0.1 when there is no more-specific loopback listener.  Legacy
+        # ARC nodes bind 0.0.0.0:9090, so both exact-loopback and wildcard are
+        # valid candidates; ownership and singleton checks below still bind
+        # the request to exactly one socket held by the sealed writer.
+        if (state=="0A" and address in {"00000000","0100007F"}
+                and int(port_hex,16)==port):
+            listeners.append(int(inode))
+    return listeners
+def listener_inodes_on_port(raw,port):
+    listeners=[]
+    for line in raw.splitlines()[1:]:
+        fields=line.split()
+        if len(fields)<10:continue
+        local,state,inode=fields[1],fields[3],fields[9]
+        _address,port_hex=local.split(":",1)
+        if state=="0A" and int(port_hex,16)==port:
+            listeners.append(int(inode))
+    return listeners
+def unique_owned_listener_inode(listeners,owned,ipv6_listeners):
+    matches=sorted(set(listeners)&owned)
+    if ipv6_listeners or len(matches)!=1 or len(set(listeners))!=1:
+        fail("loopback-reachable snapshot listener is not uniquely owned by the sealed writer")
+    return matches[0]
 def listener_owner():
     origin=urllib.parse.urlsplit(rpc_origin);port=origin.port
     owned=set()
@@ -4613,20 +4644,14 @@ def listener_owner():
         except (FileNotFoundError,PermissionError,OSError):continue
         match=re.fullmatch(r"socket:\[([0-9]+)\]",target)
         if match:owned.add(int(match.group(1)))
-    listeners=[]
-    for table in (pathlib.Path("/proc/net/tcp"),):
-        for line in table.read_text().splitlines()[1:]:
-            fields=line.split()
-            if len(fields)<10:continue
-            local,state,inode=fields[1],fields[3],fields[9]
-            address,port_hex=local.split(":",1)
-            if state=="0A" and address=="0100007F" and int(port_hex,16)==port:
-                listeners.append(int(inode))
-    matches=sorted(set(listeners)&owned)
-    if len(matches)!=1 or len(set(listeners))!=1:
-        fail("loopback snapshot listener is not uniquely owned by the sealed writer")
+    listeners=ipv4_loopback_reachable_listener_inodes(
+        pathlib.Path("/proc/net/tcp").read_text(),port)
+    tcp6=pathlib.Path("/proc/net/tcp6")
+    ipv6_listeners=listener_inodes_on_port(
+        tcp6.read_text() if tcp6.exists() else "",port)
+    socket_inode=unique_owned_listener_inode(listeners,owned,ipv6_listeners)
     return {"boot_id":boot_id,"pid":pid,"start_ticks":start_ticks,
-            "port":port,"socket_inode":matches[0]}
+            "port":port,"socket_inode":socket_inode}
 def verify_network_quarantine():
     if source_pair_role == "preauthorization-boundary":
         return None

--- a/scripts/recovery/test_archive_node_quarantine_runtime.py
+++ b/scripts/recovery/test_archive_node_quarantine_runtime.py
@@ -12,8 +12,11 @@ from __future__ import annotations
 import ast
 import dataclasses
 import hashlib
+import os
 import pathlib
 import re
+import socket
+import sys
 import unittest
 
 
@@ -225,6 +228,118 @@ class EmbeddedProgramTests(unittest.TestCase):
         compile(self.outer, "archive-node-quarantine-round", "exec")
         compile(self.helper, "archive-node-pinned-helper", "exec")
         compile(self.live_capture, "archive-node-live-source-capture", "exec")
+
+    def test_live_capture_accepts_only_loopback_reachable_ipv4_listeners(self) -> None:
+        tree = ast.parse(self.live_capture)
+        function_names = {
+            "ipv4_loopback_reachable_listener_inodes",
+            "listener_inodes_on_port",
+            "unique_owned_listener_inode",
+        }
+        functions = [
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name in function_names
+        ]
+
+        def fail(message: str) -> None:
+            raise RuntimeError(message)
+
+        namespace: dict[str, object] = {"fail": fail}
+        exec(
+            compile(ast.Module(body=functions, type_ignores=[]), "listener-parser", "exec"),
+            namespace,
+        )
+        parse = namespace["ipv4_loopback_reachable_listener_inodes"]
+        parse_all = namespace["listener_inodes_on_port"]
+        select = namespace["unique_owned_listener_inode"]
+        header = "  sl  local_address rem_address st tx_queue rx_queue tr tm->when retrnsmt uid timeout inode\n"
+
+        exact_loopback = header + "0: 0100007F:2382 00000000:0000 0A 0:0 0:0 0 0 0 4242\n"
+        wildcard = header + "0: 00000000:2382 00000000:0000 0A 0:0 0:0 0 0 0 4343\n"
+        public_specific = header + "0: 4C201C95:2382 00000000:0000 0A 0:0 0:0 0 0 0 4444\n"
+        wrong_port = header + "0: 00000000:2383 00000000:0000 0A 0:0 0:0 0 0 0 4545\n"
+        non_listener = header + "0: 00000000:2382 00000000:0000 01 0:0 0:0 0 0 0 4646\n"
+
+        self.assertEqual(parse(exact_loopback, 9090), [4242])
+        self.assertEqual(parse(wildcard, 9090), [4343])
+        self.assertEqual(parse(public_specific, 9090), [])
+        self.assertEqual(parse(wrong_port, 9090), [])
+        self.assertEqual(parse(non_listener, 9090), [])
+        self.assertEqual(parse_all(public_specific, 9090), [4444])
+        self.assertEqual(select([4242], {4242}, []), 4242)
+        self.assertEqual(select([4343], {4343}, []), 4343)
+        for listeners, owned, ipv6 in (
+            ([], set(), []),
+            ([4242], set(), []),
+            ([4242, 4343], {4242, 4343}, []),
+            ([4242], {4242}, [4747]),
+        ):
+            with self.assertRaises(RuntimeError):
+                select(listeners, owned, ipv6)
+
+    @unittest.skipUnless(sys.platform.startswith("linux"), "requires Linux /proc")
+    def test_live_capture_matches_real_owned_ipv4_proc_listener(self) -> None:
+        tree = ast.parse(self.live_capture)
+        functions = [
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name in {
+                "ipv4_loopback_reachable_listener_inodes",
+                "listener_inodes_on_port",
+                "unique_owned_listener_inode",
+            }
+        ]
+
+        def fail(message: str) -> None:
+            raise RuntimeError(message)
+
+        namespace: dict[str, object] = {"fail": fail}
+        exec(
+            compile(ast.Module(body=functions, type_ignores=[]), "listener-proc", "exec"),
+            namespace,
+        )
+        parse = namespace["ipv4_loopback_reachable_listener_inodes"]
+        select = namespace["unique_owned_listener_inode"]
+
+        for bind_address in ("127.0.0.1", "0.0.0.0"):
+            with self.subTest(bind_address=bind_address):
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+                    listener.bind((bind_address, 0))
+                    listener.listen(1)
+                    port = listener.getsockname()[1]
+                    target = os.readlink(f"/proc/{os.getpid()}/fd/{listener.fileno()}")
+                    match = re.fullmatch(r"socket:\[([0-9]+)\]", target)
+                    self.assertIsNotNone(match)
+                    inode = int(match.group(1))
+                    rows = parse(pathlib.Path("/proc/net/tcp").read_text(), port)
+                    self.assertEqual(select(rows, {inode}, []), inode)
+                    with self.assertRaises(RuntimeError):
+                        select(rows, set(), [])
+
+        if hasattr(socket, "SO_REUSEPORT"):
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as first:
+                first.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+                first.bind(("127.0.0.1", 0))
+                first.listen(1)
+                port = first.getsockname()[1]
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as second:
+                    second.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+                    second.bind(("127.0.0.1", port))
+                    second.listen(1)
+                    rows = parse(pathlib.Path("/proc/net/tcp").read_text(), port)
+                    owned = {
+                        int(re.fullmatch(
+                            r"socket:\[([0-9]+)\]",
+                            os.readlink(f"/proc/{os.getpid()}/fd/{item.fileno()}"),
+                        ).group(1))
+                        for item in (first, second)
+                    }
+                    self.assertEqual(len(set(rows)), 2)
+                    with self.assertRaises(RuntimeError):
+                        select(rows, owned, [])
 
     def test_live_capture_receipt_is_durable_before_its_selector_and_reconciled_before_http(self) -> None:
         receipt = 'create(attempt/"receipt.json",raw)'


### PR DESCRIPTION
## Summary
- treat an IPv4 wildcard listener as loopback-reachable for the pre-quarantine `/sync/snapshot` capture
- retain exact sealed writer PID, boot, start-time, executable, argv, cgroup, socket-inode, and singleton ownership checks
- add regression coverage for exact loopback, wildcard, public-specific, wrong-port, and non-LISTEN `/proc/net/tcp` rows

## Production evidence
All six sealed legacy validators expose exactly one `0.0.0.0:9090` listener owned by their exact `arc-node` PID. The previous helper accepted only `127.0.0.1:9090`, so it deterministically failed before authorization, quarantine, or stop. All six writers remain live and fail-open; no mutation dispatch was created.

## Verification
- `bash -n scripts/recovery/archive-node.sh`
- `shellcheck -S warning scripts/recovery/archive-node.sh`
- all 9 `scripts/recovery/test_*.py` programs pass
- independent security review: PASS
