### PR TITLE
Fix Windows pre-tag Tauri source normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,8 @@
 *.pdf binary
+# Tauri serializes this manifest with LF during Windows builds. Check it out in
+# that canonical form so its strict post-build source-drift gate distinguishes
+# real changes from Git's CRLF worktree conversion.
+desktop/src-tauri/Cargo.toml text eol=lf
 # Preserve the byte-exact crates.io payload on every checkout. The canonical
 # MIT text intentionally contains its published blank line at EOF.
 vendor/third_party/glib-0.18.5/** text eol=lf

--- a/tests/release/workflow_source_cleanliness_test.sh
+++ b/tests/release/workflow_source_cleanliness_test.sh
@@ -5,14 +5,22 @@ TEST_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(CDPATH='' cd -- "$TEST_DIR/../.." && pwd)"
 PREFLIGHT="$REPO_ROOT/.github/workflows/release-signing-preflight.yml"
 RELEASE="$REPO_ROOT/.github/workflows/release.yml"
+ATTRIBUTES="$REPO_ROOT/.gitattributes"
 
-python3 - "$PREFLIGHT" "$RELEASE" <<'PY'
+python3 - "$PREFLIGHT" "$RELEASE" "$ATTRIBUTES" <<'PY'
 from pathlib import Path
 import re
 import sys
 
 preflight = Path(sys.argv[1]).read_text(encoding="utf-8")
 release = Path(sys.argv[2]).read_text(encoding="utf-8")
+attributes = Path(sys.argv[3]).read_text(encoding="utf-8").splitlines()
+
+windows_tauri_manifest_rule = "desktop/src-tauri/Cargo.toml text eol=lf"
+if attributes.count(windows_tauri_manifest_rule) != 1:
+    raise SystemExit(
+        "the Windows Tauri manifest must have exactly one canonical LF checkout rule"
+    )
 
 
 def job(document: str, name: str) -> str:


### PR DESCRIPTION
## Production gate failure

The exact-main release preflight correctly stopped before signing because Tauri rewrote `desktop/src-tauri/Cargo.toml` from the Windows checkout CRLF form to its canonical LF form. Git reports `needs update` even though the filtered blob is identical to `HEAD`.

## Fix

- pin that single manifest to `text eol=lf` in `.gitattributes`
- keep every strict pre/post-build source-drift check unchanged
- add a release contract that requires the LF checkout rule exactly once

## Evidence

- reproduced the exact Windows `i/lf w/crlf` -> `i/lf w/lf` transition and `git update-index --really-refresh` failure
- verified the LF rule yields `i/lf w/lf` and refresh succeeds
- verified a real manifest mutation still fails the refresh/status gate
- targeted workflow cleanliness and actionlint gates pass

Failed preflight: https://github.com/FerrumVir/arc-chain/actions/runs/34089288298
Failed job: 101640367756