### PR TITLE
fix(recovery): make quarantine rounds safely resumable

### DIFF
--- a/docs/VALIDATOR-FLEET-ROLLOUT.md
+++ b/docs/VALIDATOR-FLEET-ROLLOUT.md
@@ -157,10 +157,14 @@ first mutation lease is capped at 300 seconds by paired operator monotonic and
 realtime elapsed clocks; clock regression, suspend divergence, or expiry fails
 closed. Once a create-only mutation dispatch binds the selection, crash resume
 uses each node's durable same-boot `CLOCK_BOOTTIME` acceptance lease rather
-than cross-host UTC. An expired dispatch becomes rotatable only after six exact
-challenged zero-progress proofs show no nft, selector, restart-effective write,
-or node transition. Old generations never satisfy a new status set, and
-generation files are never overwritten.
+than cross-host UTC. An expired dispatch is released only after exact challenged
+zero-progress proofs from every target in that authorization show no nft,
+selector, restart-effective write, or node transition. A released all-live
+round-1 dispatch makes the selection rotatable. In later rounds, the release
+neutralizes only that zero-progress attempt; the fully revalidated positive
+prefix keeps the selection bound while a fresh attempt targets its exact
+remaining fleet-ordered subset. Old generations never satisfy a new status
+set, and generation files are never overwritten.
 
 A positive partial dispatch has the same fail-closed boundary. Before its
 create-only result can be sealed, every remaining target must return one exact,
@@ -750,9 +754,12 @@ substitute a hand-copied top-level file for any of those paths.
    roots independently. The next round freshly samples only those remaining
    live nodes. Crash recovery reuses a durable positive result byte-for-byte and
    completes its prefix publication before any old-attempt status probe. A
-   zero-progress attempt is never appended to the transition ledger and may be
-   resampled. A positive round is never rewritten or reused as authorization
-   for a later target. Each node may cross live-to-fenced exactly once, so at
+   zero-progress attempt is never appended to the transition ledger. It may be
+   resampled only after every exact target supplies a challenged post-lease
+   live/unfenced proof; later-round release validation also replays the complete
+   immutable positive prefix before authorizing its remaining subset. A positive
+   round is never rewritten or reused as authorization for a later target. Each
+   node may cross live-to-fenced exactly once, so at
    most six positive rounds exist. The final generation ledger must cover all
    six nodes and sets the legacy cutoff to the maximum public height observed
    across all authorized rounds. There is no global all-six latch and no

--- a/scripts/recovery/README.md
+++ b/scripts/recovery/README.md
@@ -1344,7 +1344,12 @@ target's nft apply, the helper proves that round hash and deadline and writes a
 create-only node-applied receipt. A crash may leave any positive subset fenced;
 the immutable result records that subset and a later round freshly authorizes
 only the remainder. Zero-progress attempts stay outside the ledger and may be
-resampled; positive rounds are never rewritten, and no node may cross twice.
+resampled only after every target in that exact authorization returns a
+challenged post-lease live/unfenced proof. A round-1 release can rotate its
+all-live observation selection; a later-round release revalidates and preserves
+the immutable positive prefix, keeps that selection bound, and retries only its
+exact remaining fleet-ordered subset. Positive rounds are never rewritten, and
+no node may cross twice.
 The completed generation ledger has at most six rounds, covers all six nodes,
 and derives the legacy cutoff as the maximum public height across every round.
 This permits honest mixed-state resume without pretending that one local

--- a/scripts/recovery/archive-fleet-to-drive.sh
+++ b/scripts/recovery/archive-fleet-to-drive.sh
@@ -4268,15 +4268,21 @@ PY
 live_observation_selection_resume_state() {
     local selection="$1" round_root="$2" current_drive_sha="$3"
     local freeze_sha="$4" capture_id="$5"
-    python3 - "$selection" "$round_root" "$current_drive_sha" "$freeze_sha" "$capture_id" <<'PY'
-import datetime,hashlib,json,os,pathlib,re,stat,sys
+    python3 - "$selection" "$round_root" "$current_drive_sha" "$freeze_sha" \
+        "$capture_id" "$QUARANTINE_ROUND_MODULE" <<'PY'
+import hashlib,importlib.util,json,os,pathlib,re,stat,sys
 selection=pathlib.Path(sys.argv[1]);round_root=pathlib.Path(sys.argv[2])
-drive_sha,freeze,capture=sys.argv[3:]
+drive_sha,freeze,capture,module_path=sys.argv[3:]
 canonical=lambda value:(json.dumps(value,sort_keys=True,separators=(",",":"))+"\n").encode()
 digest=lambda raw:hashlib.sha256(raw).hexdigest()
 hash_re=re.compile(r"[0-9a-f]{64}");utc_format="%Y-%m-%dT%H:%M:%S.%fZ"
 if any(hash_re.fullmatch(value) is None for value in (drive_sha,freeze,capture)):
     raise SystemExit("live-observation resume identity is malformed")
+spec=importlib.util.spec_from_file_location("arc_live_observation_rounds",module_path)
+if spec is None or spec.loader is None:
+    raise SystemExit("cannot load quarantine-round validator")
+rounds=importlib.util.module_from_spec(spec);sys.modules[spec.name]=rounds
+spec.loader.exec_module(rounds)
 def locked(path,label,maximum=32*1024*1024,links={1},modes={0o400}):
     fd=os.open(path,os.O_RDONLY|getattr(os,"O_NOFOLLOW",0))
     try:
@@ -4343,80 +4349,47 @@ if not (selection.exists() or selection.is_symlink()):
 def zero_progress_released(attempt,authorization_raw,readiness_raw,dispatch_raw):
     path=attempt/"zero-progress-release.json"
     if not (path.exists() or path.is_symlink()):return False
-    release,_release_raw=locked(path,"zero-progress release")
-    fields={"schema","capture_id","freeze_plan_sha256","round_number",
-        "round_authorization_sha256","round_readiness_sha256",
-        "mutation_dispatch_sha256","live_observation_selection_sha256",
-        "live_observation_generation","observation_generation_receipt_sha256",
-        "drive_prefreeze_receipt_sha256","challenge","released_at","nodes"}
-    nodes=release.get("nodes");challenge=release.get("challenge")
+    for directory,label in ((attempt,"attempt"),(attempt.parent,"round")):
+        details=directory.lstat()
+        if (directory.is_symlink() or not stat.S_ISDIR(details.st_mode)
+                or details.st_uid!=os.geteuid()
+                or stat.S_IMODE(details.st_mode)!=0o700):
+            raise SystemExit(f"live-observation zero-progress {label} is unsafe")
     authorization=json.loads(authorization_raw)
-    targets=authorization.get("targets")
-    try:datetime.datetime.strptime(release.get("released_at"),"%Y-%m-%dT%H:%M:%SZ")
-    except (TypeError,ValueError):
-        raise SystemExit("live-observation zero-progress release time differs")
-    if (set(release)!=fields
-            or release.get("schema")!="arc.recovery.quarantine-round-zero-progress-release.v1"
-            or release.get("round_number")!=1
-            or (release.get("capture_id"),release.get("freeze_plan_sha256"),
-                release.get("round_authorization_sha256"),release.get("round_readiness_sha256"),
-                release.get("mutation_dispatch_sha256"),
-                release.get("live_observation_selection_sha256"),
-                release.get("live_observation_generation"),
-                release.get("observation_generation_receipt_sha256"),
-                release.get("drive_prefreeze_receipt_sha256"))
-                !=(capture,freeze,digest(authorization_raw),digest(readiness_raw),
-                   digest(dispatch_raw),selection_sha,generation,generation_sha,
-                   selection_drive_sha)
-            or hash_re.fullmatch(str(challenge)) is None or not isinstance(nodes,list)
-            or not isinstance(targets,list)
-            or [row.get("node") for row in targets]
-                !=["nyc","lax","ams","lhr","nrt","sgp"]
-            or [row.get("value",{}).get("node") for row in nodes]
-                !=["nyc","lax","ams","lhr","nrt","sgp"]):
-        raise SystemExit("live-observation zero-progress release differs")
-    target_by_node={row["node"]:row for row in targets}
-    proof_fields={"schema","capture_id","freeze_plan_sha256","observation_generation",
-        "round_number","round_authorization_sha256","round_readiness_sha256",
-        "mutation_dispatch_sha256","challenge","node","boot_id","writer_live_unfenced",
-        "apply_state_present","restart_effective_mutation_absent","active_selector_absent",
-        "quarantine_nft_absent","authorization_accepted","readiness_present",
-        "accepted_boottime_ns","elapsed_since_acceptance_ns","observed_boottime_ns","observed_at"}
-    for wrapper in nodes:
-        proof=wrapper.get("value") if isinstance(wrapper,dict) else None
-        if isinstance(proof,dict):
-            accepted_ns=proof.get("accepted_boottime_ns")
-            observed_ns=proof.get("observed_boottime_ns")
-            elapsed_ns=proof.get("elapsed_since_acceptance_ns")
-            try:datetime.datetime.strptime(proof.get("observed_at"),"%Y-%m-%dT%H:%M:%SZ")
-            except (TypeError,ValueError):observed_at_valid=False
-            else:observed_at_valid=True
-        else:
-            accepted_ns=observed_ns=elapsed_ns=None;observed_at_valid=False
-        if (not isinstance(wrapper,dict) or set(wrapper)!={"value","sha256"}
-                or not isinstance(wrapper.get("value"),dict)
-                or set(proof)!=proof_fields
-                or digest(canonical(proof))!=wrapper.get("sha256")
-                or proof.get("schema")!="arc.recovery.quarantine-round-zero-progress-node-proof.v1"
-                or (proof.get("capture_id"),proof.get("freeze_plan_sha256"),
-                    proof.get("observation_generation"),proof.get("round_number"),
-                    proof.get("round_authorization_sha256"),proof.get("round_readiness_sha256"),
-                    proof.get("mutation_dispatch_sha256"),proof.get("challenge"))
-                    !=(capture,freeze,generation,1,digest(authorization_raw),
-                       digest(readiness_raw),digest(dispatch_raw),challenge)
-                or proof.get("boot_id")!=target_by_node.get(proof.get("node"),{}).get("boot_id")
-                or proof.get("writer_live_unfenced") is not True
-                or proof.get("restart_effective_mutation_absent") is not True
-                or proof.get("active_selector_absent") is not True
-                or proof.get("quarantine_nft_absent") is not True
-                or proof.get("authorization_accepted") is not True
-                or not isinstance(proof.get("apply_state_present"),bool)
-                or not isinstance(proof.get("readiness_present"),bool)
-                or any(isinstance(number,bool) or not isinstance(number,int) or number<=0
-                       for number in (accepted_ns,elapsed_ns,observed_ns))
-                or observed_ns<=accepted_ns+300_000_000_000
-                or elapsed_ns!=observed_ns-accepted_ns or not observed_at_valid):
-            raise SystemExit("live-observation zero-progress node proof differs")
+    number=authorization.get("round_number")
+    if isinstance(number,bool) or not isinstance(number,int) or not 1<=number<=len(rounds.FLEET):
+        raise SystemExit("live-observation zero-progress round differs")
+    prior_authorizations=[];prior_results=[]
+    for previous in range(1,number):
+        prefix_directory=round_root/f"round-{previous}"
+        details=prefix_directory.lstat()
+        if (prefix_directory.is_symlink() or not stat.S_ISDIR(details.st_mode)
+                or details.st_uid!=os.geteuid()
+                or stat.S_IMODE(details.st_mode)!=0o700):
+            raise SystemExit("live-observation zero-progress prefix directory is unsafe")
+        prior_authorization,_=locked(
+            prefix_directory/"authorization.json",
+            f"round {previous} prefix authorization")
+        prior_result,_=locked(
+            prefix_directory/"result.json",
+            f"round {previous} prefix result")
+        prior_authorizations.append(prior_authorization);prior_results.append(prior_result)
+    release,_release_raw=locked(path,"zero-progress release")
+    result_path=attempt/"result.json"
+    result=locked(result_path,"zero-progress result")[0] \
+        if result_path.exists() or result_path.is_symlink() else None
+    transitions=attempt/"node-transitions"
+    if transitions.exists() or transitions.is_symlink():
+        details=transitions.lstat()
+        if (transitions.is_symlink() or not stat.S_ISDIR(details.st_mode)
+                or details.st_uid!=os.geteuid()
+                or stat.S_IMODE(details.st_mode)!=0o700 or any(transitions.iterdir())):
+            raise SystemExit("live-observation zero-progress transition root differs")
+    rounds.validate_zero_progress_release(
+        release,authorization=authorization,readiness=json.loads(readiness_raw),
+        dispatch=json.loads(dispatch_raw),prior_authorizations=prior_authorizations,
+        prior_results=prior_results,result=result,expected_capture_id=capture,
+        expected_freeze_sha256=freeze,containing_round_name=attempt.parent.name)
     return True
 value,raw=locked(selection,"selection")
 fields={"schema","source_main_commit","freeze_plan_sha256","capture_id",
@@ -4443,6 +4416,17 @@ if round_root.exists() or round_root.is_symlink():
     for path in readinesses:
         authorization,authorization_raw=locked(
             path.with_name("authorization.json"),"readiness authorization")
+        _readiness,readiness_raw=locked(path,"quarantine readiness")
+        dispatch_path=path.with_name("mutation-dispatch.json")
+        if not (dispatch_path.exists() or dispatch_path.is_symlink()):
+            # Local readiness is built before dispatch publication and before
+            # any remote readiness send; alone it is a powerless crash prefix.
+            continue
+        _dispatch,dispatch_raw=locked(dispatch_path,"mutation dispatch")
+        # A fully validated release is historical evidence for its own exact
+        # selection.  Skip it before comparing against a later replacement.
+        if zero_progress_released(path.parent,authorization_raw,readiness_raw,dispatch_raw):
+            continue
         if ((authorization.get("capture_id"),authorization.get("freeze_plan_sha256"),
              authorization.get("live_observation_selection_sha256"),
              authorization.get("live_observation_generation"),
@@ -4451,18 +4435,15 @@ if round_root.exists() or round_root.is_symlink():
                 !=(capture,freeze,selection_sha,generation,generation_sha,
                    selection_drive_sha)):
             raise SystemExit("live-observation resume readiness authorization differs")
-        _readiness,readiness_raw=locked(path,"quarantine readiness")
-        dispatch_path=path.with_name("mutation-dispatch.json")
-        if not (dispatch_path.exists() or dispatch_path.is_symlink()):
-            # Local readiness is built before dispatch publication and before
-            # any remote readiness send; alone it is a powerless crash prefix.
-            continue
-        _dispatch,dispatch_raw=locked(dispatch_path,"mutation dispatch")
-        if zero_progress_released(path.parent,authorization_raw,readiness_raw,dispatch_raw):
-            continue
         bound=True
     for path in dispatches:
         dispatch,dispatch_raw=locked(path,"mutation dispatch")
+        authorization,authorization_raw=locked(path.with_name("authorization.json"),
+                                                "dispatch authorization")
+        _readiness,readiness_raw=locked(path.with_name("readiness.json"),
+                                        "dispatch readiness")
+        if zero_progress_released(path.parent,authorization_raw,readiness_raw,dispatch_raw):
+            continue
         if (dispatch.get("schema")!="arc.recovery.quarantine-mutation-dispatch.v1"
                 or (dispatch.get("capture_id"),dispatch.get("freeze_plan_sha256"),
                     dispatch.get("live_observation_selection_sha256"),
@@ -4472,12 +4453,6 @@ if round_root.exists() or round_root.is_symlink():
                     !=(capture,freeze,selection_sha,generation,generation_sha,
                        selection_drive_sha)):
             raise SystemExit("live-observation resume mutation dispatch differs")
-        authorization,authorization_raw=locked(path.with_name("authorization.json"),
-                                                "dispatch authorization")
-        _readiness,readiness_raw=locked(path.with_name("readiness.json"),
-                                        "dispatch readiness")
-        if zero_progress_released(path.parent,authorization_raw,readiness_raw,dispatch_raw):
-            continue
         bound=True
     for result_path in sorted(round_root.glob("round-*/result.json")):
         result,_result_raw=locked(result_path,"quarantine result")
@@ -4494,9 +4469,81 @@ if round_root.exists() or round_root.is_symlink():
 if bound:
     print("bound",generation);raise SystemExit(0)
 # Every unbound selection is invocation-local.  Even a wall-fresh selection is
-# rotated after the exact six-writer live/unfenced proof on a new invocation;
-# only a dispatch-bound selection may resume across an operator crash.
+# rotated on a new invocation; a released round-1 dispatch has exact all-six
+# live/unfenced proofs. Later-round releases leave their positive prefix bound.
 print("rotate",generation)
+PY
+}
+
+quarantine_zero_progress_attempt_context() {
+    local attempt_root="$1" freeze_sha="$2" capture_id="$3"
+    python3 -I - "$attempt_root" "$freeze_sha" "$capture_id" \
+        "$QUARANTINE_ROUND_MODULE" <<'PY'
+import importlib.util,json,os,pathlib,re,stat,sys
+attempt=pathlib.Path(sys.argv[1]);freeze,capture,module_path=sys.argv[2:]
+canonical=lambda value:(json.dumps(value,sort_keys=True,separators=(",",":"))+"\n").encode()
+if any(re.fullmatch(r"[0-9a-f]{64}",value) is None for value in (freeze,capture)):
+    raise SystemExit("zero-progress context identity is malformed")
+spec=importlib.util.spec_from_file_location("arc_zero_progress_context",module_path)
+if spec is None or spec.loader is None:raise SystemExit("cannot load quarantine-round validator")
+rounds=importlib.util.module_from_spec(spec);sys.modules[spec.name]=rounds;spec.loader.exec_module(rounds)
+def locked(path,label):
+    fd=os.open(path,os.O_RDONLY|getattr(os,"O_NOFOLLOW",0))
+    try:
+        details=os.fstat(fd)
+        if (not stat.S_ISREG(details.st_mode) or path.is_symlink()
+                or details.st_uid!=os.geteuid() or details.st_nlink!=1
+                or stat.S_IMODE(details.st_mode)!=0o400
+                or not 0<details.st_size<=32*1024*1024):
+            raise SystemExit(f"zero-progress context {label} is unsafe")
+        raw=os.read(fd,32*1024*1024+1)
+        if len(raw)!=details.st_size:raise SystemExit(f"zero-progress context {label} changed")
+        value=json.loads(raw)
+        if raw!=canonical(value):raise SystemExit(f"zero-progress context {label} is noncanonical")
+        return value
+    finally:os.close(fd)
+for directory,label in ((attempt,"attempt"),(attempt.parent,"round"),
+                        (attempt.parent.parent,"round root")):
+    details=directory.lstat()
+    if (directory.is_symlink() or not stat.S_ISDIR(details.st_mode)
+            or details.st_uid!=os.geteuid() or stat.S_IMODE(details.st_mode)!=0o700):
+        raise SystemExit(f"zero-progress context {label} is unsafe")
+authorization=locked(attempt/"authorization.json","authorization")
+readiness=locked(attempt/"readiness.json","readiness")
+dispatch=locked(attempt/"mutation-dispatch.json","dispatch")
+number=authorization.get("round_number")
+if isinstance(number,bool) or not isinstance(number,int) or not 1<=number<=len(rounds.FLEET):
+    raise SystemExit("zero-progress context round differs")
+prior_authorizations=[];prior_results=[]
+for previous in range(1,number):
+    prefix_directory=attempt.parent.parent/f"round-{previous}"
+    details=prefix_directory.lstat()
+    if (prefix_directory.is_symlink() or not stat.S_ISDIR(details.st_mode)
+            or details.st_uid!=os.geteuid() or stat.S_IMODE(details.st_mode)!=0o700):
+        raise SystemExit("zero-progress context prefix directory is unsafe")
+    prior_authorizations.append(locked(
+        prefix_directory/"authorization.json",
+        f"round {previous} prefix authorization"))
+    prior_results.append(locked(
+        prefix_directory/"result.json",
+        f"round {previous} prefix result"))
+transitions=attempt/"node-transitions"
+if transitions.exists() or transitions.is_symlink():
+    details=transitions.lstat()
+    if (transitions.is_symlink() or not stat.S_ISDIR(details.st_mode)
+            or details.st_uid!=os.geteuid() or stat.S_IMODE(details.st_mode)!=0o700
+            or any(transitions.iterdir())):
+        raise SystemExit("zero-progress context transition root differs")
+result_path=attempt/"result.json"
+result=locked(result_path,"result") \
+    if result_path.exists() or result_path.is_symlink() else None
+state=rounds.validate_zero_progress_attempt(
+    authorization=authorization,readiness=readiness,dispatch=dispatch,
+    prior_authorizations=prior_authorizations,prior_results=prior_results,
+    result=result,expected_capture_id=capture,expected_freeze_sha256=freeze,
+    containing_round_name=attempt.parent.name)
+print(state["round_number"],state["live_observation_generation"],
+      ",".join(state["target_names"]))
 PY
 }
 
@@ -4506,7 +4553,9 @@ release_stale_zero_progress_dispatches() {
     [ -f "$selection" ] && [ ! -L "$selection" ] || return 0
     [ -d "$round_root" ] && [ ! -L "$round_root" ] || return 0
     local attempt authorization readiness dispatch auth_sha readiness_sha dispatch_sha
-    local round generation challenge proof_root node temporary release_temporary proof_failed
+    local round generation targets_csv challenge proof_root node temporary
+    local release_temporary proof_failed target_count context
+    local release_nodes=()
     while IFS= read -r attempt; do
         [ -n "$attempt" ] || continue
         authorization="$attempt/authorization.json"
@@ -4515,13 +4564,14 @@ release_stale_zero_progress_dispatches() {
         auth_sha="$(round_artifact_sha "$authorization")"
         readiness_sha="$(round_artifact_sha "$readiness")"
         dispatch_sha="$(round_artifact_sha "$dispatch")"
-        read -r round generation < <(python3 - "$authorization" "$selection" <<'PY'
-import json,pathlib,sys
-authorization=json.loads(pathlib.Path(sys.argv[1]).read_text())
-selection=json.loads(pathlib.Path(sys.argv[2]).read_text())
-print(authorization["round_number"],selection["observation_generation"])
-PY
-        )
+        context="$(quarantine_zero_progress_attempt_context \
+            "$attempt" "$freeze_sha" "$capture_id")" || die \
+            "expired zero-progress quarantine attempt failed exact prefix validation"
+        read -r round generation targets_csv <<< "$context"
+        IFS=',' read -r -a release_nodes <<< "$targets_csv"
+        target_count="${#release_nodes[@]}"
+        [ "$target_count" -gt 0 ] || die \
+            "expired zero-progress quarantine target set is empty"
         challenge="$(python3 - <<'PY'
 import secrets
 print(secrets.token_hex(32))
@@ -4530,7 +4580,7 @@ PY
         proof_root="$(prepare_protected_maintenance_directory \
             "$attempt/zero-progress-proofs-$challenge")"
         proof_failed=0
-        for node in nyc lax ams lhr nrt sgp; do
+        for node in "${release_nodes[@]}"; do
             temporary="$log_root/$node-zero-progress-$challenge.new.json"
             if ! run_remote "$node" quarantine-round-zero-progress-proof \
                 "$capture_id" "$generation" "$node" "$freeze_sha" "$round" \
@@ -4550,12 +4600,13 @@ PY
         fi
         release_temporary="$log_root/zero-progress-release-$challenge.new.json"
         python3 - "$authorization" "$readiness" "$dispatch" "$selection" \
-            "$proof_root" "$challenge" "$release_temporary" <<'PY'
+            "$proof_root" "$challenge" "$targets_csv" "$release_temporary" <<'PY'
 import datetime,hashlib,json,os,pathlib,stat,sys
-authorization_path,readiness_path,dispatch_path,selection_path,proof_root,challenge,output=sys.argv[1:]
+authorization_path,readiness_path,dispatch_path,selection_path,proof_root,challenge,targets_csv,output=sys.argv[1:]
 authorization_path=pathlib.Path(authorization_path);readiness_path=pathlib.Path(readiness_path)
 dispatch_path=pathlib.Path(dispatch_path);selection_path=pathlib.Path(selection_path)
 proof_root=pathlib.Path(proof_root);output=pathlib.Path(output)
+target_names=targets_csv.split(",")
 canonical=lambda value:(json.dumps(value,sort_keys=True,separators=(",",":"))+"\n").encode()
 digest=lambda raw:hashlib.sha256(raw).hexdigest()
 def locked(path,label):
@@ -4581,8 +4632,6 @@ identity=(authorization["capture_id"],authorization["freeze_plan_sha256"],
           digest(dispatch_raw),digest(selection_raw),selection["observation_generation"],
           selection["observation_generation_receipt_sha256"],
           selection["drive_prefreeze_receipt_sha256"])
-if identity[2]!=1:
-    raise SystemExit("zero-progress release is only valid for the first all-live round")
 if ((readiness.get("round_authorization_sha256"),dispatch.get("round_authorization_sha256"),
      dispatch.get("round_readiness_sha256"))!=(identity[3],identity[3],identity[4])
         or (authorization.get("live_observation_selection_sha256"),
@@ -4593,7 +4642,7 @@ if ((readiness.get("round_authorization_sha256"),dispatch.get("round_authorizati
 nodes=[]
 targets=authorization.get("targets")
 if (not isinstance(targets,list) or [row.get("node") for row in targets]
-        !=["nyc","lax","ams","lhr","nrt","sgp"]):
+        !=target_names):
     raise SystemExit("zero-progress release authorization topology differs")
 target_by_node={row["node"]:row for row in targets}
 proof_fields={"schema","capture_id","freeze_plan_sha256","observation_generation",
@@ -4602,7 +4651,7 @@ proof_fields={"schema","capture_id","freeze_plan_sha256","observation_generation
  "apply_state_present","restart_effective_mutation_absent","active_selector_absent",
  "quarantine_nft_absent","authorization_accepted","readiness_present",
  "accepted_boottime_ns","elapsed_since_acceptance_ns","observed_boottime_ns","observed_at"}
-for node in ("nyc","lax","ams","lhr","nrt","sgp"):
+for node in target_names:
     value,raw=locked(proof_root/f"{node}.json",f"{node} proof")
     accepted_ns=value.get("accepted_boottime_ns");observed_ns=value.get("observed_boottime_ns")
     elapsed_ns=value.get("elapsed_since_acceptance_ns")
@@ -4643,9 +4692,16 @@ fd=os.open(output,os.O_WRONLY|os.O_CREAT|os.O_EXCL|getattr(os,"O_NOFOLLOW",0),0o
 with os.fdopen(fd,"wb") as handle:
     handle.write(raw);handle.flush();os.fsync(handle.fileno());os.fchmod(handle.fileno(),0o400)
 PY
+        quarantine_attempt_has_valid_zero_progress_release "$attempt" \
+            "$freeze_sha" "$capture_id" "$release_temporary" || die \
+            "temporary zero-progress release failed exact prefix/target validation"
         publish_canonical_maintenance_input "$release_temporary" \
             "$attempt/zero-progress-release.json"
-        printf 'archive fleet: released expired zero-progress quarantine dispatch after six challenged live/unfenced proofs\n'
+        quarantine_attempt_has_valid_zero_progress_release "$attempt" \
+            "$freeze_sha" "$capture_id" || die \
+            "published zero-progress release failed exact prefix/target validation"
+        printf 'archive fleet: released expired round %s zero-progress quarantine dispatch after %s challenged live/unfenced proofs (%s)\n' \
+            "$round" "$target_count" "$targets_csv"
     done < <(python3 - "$selection" "$round_root" "$current_drive_sha" <<'PY'
 import hashlib,json,pathlib,sys
 selection_path=pathlib.Path(sys.argv[1]);root=pathlib.Path(sys.argv[2]);_drive=sys.argv[3]
@@ -4663,8 +4719,6 @@ for readiness in sorted(root.glob("round-*/attempt.*/readiness.json")):
             !=(selection_sha,selection.get("observation_generation"),
                selection.get("observation_generation_receipt_sha256"),
                selection.get("drive_prefreeze_receipt_sha256"))):continue
-    if (authorization.get("round_number")!=1 or authorization.get("prior_fenced")
-            or authorization.get("prior_round_result_sha256s")):continue
     result=attempt/"result.json"
     if result.exists():
         value=json.loads(result.read_text())
@@ -7862,14 +7916,14 @@ PY
 
 quarantine_attempt_has_valid_zero_progress_release() {
     local attempt_root="$1" freeze_sha="$2" capture_id="$3"
-    local release="$attempt_root/zero-progress-release.json"
+    local release="${4:-$attempt_root/zero-progress-release.json}"
     [ -f "$release" ] && [ ! -L "$release" ] || return 1
-    python3 -I - "$attempt_root" "$freeze_sha" "$capture_id" \
+    python3 -I - "$attempt_root" "$release" "$freeze_sha" "$capture_id" \
         "$QUARANTINE_ROUND_MODULE" <<'PY'
-import datetime,hashlib,importlib.util,json,os,pathlib,re,stat,sys
-attempt=pathlib.Path(sys.argv[1]);freeze,capture,module_path=sys.argv[2:]
+import importlib.util,json,os,pathlib,re,stat,sys
+attempt=pathlib.Path(sys.argv[1]);release_path=pathlib.Path(sys.argv[2])
+freeze,capture,module_path=sys.argv[3:]
 canonical=lambda value:(json.dumps(value,sort_keys=True,separators=(",",":"))+"\n").encode()
-digest=lambda raw:hashlib.sha256(raw).hexdigest()
 hash_re=re.compile(r"[0-9a-f]{64}")
 if any(hash_re.fullmatch(value) is None for value in (freeze,capture)):
     raise SystemExit("zero-progress resume identity is malformed")
@@ -7891,127 +7945,50 @@ def locked(path,label):
         if raw!=canonical(value):raise SystemExit(f"zero-progress resume {label} is noncanonical")
         return value,raw
     finally:os.close(fd)
-authorization,authorization_raw=locked(attempt/"authorization.json","authorization")
-readiness,readiness_raw=locked(attempt/"readiness.json","readiness")
-dispatch,dispatch_raw=locked(attempt/"mutation-dispatch.json","dispatch")
-release,_release_raw=locked(attempt/"zero-progress-release.json","release")
-state=rounds.validate_round_authorization(authorization,prior_results=[])
-auth_sha=digest(authorization_raw);readiness_sha=digest(readiness_raw);dispatch_sha=digest(dispatch_raw)
-targets=authorization.get("targets")
-names=[row.get("node") for row in targets] if isinstance(targets,list) else []
-if (state.get("round_number")!=1 or state.get("capture_id")!=capture
-        or state.get("freeze_plan_sha256")!=freeze
-        or names!=["nyc","lax","ams","lhr","nrt","sgp"]):
-    raise SystemExit("zero-progress resume authorization differs")
-probe={"schema":rounds.ROUND_RESULT_SCHEMA,"capture_id":capture,
-    "freeze_plan_sha256":freeze,"round_number":1,
-    "round_authorization_sha256":auth_sha,"target_readiness":rounds.wrap(readiness),
-    "transitions":[],"mutation_dispatch":rounds.wrap(dispatch),
-    "remaining_target_inert_proofs":[],"remaining_targets":names,
-    "completed_at":authorization["authorization_deadline"]}
-rounds.validate_round_result(
-    probe,authorization=authorization,prior_results=[],transition_receipts=[]
-)
-dispatch_fields={"schema","capture_id","freeze_plan_sha256","round_number",
-    "round_authorization_sha256","round_readiness_sha256",
-    "live_observation_selection_sha256","live_observation_generation",
-    "observation_generation_receipt_sha256","drive_prefreeze_receipt_sha256",
-    "targets","dispatched_at"}
-try:
-    dispatched=datetime.datetime.strptime(dispatch.get("dispatched_at"),"%Y-%m-%dT%H:%M:%SZ")
-except (TypeError,ValueError):
-    raise SystemExit("zero-progress resume dispatch time differs")
-del dispatched
-observation_identity=(authorization.get("live_observation_selection_sha256"),
-    authorization.get("live_observation_generation"),
-    authorization.get("observation_generation_receipt_sha256"),
-    authorization.get("drive_prefreeze_receipt_sha256"))
-if (set(dispatch)!=dispatch_fields
-        or dispatch.get("schema")!="arc.recovery.quarantine-mutation-dispatch.v1"
-        or (dispatch.get("capture_id"),dispatch.get("freeze_plan_sha256"),
-            dispatch.get("round_number"),dispatch.get("round_authorization_sha256"),
-            dispatch.get("round_readiness_sha256"))
-            !=(capture,freeze,1,auth_sha,readiness_sha)
-        or (dispatch.get("live_observation_selection_sha256"),
-            dispatch.get("live_observation_generation"),
-            dispatch.get("observation_generation_receipt_sha256"),
-            dispatch.get("drive_prefreeze_receipt_sha256"))!=observation_identity
-        or dispatch.get("targets")!=[
-            {"node":row.get("node"),"host":row.get("host")} for row in targets]):
-    raise SystemExit("zero-progress resume dispatch differs")
-release_fields={"schema","capture_id","freeze_plan_sha256","round_number",
-    "round_authorization_sha256","round_readiness_sha256","mutation_dispatch_sha256",
-    "live_observation_selection_sha256","live_observation_generation",
-    "observation_generation_receipt_sha256","drive_prefreeze_receipt_sha256",
-    "challenge","released_at","nodes"}
-challenge=release.get("challenge");nodes=release.get("nodes")
-try:
-    released=datetime.datetime.strptime(release.get("released_at"),"%Y-%m-%dT%H:%M:%SZ")
-except (TypeError,ValueError):
-    raise SystemExit("zero-progress resume release time differs")
-del released
-if (set(release)!=release_fields
-        or release.get("schema")!="arc.recovery.quarantine-round-zero-progress-release.v1"
-        or (release.get("capture_id"),release.get("freeze_plan_sha256"),
-            release.get("round_number"),release.get("round_authorization_sha256"),
-            release.get("round_readiness_sha256"),release.get("mutation_dispatch_sha256"))
-            !=(capture,freeze,1,auth_sha,readiness_sha,dispatch_sha)
-        or (release.get("live_observation_selection_sha256"),
-            release.get("live_observation_generation"),
-            release.get("observation_generation_receipt_sha256"),
-            release.get("drive_prefreeze_receipt_sha256"))!=observation_identity
-        or hash_re.fullmatch(str(challenge)) is None
-        or not isinstance(nodes,list) or len(nodes)!=6):
-    raise SystemExit("zero-progress resume release differs")
-target_by_node={row["node"]:row for row in targets}
-proof_fields={"schema","capture_id","freeze_plan_sha256","observation_generation",
-    "round_number","round_authorization_sha256","round_readiness_sha256",
-    "mutation_dispatch_sha256","challenge","node","boot_id","writer_live_unfenced",
-    "apply_state_present","restart_effective_mutation_absent","active_selector_absent",
-    "quarantine_nft_absent","authorization_accepted","readiness_present",
-    "accepted_boottime_ns","elapsed_since_acceptance_ns","observed_boottime_ns","observed_at"}
-for expected_node,wrapper in zip(names,nodes):
-    proof=wrapper.get("value") if isinstance(wrapper,dict) else None
-    if isinstance(proof,dict):
-        accepted=proof.get("accepted_boottime_ns");elapsed=proof.get("elapsed_since_acceptance_ns")
-        observed=proof.get("observed_boottime_ns")
-        try:seen=datetime.datetime.strptime(proof.get("observed_at"),"%Y-%m-%dT%H:%M:%SZ")
-        except (TypeError,ValueError):seen=None
-    else:accepted=elapsed=observed=seen=None
-    if (not isinstance(wrapper,dict) or set(wrapper)!={"value","sha256"}
-            or not isinstance(proof,dict) or set(proof)!=proof_fields
-            or wrapper.get("sha256")!=digest(canonical(proof))
-            or proof.get("schema")!="arc.recovery.quarantine-round-zero-progress-node-proof.v1"
-            or (proof.get("capture_id"),proof.get("freeze_plan_sha256"),
-                proof.get("observation_generation"),proof.get("round_number"),
-                proof.get("round_authorization_sha256"),proof.get("round_readiness_sha256"),
-                proof.get("mutation_dispatch_sha256"),proof.get("challenge"),proof.get("node"))
-                !=(capture,freeze,observation_identity[1],1,auth_sha,readiness_sha,
-                   dispatch_sha,challenge,expected_node)
-            or proof.get("boot_id")!=target_by_node[expected_node].get("boot_id")
-            or any(proof.get(field) is not True for field in
-                   ("writer_live_unfenced","restart_effective_mutation_absent",
-                    "active_selector_absent","quarantine_nft_absent","authorization_accepted"))
-            or not isinstance(proof.get("apply_state_present"),bool)
-            or not isinstance(proof.get("readiness_present"),bool)
-            or any(isinstance(number,bool) or not isinstance(number,int) or number<=0
-                   for number in (accepted,elapsed,observed))
-            or observed<=accepted+300_000_000_000 or elapsed!=observed-accepted
-            or seen is None):
-        raise SystemExit(f"zero-progress resume node proof differs: {expected_node}")
+for directory,label in ((attempt,"attempt"),(attempt.parent,"round"),
+                        (attempt.parent.parent,"round root")):
+    details=directory.lstat()
+    if (directory.is_symlink() or not stat.S_ISDIR(details.st_mode)
+            or details.st_uid!=os.geteuid() or stat.S_IMODE(details.st_mode)!=0o700):
+        raise SystemExit(f"zero-progress resume {label} is unsafe")
+authorization,_authorization_raw=locked(attempt/"authorization.json","authorization")
+readiness,_readiness_raw=locked(attempt/"readiness.json","readiness")
+dispatch,_dispatch_raw=locked(attempt/"mutation-dispatch.json","dispatch")
+release,_release_raw=locked(release_path,"release")
+number=authorization.get("round_number")
+if isinstance(number,bool) or not isinstance(number,int) or not 1<=number<=len(rounds.FLEET):
+    raise SystemExit("zero-progress resume round differs")
+round_root=attempt.parent.parent
+prior_authorizations=[];prior_results=[]
+for previous in range(1,number):
+    prefix_directory=round_root/f"round-{previous}"
+    details=prefix_directory.lstat()
+    if (prefix_directory.is_symlink() or not stat.S_ISDIR(details.st_mode)
+            or details.st_uid!=os.geteuid() or stat.S_IMODE(details.st_mode)!=0o700):
+        raise SystemExit("zero-progress resume prefix directory is unsafe")
+    prior_authorization,_=locked(
+        prefix_directory/"authorization.json",
+        f"round {previous} prefix authorization")
+    prior_result,_=locked(
+        prefix_directory/"result.json",
+        f"round {previous} prefix result")
+    prior_authorizations.append(prior_authorization);prior_results.append(prior_result)
 transitions=attempt/"node-transitions"
 if transitions.exists() or transitions.is_symlink():
     details=transitions.lstat()
-    if transitions.is_symlink() or not stat.S_ISDIR(details.st_mode):
+    if (transitions.is_symlink() or not stat.S_ISDIR(details.st_mode)
+            or details.st_uid!=os.geteuid() or stat.S_IMODE(details.st_mode)!=0o700):
         raise SystemExit("zero-progress resume transition root is unsafe")
     if any(transitions.iterdir()):raise SystemExit("zero-progress resume has a node transition")
 result_path=attempt/"result.json"
+result=None
 if result_path.exists() or result_path.is_symlink():
     result,_result_raw=locked(result_path,"result")
-    if result.get("transitions")!=[]:raise SystemExit("zero-progress resume result transitioned")
-    rounds.validate_round_result(
-        result,authorization=authorization,prior_results=[],transition_receipts=[]
-    )
+rounds.validate_zero_progress_release(
+    release,authorization=authorization,readiness=readiness,dispatch=dispatch,
+    prior_authorizations=prior_authorizations,prior_results=prior_results,
+    result=result,expected_capture_id=capture,expected_freeze_sha256=freeze,
+    containing_round_name=attempt.parent.name)
 PY
 }
 
@@ -8020,8 +7997,9 @@ quarantine_attempt_binds_live_observation_selection() {
     # Authorization, acceptances, and a locally sealed readiness are all
     # powerless crash prefixes: dispatch is published before readiness is sent
     # to any node.  Only dispatch/result/transition evidence can bind a stale
-    # attempt to its observation selection.  A complete exact six-node
-    # zero-progress release proves an otherwise-binding dispatch was inert.
+    # attempt to its observation selection.  A complete exact-target
+    # zero-progress release proves an otherwise-binding dispatch was inert;
+    # any positive immutable prefix continues to bind the selection itself.
     if quarantine_attempt_has_valid_zero_progress_release "$attempt_root" \
             "$freeze_sha" "$capture_id"; then
         return 1
@@ -8382,6 +8360,10 @@ run_quarantine_generation_rounds() {
                     die "positive quarantine round $round_number is awaiting exact remaining-target BOOTTIME closure"
                 fi
                 [ "$status" -eq 2 ] || die "quarantine round $round_number recovery failed"
+                if quarantine_attempt_binds_live_observation_selection \
+                        "$attempt_root" "$freeze_sha" "$capture_id"; then
+                    die "dispatch-bound zero-progress quarantine round $round_number requires capture resume and BOOTTIME closure"
+                fi
             fi
         done
         if [ -f "$round_dir/result.json" ] && [ ! -L "$round_dir/result.json" ]; then
@@ -8391,6 +8373,12 @@ run_quarantine_generation_rounds() {
         fi
         if [ ! -e "$round_dir" ]; then
             mkdir -m 700 -- "$round_dir"
+        fi
+        if [ "$round_number" -eq 1 ] && \
+                ! operator_selection_window_is_live \
+                    "$operator_selection_monotonic_ns" \
+                    "$operator_selection_realtime_ns"; then
+            die "live-observation selection expired before fresh quarantine round"
         fi
         attempt_root="$(mktemp -d "$round_dir/attempt.XXXXXX")"
         chmod 700 "$attempt_root"
@@ -8439,6 +8427,10 @@ run_quarantine_generation_rounds() {
                 die "positive quarantine round $round_number is awaiting exact remaining-target BOOTTIME closure"
             fi
             [ "$status" -eq 2 ] || die "fresh quarantine round failed"
+            if quarantine_attempt_binds_live_observation_selection \
+                    "$attempt_root" "$freeze_sha" "$capture_id"; then
+                die "dispatch-bound zero-progress quarantine round $round_number requires capture resume and BOOTTIME closure"
+            fi
             printf 'archive fleet: preserved zero-progress round attempt %s; resampling still-live targets\n' \
                 "$round_number"
         fi

--- a/scripts/recovery/archive-node.sh
+++ b/scripts/recovery/archive-node.sh
@@ -5510,6 +5510,23 @@ def supervisor_contract(frozen):
         fail("sealed quarantine-round supervisor context differs")
     return value
 
+def verify_supervisor_writer_topology(
+        sealed, supervisor_pid, supervisor_unified,
+        writer_pid, writer_unified, writer_stat_fields):
+    """Fail closed unless the sealed supervisor owns the exact writer shape."""
+    if sealed["mode"] == "systemd-unit":
+        if (writer_unified != supervisor_unified
+                or (sealed["unit"] == "arc-node.service"
+                    and writer_pid != supervisor_pid)):
+            fail("sealed systemd writer topology changed")
+    elif (sealed["unit"] != "arc-self-heal.service"
+            or writer_pid == supervisor_pid
+            or len(writer_stat_fields) < 4
+            or writer_stat_fields[1] != "1"
+            or writer_stat_fields[3] != str(writer_pid)):
+        fail("sealed detached root-session writer topology changed")
+
+
 def verify_supervisor(frozen, target):
     """Prove the exact live supervisor plus detached/direct writer topology."""
     verify_writer(target)
@@ -5545,12 +5562,9 @@ def verify_supervisor(frozen, target):
         fail("sealed quarantine-round writer cgroup path changed")
     stat_raw = (writer_proc / "stat").read_text(encoding="ascii")
     fields = stat_raw[stat_raw.rfind(")") + 2:].split()
-    if sealed["mode"] == "systemd-unit":
-        if writer_pid != pid or writer_unified != unified:
-            fail("sealed systemd writer topology changed")
-    elif (sealed["unit"] != "arc-self-heal.service" or writer_pid == pid
-            or len(fields) < 4 or fields[1] != "1" or fields[3] != str(writer_pid)):
-        fail("sealed detached root-session writer topology changed")
+    verify_supervisor_writer_topology(
+        sealed, pid, unified, writer_pid, writer_unified, fields,
+    )
 
 def validate_authorization(raw):
     if sha(raw) != authorization_sha:

--- a/scripts/recovery/quarantine_round_driver.py
+++ b/scripts/recovery/quarantine_round_driver.py
@@ -425,7 +425,11 @@ def build_authorization(args: argparse.Namespace) -> dict[str, Any]:
     ):
         fail("quarantine authorization live-observation selection differs")
     authorized_at = utc_now()
-    deadline = public_completed + dt.timedelta(seconds=rounds.MAX_WINDOW_SECONDS)
+    authorization_now = rounds.parse_utc(authorized_at, "authorization now")
+    public_deadline = public_completed + dt.timedelta(seconds=rounds.MAX_WINDOW_SECONDS)
+    if authorization_now > public_deadline:
+        fail("target public receipt expired before round authorization")
+    deadline = public_deadline
     if args.round_number == 1:
         try:
             selected_at = dt.datetime.strptime(
@@ -434,11 +438,12 @@ def build_authorization(args: argparse.Namespace) -> dict[str, Any]:
         except (KeyError, TypeError, ValueError) as error:
             raise DriverError("live-observation selection timestamp differs") from error
         selection_deadline = selected_at + dt.timedelta(seconds=rounds.MAX_WINDOW_SECONDS)
-        deadline = min(deadline, selection_deadline.replace(microsecond=0))
-        if rounds.parse_utc(authorized_at, "authorization now") < selected_at:
+        selection_deadline = selection_deadline.replace(microsecond=0)
+        if authorization_now < selected_at:
             fail("quarantine authorization predates live-observation selection")
-    if rounds.parse_utc(authorized_at, "authorization now") > deadline:
-        fail("target public receipt expired before round authorization")
+        if authorization_now > selection_deadline:
+            fail("live-observation selection expired before round authorization")
+        deadline = min(deadline, selection_deadline)
     value = {
         "schema": rounds.ROUND_AUTH_SCHEMA,
         "capture_id": args.capture_id,

--- a/scripts/recovery/quarantine_rounds.py
+++ b/scripts/recovery/quarantine_rounds.py
@@ -38,6 +38,7 @@ NODE_STOPPED_PRECOMMIT_SCHEMA = (
 )
 ROUND_RESULT_SCHEMA = "arc.recovery.quarantine-round-result.v3"
 INERT_NODE_PROOF_SCHEMA = "arc.recovery.quarantine-round-zero-progress-node-proof.v1"
+ZERO_PROGRESS_RELEASE_SCHEMA = "arc.recovery.quarantine-round-zero-progress-release.v1"
 LEDGER_SCHEMA = "arc.recovery.quarantine-generation-ledger.v2"
 TARGET_HEIGHT_SCHEMA = "arc.recovery.legacy-public-height-targets.v1"
 TARGET_CROSS_SCHEMA = "arc.recovery.authenticated-legacy-height-targets.v1"
@@ -2465,6 +2466,263 @@ def validate_round_result(
         "transitioned_names": transitioned_names,
         "remaining_names": remaining,
     }
+
+
+def validate_zero_progress_attempt(
+    *,
+    authorization: Mapping[str, Any],
+    readiness: Mapping[str, Any],
+    dispatch: Mapping[str, Any],
+    prior_authorizations: Sequence[Mapping[str, Any]] = (),
+    prior_results: Sequence[Mapping[str, Any]] = (),
+    result: Mapping[str, Any] | None = None,
+    expected_capture_id: str | None = None,
+    expected_freeze_sha256: str | None = None,
+    containing_round_name: str | None = None,
+) -> dict[str, Any]:
+    """Validate an inert dispatched attempt and its complete positive prefix.
+
+    A current authorization hash transitively binds the immutable result roots,
+    but that is useful only after every prefix result has been validated in
+    order.  This shared contract is used before issuing remote challenges and
+    by every consumer of a zero-progress release receipt.
+    """
+    if len(prior_authorizations) != len(prior_results):
+        fail("zero-progress prior quarantine-round pair count differs")
+    validated_results: list[Mapping[str, Any]] = []
+    prefix_states: list[dict[str, Any]] = []
+    for number, (prior_authorization, prior_result) in enumerate(
+        zip(prior_authorizations, prior_results), start=1
+    ):
+        wrappers = prior_result.get("transitions")
+        if not isinstance(wrappers, list):
+            fail("zero-progress prior quarantine-round transition set differs")
+        transitions = [
+            validate_wrapper(wrapper, "zero-progress prefix transition")[0]
+            for wrapper in wrappers
+        ]
+        state = validate_round_result(
+            prior_result,
+            authorization=prior_authorization,
+            prior_results=validated_results,
+            transition_receipts=transitions,
+        )
+        if state["round_number"] != number or not state["transitioned_names"]:
+            fail("zero-progress prior quarantine-round prefix differs")
+        prefix_states.append(state)
+        validated_results.append(prior_result)
+
+    state = validate_round_authorization(
+        authorization, prior_results=validated_results
+    )
+    number = state["round_number"]
+    if number != len(validated_results) + 1:
+        fail("zero-progress current quarantine round is not contiguous")
+    if containing_round_name is not None and containing_round_name != f"round-{number}":
+        fail("zero-progress attempt directory round differs")
+    if expected_capture_id is not None and state["capture_id"] != expected_capture_id:
+        fail("zero-progress attempt capture differs")
+    if (
+        expected_freeze_sha256 is not None
+        and state["freeze_plan_sha256"] != expected_freeze_sha256
+    ):
+        fail("zero-progress attempt freeze root differs")
+    observation_identity = (
+        state["live_observation_selection_sha256"],
+        state["live_observation_generation"],
+        state["observation_generation_receipt_sha256"],
+        state["drive_prefreeze_receipt_sha256"],
+    )
+    for prefix in prefix_states:
+        if (
+            prefix["capture_id"] != state["capture_id"]
+            or prefix["freeze_plan_sha256"] != state["freeze_plan_sha256"]
+            or prefix["source_main_commit"] != state["source_main_commit"]
+            or (
+                prefix["live_observation_selection_sha256"],
+                prefix["live_observation_generation"],
+                prefix["observation_generation_receipt_sha256"],
+                prefix["drive_prefreeze_receipt_sha256"],
+            )
+            != observation_identity
+        ):
+            fail("zero-progress prior quarantine-round identity differs")
+
+    auth_sha = digest(authorization)
+    readiness_sha = digest(readiness)
+    dispatch_sha = digest(dispatch)
+    probe = {
+        "schema": ROUND_RESULT_SCHEMA,
+        "capture_id": state["capture_id"],
+        "freeze_plan_sha256": state["freeze_plan_sha256"],
+        "round_number": number,
+        "round_authorization_sha256": auth_sha,
+        "target_readiness": wrap(readiness),
+        "transitions": [],
+        "mutation_dispatch": wrap(dispatch),
+        "remaining_target_inert_proofs": [],
+        "remaining_targets": state["target_names"],
+        "completed_at": authorization["authorization_deadline"],
+    }
+    validate_round_result(
+        probe,
+        authorization=authorization,
+        prior_results=validated_results,
+        transition_receipts=[],
+    )
+    if result is not None:
+        if result.get("transitions") != []:
+            fail("zero-progress attempt result transitioned")
+        validate_round_result(
+            result,
+            authorization=authorization,
+            prior_results=validated_results,
+            transition_receipts=[],
+        )
+    return {
+        **state,
+        "authorization_sha256": auth_sha,
+        "readiness_sha256": readiness_sha,
+        "dispatch_sha256": dispatch_sha,
+        "readiness_acceptances": {
+            row["node"]: row["authorization_acceptance"]["value"]
+            for row in readiness["targets"]
+        },
+    }
+
+
+def validate_zero_progress_release(
+    value: Any,
+    *,
+    authorization: Mapping[str, Any],
+    readiness: Mapping[str, Any],
+    dispatch: Mapping[str, Any],
+    prior_authorizations: Sequence[Mapping[str, Any]] = (),
+    prior_results: Sequence[Mapping[str, Any]] = (),
+    result: Mapping[str, Any] | None = None,
+    expected_capture_id: str | None = None,
+    expected_freeze_sha256: str | None = None,
+    containing_round_name: str | None = None,
+) -> dict[str, Any]:
+    """Validate a challenged release for an expired zero-progress dispatch."""
+    state = validate_zero_progress_attempt(
+        authorization=authorization,
+        readiness=readiness,
+        dispatch=dispatch,
+        prior_authorizations=prior_authorizations,
+        prior_results=prior_results,
+        result=result,
+        expected_capture_id=expected_capture_id,
+        expected_freeze_sha256=expected_freeze_sha256,
+        containing_round_name=containing_round_name,
+    )
+    fields = {
+        "schema", "capture_id", "freeze_plan_sha256", "round_number",
+        "round_authorization_sha256", "round_readiness_sha256",
+        "mutation_dispatch_sha256", "live_observation_selection_sha256",
+        "live_observation_generation", "observation_generation_receipt_sha256",
+        "drive_prefreeze_receipt_sha256", "challenge", "released_at", "nodes",
+    }
+    if not isinstance(value, dict) or set(value) != fields:
+        fail("zero-progress release fields differ")
+    challenge = require_hash(value.get("challenge"), "zero-progress release challenge")
+    parse_utc(value.get("released_at"), "zero-progress release time")
+    if (
+        value.get("schema") != ZERO_PROGRESS_RELEASE_SCHEMA
+        or (
+            value.get("capture_id"),
+            value.get("freeze_plan_sha256"),
+            value.get("round_number"),
+            value.get("round_authorization_sha256"),
+            value.get("round_readiness_sha256"),
+            value.get("mutation_dispatch_sha256"),
+            value.get("live_observation_selection_sha256"),
+            value.get("live_observation_generation"),
+            value.get("observation_generation_receipt_sha256"),
+            value.get("drive_prefreeze_receipt_sha256"),
+        )
+        != (
+            state["capture_id"],
+            state["freeze_plan_sha256"],
+            state["round_number"],
+            state["authorization_sha256"],
+            state["readiness_sha256"],
+            state["dispatch_sha256"],
+            state["live_observation_selection_sha256"],
+            state["live_observation_generation"],
+            state["observation_generation_receipt_sha256"],
+            state["drive_prefreeze_receipt_sha256"],
+        )
+    ):
+        fail("zero-progress release identity differs")
+    wrappers = value.get("nodes")
+    if not isinstance(wrappers, list) or len(wrappers) != len(state["target_names"]):
+        fail("zero-progress release node proof count differs")
+    proof_fields = {
+        "schema", "capture_id", "freeze_plan_sha256", "observation_generation",
+        "round_number", "round_authorization_sha256", "round_readiness_sha256",
+        "mutation_dispatch_sha256", "challenge", "node", "boot_id",
+        "writer_live_unfenced", "apply_state_present",
+        "restart_effective_mutation_absent", "active_selector_absent",
+        "quarantine_nft_absent", "authorization_accepted", "readiness_present",
+        "accepted_boottime_ns", "elapsed_since_acceptance_ns",
+        "observed_boottime_ns", "observed_at",
+    }
+    for wrapper, name in zip(wrappers, state["target_names"]):
+        proof, _proof_sha = validate_wrapper(
+            wrapper, f"{name} zero-progress release proof"
+        )
+        accepted = proof.get("accepted_boottime_ns")
+        elapsed = proof.get("elapsed_since_acceptance_ns")
+        observed = proof.get("observed_boottime_ns")
+        acceptance = state["readiness_acceptances"][name]
+        target = state["target_rows"][name]
+        if (
+            set(proof) != proof_fields
+            or proof.get("schema") != INERT_NODE_PROOF_SCHEMA
+            or (
+                proof.get("capture_id"),
+                proof.get("freeze_plan_sha256"),
+                proof.get("observation_generation"),
+                proof.get("round_number"),
+                proof.get("round_authorization_sha256"),
+                proof.get("round_readiness_sha256"),
+                proof.get("mutation_dispatch_sha256"),
+                proof.get("challenge"),
+                proof.get("node"),
+                proof.get("boot_id"),
+            )
+            != (
+                state["capture_id"],
+                state["freeze_plan_sha256"],
+                state["live_observation_generation"],
+                state["round_number"],
+                state["authorization_sha256"],
+                state["readiness_sha256"],
+                state["dispatch_sha256"],
+                challenge,
+                name,
+                target["boot_id"],
+            )
+            or proof.get("writer_live_unfenced") is not True
+            or proof.get("restart_effective_mutation_absent") is not True
+            or proof.get("active_selector_absent") is not True
+            or proof.get("quarantine_nft_absent") is not True
+            or proof.get("authorization_accepted") is not True
+            or not isinstance(proof.get("apply_state_present"), bool)
+            or not isinstance(proof.get("readiness_present"), bool)
+            or any(
+                isinstance(number, bool) or not isinstance(number, int) or number <= 0
+                for number in (accepted, elapsed, observed)
+            )
+            or accepted != acceptance.get("accepted_monotonic_ns")
+            or proof.get("boot_id") != acceptance.get("accepted_boot_id")
+            or observed - accepted != elapsed
+            or elapsed <= MAX_WINDOW_SECONDS * 1_000_000_000
+        ):
+            fail(f"{name} zero-progress release proof differs")
+        parse_utc(proof.get("observed_at"), f"{name} zero-progress proof time")
+    return state
 
 
 def validate_generation_ledger(value: Any) -> dict[str, Any]:

--- a/scripts/recovery/test_archive_node_quarantine_runtime.py
+++ b/scripts/recovery/test_archive_node_quarantine_runtime.py
@@ -427,6 +427,109 @@ class EmbeddedProgramTests(unittest.TestCase):
         self.assertIn("len(rows) != len(auth_target_names)", self.outer)
         self.assertNotIn("len(targets) != 1", self.outer)
 
+    def test_supervisor_writer_topology_matches_each_sealed_production_shape(self) -> None:
+        tree = ast.parse(self.outer)
+        topology_function = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "verify_supervisor_writer_topology"
+        )
+
+        class TopologyError(RuntimeError):
+            pass
+
+        def fail(message: str) -> None:
+            raise TopologyError(message)
+
+        namespace: dict[str, object] = {"fail": fail}
+        exec(
+            compile(
+                ast.Module(body=[topology_function], type_ignores=[]),
+                "supervisor-writer-topology",
+                "exec",
+            ),
+            namespace,
+        )
+        verify = namespace["verify_supervisor_writer_topology"]
+        systemd_cgroup = ["/system.slice/arc-self-heal.service"]
+        writer_stat = ["S", "1", "200", "200"]
+
+        # The five production self-heal units own an exact writer child in the
+        # same sealed systemd cgroup; their MainPID is intentionally distinct.
+        verify(
+            {"mode": "systemd-unit", "unit": "arc-self-heal.service"},
+            100,
+            systemd_cgroup,
+            200,
+            systemd_cgroup,
+            writer_stat,
+        )
+        with self.assertRaisesRegex(TopologyError, "systemd writer topology"):
+            verify(
+                {"mode": "systemd-unit", "unit": "arc-self-heal.service"},
+                100,
+                systemd_cgroup,
+                200,
+                ["/user.slice/user-0.slice/session-1.scope"],
+                writer_stat,
+            )
+
+        # A direct arc-node.service remains stricter: its sealed MainPID must
+        # be the writer as well as sharing the exact cgroup.
+        direct = ["/system.slice/arc-node.service"]
+        with self.assertRaisesRegex(TopologyError, "systemd writer topology"):
+            verify(
+                {"mode": "systemd-unit", "unit": "arc-node.service"},
+                100,
+                direct,
+                200,
+                direct,
+                writer_stat,
+            )
+        verify(
+            {"mode": "systemd-unit", "unit": "arc-node.service"},
+            100,
+            direct,
+            100,
+            direct,
+            ["S", "1", "100", "100"],
+        )
+
+        # The detached production shape remains a disjoint PID-1 child and
+        # session leader supervised by arc-self-heal.service.
+        verify(
+            {"mode": "detached-root-session", "unit": "arc-self-heal.service"},
+            100,
+            systemd_cgroup,
+            200,
+            ["/user.slice/user-0.slice/session-1.scope"],
+            writer_stat,
+        )
+        for invalid in (
+            ({"mode": "detached-root-session", "unit": "arc-node.service"}, 200, writer_stat),
+            ({"mode": "detached-root-session", "unit": "arc-self-heal.service"}, 100, writer_stat),
+            ({"mode": "detached-root-session", "unit": "arc-self-heal.service"}, 200, ["S", "9", "200", "200"]),
+            ({"mode": "detached-root-session", "unit": "arc-self-heal.service"}, 200, ["S", "1", "200", "201"]),
+        ):
+            sealed, writer_pid, fields = invalid
+            with self.assertRaisesRegex(TopologyError, "detached root-session"):
+                verify(
+                    sealed,
+                    100,
+                    systemd_cgroup,
+                    writer_pid,
+                    ["/user.slice/user-0.slice/session-1.scope"],
+                    fields,
+                )
+
+        self.assertIn(
+            "verify_supervisor_writer_topology(\n"
+            "        sealed, pid, unified, writer_pid, writer_unified, fields,\n"
+            "    )",
+            self.outer,
+        )
+
     def test_no_runtime_mutation_precedes_readiness(self) -> None:
         ready = self.outer.index("readiness = validate_readiness(readiness_raw")
         for token in (

--- a/scripts/recovery/test_quarantine_rounds.py
+++ b/scripts/recovery/test_quarantine_rounds.py
@@ -680,6 +680,98 @@ def authorized_height(auth: dict, name: str) -> int:
     return next(row["loopback_info_after_height"] for row in nodes if row["node"] == name) + 1
 
 
+def zero_progress_release(auth: dict, readiness: dict, dispatch: dict) -> dict:
+    challenge = H["96"]
+    return {
+        "schema": qr.ZERO_PROGRESS_RELEASE_SCHEMA,
+        "capture_id": CAPTURE,
+        "freeze_plan_sha256": FREEZE,
+        "round_number": auth["round_number"],
+        "round_authorization_sha256": qr.digest(auth),
+        "round_readiness_sha256": qr.digest(readiness),
+        "mutation_dispatch_sha256": qr.digest(dispatch),
+        "live_observation_selection_sha256": auth[
+            "live_observation_selection_sha256"
+        ],
+        "live_observation_generation": auth["live_observation_generation"],
+        "observation_generation_receipt_sha256": auth[
+            "observation_generation_receipt_sha256"
+        ],
+        "drive_prefreeze_receipt_sha256": auth[
+            "drive_prefreeze_receipt_sha256"
+        ],
+        "challenge": challenge,
+        "released_at": utc(4000),
+        "nodes": [
+            qr.wrap(
+                remaining_target_inert_proof(
+                    auth, readiness, dispatch, target["node"], challenge=challenge
+                )
+            )
+            for target in auth["targets"]
+        ],
+    }
+
+
+def zero_progress_fixture(
+    round_number: int,
+    *,
+    transition_choices: list[str] | None = None,
+) -> dict:
+    if not 1 <= round_number <= len(qr.FLEET):
+        raise ValueError("round_number must fit the fixed fleet")
+    if transition_choices is None:
+        transition_choices = [
+            qr.FLEET[index][0] for index in range(round_number - 1)
+        ]
+    if len(transition_choices) != round_number - 1:
+        raise ValueError("one positive transition is required for each prefix round")
+
+    remaining = [name for name, _host in qr.FLEET]
+    prior_authorizations: list[dict] = []
+    prior_results: list[dict] = []
+    for number, chosen in enumerate(transition_choices, start=1):
+        if chosen not in remaining:
+            raise ValueError(f"{chosen} is not available in prefix round {number}")
+        offset = (number - 1) * 400
+        auth = authorization(number, prior_results, remaining, offset)
+        item = applied(auth, chosen, offset + 20, authorized_height(auth, chosen))
+        round_result = result(auth, [item], offset + 330)
+        prior_authorizations.append(auth)
+        prior_results.append(round_result)
+        remaining = [name for name in remaining if name != chosen]
+
+    offset = (round_number - 1) * 400
+    auth = authorization(round_number, prior_results, remaining, offset)
+    readiness = target_readiness(auth)
+    dispatch = mutation_dispatch(auth, readiness)
+    return {
+        "authorization": auth,
+        "readiness": readiness,
+        "dispatch": dispatch,
+        "result": result(auth, [], offset + 303),
+        "release": zero_progress_release(auth, readiness, dispatch),
+        "prior_authorizations": prior_authorizations,
+        "prior_results": prior_results,
+    }
+
+
+def zero_progress_validation_args(fixture: dict) -> dict:
+    return {
+        "authorization": fixture["authorization"],
+        "readiness": fixture["readiness"],
+        "dispatch": fixture["dispatch"],
+        "prior_authorizations": fixture["prior_authorizations"],
+        "prior_results": fixture["prior_results"],
+        "result": fixture["result"],
+        "expected_capture_id": CAPTURE,
+        "expected_freeze_sha256": FREEZE,
+        "containing_round_name": (
+            f"round-{fixture['authorization']['round_number']}"
+        ),
+    }
+
+
 def ledger_for_first_successes(count: int) -> dict:
     names = [name for name, _host in qr.FLEET]
     results: list[dict] = [];round_rows = []
@@ -831,6 +923,188 @@ class QuarantineRoundTests(unittest.TestCase):
         ledger["rounds"][0] = {"authorization": qr.wrap(auth), "result": qr.wrap(empty)}
         with self.assertRaisesRegex(qr.QuarantineRoundError, "zero-progress"):
             qr.validate_generation_ledger(ledger)
+
+    def test_shared_zero_progress_contract_accepts_rounds_one_through_six(self) -> None:
+        names = [name for name, _host in qr.FLEET]
+        for round_number in range(1, len(names) + 1):
+            with self.subTest(round_number=round_number):
+                fixture = zero_progress_fixture(round_number)
+                args = zero_progress_validation_args(fixture)
+                expected_targets = names[round_number - 1:]
+
+                attempt_state = qr.validate_zero_progress_attempt(**args)
+                release_state = qr.validate_zero_progress_release(
+                    fixture["release"], **args
+                )
+
+                self.assertEqual(attempt_state["round_number"], round_number)
+                self.assertEqual(attempt_state["target_names"], expected_targets)
+                self.assertEqual(release_state["target_names"], expected_targets)
+                self.assertEqual(len(expected_targets), len(names) + 1 - round_number)
+                self.assertEqual(
+                    [wrapper["value"]["node"] for wrapper in fixture["release"]["nodes"]],
+                    expected_targets,
+                )
+
+    def test_shared_zero_progress_contract_accepts_noncontiguous_remaining_subset(self) -> None:
+        fixture = zero_progress_fixture(
+            3, transition_choices=["lax", "sgp"]
+        )
+        expected_targets = [
+            name for name, _host in qr.FLEET if name not in {"lax", "sgp"}
+        ]
+        args = zero_progress_validation_args(fixture)
+
+        self.assertEqual(
+            qr.validate_zero_progress_attempt(**args)["target_names"],
+            expected_targets,
+        )
+        self.assertEqual(
+            qr.validate_zero_progress_release(fixture["release"], **args)[
+                "target_names"
+            ],
+            expected_targets,
+        )
+
+    def test_zero_progress_release_requires_exact_ordered_proof_set(self) -> None:
+        fixture = zero_progress_fixture(3)
+        args = zero_progress_validation_args(fixture)
+
+        missing = copy.deepcopy(fixture["release"])
+        missing["nodes"].pop()
+        reordered = copy.deepcopy(fixture["release"])
+        reordered["nodes"][0], reordered["nodes"][1] = (
+            reordered["nodes"][1], reordered["nodes"][0]
+        )
+        extra = copy.deepcopy(fixture["release"])
+        extra["nodes"].append(copy.deepcopy(extra["nodes"][0]))
+
+        for label, release, message in (
+            ("missing", missing, "proof count"),
+            ("reordered", reordered, "proof differs"),
+            ("extra", extra, "proof count"),
+        ):
+            with self.subTest(case=label), self.assertRaisesRegex(
+                qr.QuarantineRoundError, message
+            ):
+                qr.validate_zero_progress_release(release, **args)
+
+    def test_zero_progress_release_rejects_wrong_or_unexpired_boottime(self) -> None:
+        fixture = zero_progress_fixture(4)
+        args = zero_progress_validation_args(fixture)
+
+        wrong_acceptance = copy.deepcopy(fixture["release"])
+        proof = wrong_acceptance["nodes"][0]["value"]
+        proof["accepted_boottime_ns"] += 1
+        proof["observed_boottime_ns"] += 1
+        wrong_acceptance["nodes"][0] = qr.wrap(proof)
+
+        not_expired = copy.deepcopy(fixture["release"])
+        proof = not_expired["nodes"][0]["value"]
+        proof["elapsed_since_acceptance_ns"] = (
+            qr.MAX_WINDOW_SECONDS * 1_000_000_000
+        )
+        proof["observed_boottime_ns"] = (
+            proof["accepted_boottime_ns"] + proof["elapsed_since_acceptance_ns"]
+        )
+        not_expired["nodes"][0] = qr.wrap(proof)
+
+        for label, release in (
+            ("wrong accepted BOOTTIME", wrong_acceptance),
+            ("elapsed at the 300-second boundary", not_expired),
+        ):
+            with self.subTest(case=label), self.assertRaisesRegex(
+                qr.QuarantineRoundError, "proof differs"
+            ):
+                qr.validate_zero_progress_release(release, **args)
+
+    def test_zero_progress_attempt_rejects_missing_reordered_or_tampered_prefix(self) -> None:
+        fixture = zero_progress_fixture(4)
+        args = zero_progress_validation_args(fixture)
+
+        missing_authorization = {
+            **args,
+            "prior_authorizations": args["prior_authorizations"][:-1],
+        }
+        missing_pair = {
+            **args,
+            "prior_authorizations": args["prior_authorizations"][:-1],
+            "prior_results": args["prior_results"][:-1],
+        }
+        reordered = {
+            **args,
+            "prior_authorizations": [
+                args["prior_authorizations"][1],
+                args["prior_authorizations"][0],
+                *args["prior_authorizations"][2:],
+            ],
+            "prior_results": [
+                args["prior_results"][1],
+                args["prior_results"][0],
+                *args["prior_results"][2:],
+            ],
+        }
+        tampered_results = copy.deepcopy(args["prior_results"])
+        tampered_results[0]["completed_at"] = utc(331)
+        tampered = {**args, "prior_results": tampered_results}
+
+        for label, invalid_args in (
+            ("missing authorization", missing_authorization),
+            ("missing pair", missing_pair),
+            ("reordered", reordered),
+            ("tampered", tampered),
+        ):
+            with self.subTest(case=label), self.assertRaises(qr.QuarantineRoundError):
+                qr.validate_zero_progress_attempt(**invalid_args)
+
+    def test_zero_progress_attempt_rejects_zero_progress_prefix(self) -> None:
+        names = [name for name, _host in qr.FLEET]
+        prefix_auth = authorization(1, [], names, 0)
+        zero_prefix = result(prefix_auth, [], 303)
+        auth = authorization(2, [zero_prefix], names, 400)
+        readiness = target_readiness(auth)
+        dispatch = mutation_dispatch(auth, readiness)
+
+        with self.assertRaisesRegex(
+            qr.QuarantineRoundError, "prior quarantine-round prefix differs"
+        ):
+            qr.validate_zero_progress_attempt(
+                authorization=auth,
+                readiness=readiness,
+                dispatch=dispatch,
+                prior_authorizations=[prefix_auth],
+                prior_results=[zero_prefix],
+                expected_capture_id=CAPTURE,
+                expected_freeze_sha256=FREEZE,
+                containing_round_name="round-2",
+            )
+
+    def test_zero_progress_attempt_rejects_observation_identity_change(self) -> None:
+        fixture = zero_progress_fixture(3)
+        for field in (
+            "live_observation_selection_sha256",
+            "live_observation_generation",
+            "observation_generation_receipt_sha256",
+            "drive_prefreeze_receipt_sha256",
+        ):
+            auth = copy.deepcopy(fixture["authorization"])
+            auth[field] = H["95"]
+            readiness = target_readiness(auth)
+            dispatch = mutation_dispatch(auth, readiness)
+            with self.subTest(field=field), self.assertRaisesRegex(
+                qr.QuarantineRoundError,
+                "prior quarantine-round identity differs",
+            ):
+                qr.validate_zero_progress_attempt(
+                    authorization=auth,
+                    readiness=readiness,
+                    dispatch=dispatch,
+                    prior_authorizations=fixture["prior_authorizations"],
+                    prior_results=fixture["prior_results"],
+                    expected_capture_id=CAPTURE,
+                    expected_freeze_sha256=FREEZE,
+                    containing_round_name="round-3",
+                )
 
     def test_reordered_transition_receipts_rejected(self) -> None:
         value = ledger_for_first_successes(3)

--- a/tests/release/recovery_archive_contract_test.sh
+++ b/tests/release/recovery_archive_contract_test.sh
@@ -1474,6 +1474,207 @@ assert '[ -e "$attempt_root/readiness.json" ]' not in scan
 PY
 )
 
+dispatch_bound_zero_progress_and_expired_selection_stop_before_resample() (
+    local f freeze capture generation selection_sha generation_sha drive_sha status
+    f="$(mktemp -d)"; trap 'rm -rf -- "$f"' EXIT
+    freeze="$(printf 'a%.0s' {1..64})";capture="$(printf 'b%.0s' {1..64})"
+    generation="$(printf 'c%.0s' {1..64})";selection_sha="$(printf 'd%.0s' {1..64})"
+    generation_sha="$(printf 'e%.0s' {1..64})";drive_sha="$(printf 'f%.0s' {1..64})"
+    mkdir -p -- "$f/bound/quarantine-rounds/round-1/attempt.bound" \
+        "$f/expired/quarantine-rounds" "$f/fresh/quarantine-rounds" "$f/logs"
+    printf '{}\n' > "$f/bound/quarantine-rounds/round-1/attempt.bound/authorization.json"
+
+    set +e
+    (
+        # shellcheck source=/dev/null
+        . "$ORCHESTRATOR" >/dev/null
+        manifest_field() { printf '%s\n' "$(printf '1%.0s' {1..40})"; }
+        tracked_source_hash() { printf '%s\n' "$freeze"; }
+        verify_live_observation_selection_exact() { :; }
+        prepare_protected_maintenance_directory() { printf '%s\n' "$1"; }
+        quarantine_round_remaining_targets() { printf 'nyc,lax,ams,lhr,nrt,sgp\n'; }
+        quarantine_authorization_matches_live_observation() { return 0; }
+        complete_quarantine_round_attempt() { return 2; }
+        quarantine_attempt_binds_live_observation_selection() {
+            : > "$f/bound-dispatch-checked"
+            return 0
+        }
+        operator_selection_window_is_live() {
+            : > "$f/bound-selection-rechecked"
+            return 0
+        }
+        mktemp() { : > "$f/bound-resample-attempted"; command mktemp "$@"; }
+        run_quarantine_generation_rounds \
+            "$f/freeze.json" "$freeze" "$capture" "$f/bound" "$f/logs" \
+            "$f/bound-ledger.json" "$freeze" "$freeze" "$freeze" "$freeze" 0 \
+            "$f/selection.json" "$selection_sha" "$f/generation.json" \
+            "$generation" "$generation_sha" "$drive_sha" 1 1
+    ) >"$f/bound.stdout" 2>"$f/bound.stderr"
+    status=$?
+    set -e
+    [ "$status" -ne 0 ] && [ -e "$f/bound-dispatch-checked" ] && \
+        [ ! -e "$f/bound-selection-rechecked" ] && \
+        [ ! -e "$f/bound-resample-attempted" ] || return 1
+    grep -Fq 'dispatch-bound zero-progress quarantine round 1 requires capture resume and BOOTTIME closure' \
+        "$f/bound.stderr" || return 1
+
+    set +e
+    (
+        # shellcheck source=/dev/null
+        . "$ORCHESTRATOR" >/dev/null
+        manifest_field() { printf '%s\n' "$(printf '1%.0s' {1..40})"; }
+        tracked_source_hash() { printf '%s\n' "$freeze"; }
+        verify_live_observation_selection_exact() { :; }
+        prepare_protected_maintenance_directory() { printf '%s\n' "$1"; }
+        quarantine_round_remaining_targets() { printf 'nyc,lax,ams,lhr,nrt,sgp\n'; }
+        operator_selection_window_is_live() {
+            : > "$f/expired-selection-rechecked"
+            return 1
+        }
+        mktemp() { : > "$f/expired-resample-attempted"; command mktemp "$@"; }
+        run_quarantine_generation_rounds \
+            "$f/freeze.json" "$freeze" "$capture" "$f/expired" "$f/logs" \
+            "$f/expired-ledger.json" "$freeze" "$freeze" "$freeze" "$freeze" 0 \
+            "$f/selection.json" "$selection_sha" "$f/generation.json" \
+            "$generation" "$generation_sha" "$drive_sha" 1 1
+    ) >"$f/expired.stdout" 2>"$f/expired.stderr"
+    status=$?
+    set -e
+    [ "$status" -ne 0 ] && [ -e "$f/expired-selection-rechecked" ] && \
+        [ ! -e "$f/expired-resample-attempted" ] || return 1
+    grep -Fq 'live-observation selection expired before fresh quarantine round' \
+        "$f/expired.stderr" || return 1
+
+    set +e
+    (
+        # Exercise the post-dispatch guard on a brand-new attempt. If that
+        # guard regresses, the second mktemp fails the fixture before an
+        # accidental resample can loop indefinitely.
+        # shellcheck source=/dev/null
+        . "$ORCHESTRATOR" >/dev/null
+        manifest_field() { printf '%s\n' "$(printf '1%.0s' {1..40})"; }
+        tracked_source_hash() { printf '%s\n' "$freeze"; }
+        verify_live_observation_selection_exact() { :; }
+        prepare_protected_maintenance_directory() { printf '%s\n' "$1"; }
+        quarantine_round_remaining_targets() { printf 'nyc,lax,ams,lhr,nrt,sgp\n'; }
+        operator_selection_window_is_live() { return 0; }
+        capture_quarantine_round_prior_statuses() { :; }
+        capture_quarantine_round_target_cross() { :; }
+        capture_quarantine_round_live_sources() { :; }
+        python3() {
+            local argument output="" expect_output=false
+            for argument in "$@"; do
+                if [ "$expect_output" = true ]; then
+                    output="$argument"
+                    expect_output=false
+                elif [ "$argument" = --output ]; then
+                    expect_output=true
+                fi
+            done
+            [ -n "$output" ] || return 1
+            printf '{}\n' > "$output"
+        }
+        complete_quarantine_round_attempt() {
+            : > "$f/fresh-complete-called"
+            return 2
+        }
+        quarantine_attempt_binds_live_observation_selection() {
+            : > "$f/fresh-dispatch-checked"
+            return 0
+        }
+        mktemp() {
+            local count=0
+            [ ! -f "$f/fresh-mktemp-count" ] || count="$(cat "$f/fresh-mktemp-count")"
+            count=$((count + 1))
+            printf '%s\n' "$count" > "$f/fresh-mktemp-count"
+            [ "$count" -eq 1 ] || {
+                : > "$f/fresh-resample-attempted"
+                return 1
+            }
+            command mktemp "$@"
+        }
+        run_quarantine_generation_rounds \
+            "$f/freeze.json" "$freeze" "$capture" "$f/fresh" "$f/logs" \
+            "$f/fresh-ledger.json" "$freeze" "$freeze" "$freeze" "$freeze" 0 \
+            "$f/selection.json" "$selection_sha" "$f/generation.json" \
+            "$generation" "$generation_sha" "$drive_sha" 1 1
+    ) >"$f/fresh.stdout" 2>"$f/fresh.stderr"
+    status=$?
+    set -e
+    [ "$status" -ne 0 ] && [ -e "$f/fresh-complete-called" ] && \
+        [ -e "$f/fresh-dispatch-checked" ] && \
+        [ "$(cat "$f/fresh-mktemp-count")" = 1 ] && \
+        [ ! -e "$f/fresh-resample-attempted" ] || return 1
+    grep -Fq 'dispatch-bound zero-progress quarantine round 1 requires capture resume and BOOTTIME closure' \
+        "$f/fresh.stderr" || return 1
+)
+
+authorization_expiry_reports_the_actual_limiting_receipt() (
+    PYTHONPATH="$REPO_ROOT/scripts/recovery" python3 - <<'PY' || return 1
+import pathlib
+import types
+
+import quarantine_round_driver as driver
+import test_quarantine_rounds as fixture
+
+names = [name for name, _host in fixture.qr.FLEET]
+public = fixture.public_receipt(names, 295)
+cross = fixture.cross_receipt(names, public, 295)
+generation_receipt = {
+    "observation_generation": fixture.H["92"],
+    "drive_prefreeze_receipt": {"sha256": fixture.H["94"]},
+}
+selection = {
+    "schema": "arc.recovery.legacy-live-observation-selection.v1",
+    "freeze_plan_sha256": fixture.FREEZE,
+    "capture_id": fixture.CAPTURE,
+    "observation_generation": fixture.H["92"],
+    "observation_generation_receipt": generation_receipt,
+    "observation_generation_receipt_sha256": driver.digest_bytes(
+        driver.canonical(generation_receipt)
+    ),
+    "drive_prefreeze_receipt_sha256": fixture.H["94"],
+    "selected_at": fixture.BASE.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+}
+args = types.SimpleNamespace(
+    freeze_plan=pathlib.Path("/freeze"),
+    freeze_plan_sha256=fixture.FREEZE,
+    capture_id=fixture.CAPTURE,
+    round_root=pathlib.Path("/rounds"),
+    round_number=1,
+    public=pathlib.Path("/public"),
+    cross=pathlib.Path("/cross"),
+    prior_status_root=pathlib.Path("/prior"),
+    source_capture_root=pathlib.Path("/sources"),
+    live_observation_selection=pathlib.Path("/selection"),
+    live_observation_selection_sha256=driver.digest_bytes(driver.canonical(selection)),
+    output=pathlib.Path("/unused"),
+)
+driver.load_freeze = lambda *_args: {"source_commit": fixture.SOURCE}
+driver.load_prefix = lambda *_args: ([], [])
+
+def read_fixture(_path, label):
+    if label == "round target public receipt":
+        return public
+    if label == "round target authenticated cross proof":
+        return cross
+    if label == "live-observation selection":
+        return selection
+    if label.endswith(" live source capture"):
+        return {}
+    raise AssertionError(label)
+
+driver.read_canonical = read_fixture
+driver.utc_now = lambda: fixture.utc(301)
+try:
+    driver.build_authorization(args)
+except driver.DriverError as error:
+    assert str(error) == "live-observation selection expired before round authorization"
+else:
+    raise AssertionError("fresh public receipt crossed an expired live-observation selection")
+PY
+)
+
 local_create_only_post_link_crashes_are_reconciled_before_resume() (
     # shellcheck source=/dev/null
     . "$ORCHESTRATOR" >/dev/null
@@ -1920,15 +2121,19 @@ PY
 released_zero_progress_attempt_does_not_bind_rotated_selection() (
     # shellcheck source=/dev/null
     . "$ORCHESTRATOR" >/dev/null
-    local f attempt freeze capture
+    local f attempt selection_b identity_b freeze capture current_generation
+    local current_drive resume state resumed_generation unreleased_status
     f="$(mktemp -d)";trap 'rm -rf -- "$f"' EXIT
     attempt="$f/round-1/attempt.released";mkdir -p -- "$attempt/node-transitions"
     chmod 700 "$attempt/node-transitions"
+    selection_b="$f/selection-b.json";identity_b="$f/selection-b.identity"
     freeze="$(printf '0%.0s' {1..63})2";capture="$(printf '0%.0s' {1..63})1"
-    PYTHONPATH="$REPO_ROOT/scripts/recovery" python3 - "$attempt" <<'PY' || return 1
+    PYTHONPATH="$REPO_ROOT/scripts/recovery" python3 - \
+        "$attempt" "$selection_b" "$identity_b" <<'PY' || return 1
 import datetime,hashlib,json,pathlib,sys
 import test_quarantine_rounds as fixture
-root=pathlib.Path(sys.argv[1]);qr=fixture.qr
+root=pathlib.Path(sys.argv[1]);selection_path=pathlib.Path(sys.argv[2])
+identity_path=pathlib.Path(sys.argv[3]);qr=fixture.qr
 canonical=lambda value:(json.dumps(value,sort_keys=True,separators=(",",":"))+"\n").encode()
 digest=lambda value:hashlib.sha256(canonical(value)).hexdigest()
 names=[name for name,_host in qr.FLEET]
@@ -1979,6 +2184,25 @@ for name,value in (("authorization.json",authorization),("readiness.json",readin
                    ("mutation-dispatch.json",dispatch),("result.json",result),
                    ("zero-progress-release.json",release)):
     path=root/name;path.write_bytes(canonical(value));path.chmod(0o400)
+selection_b={
+ "schema":"arc.recovery.legacy-live-observation-selection.v1",
+ "source_main_commit":fixture.SOURCE,"freeze_plan_sha256":fixture.FREEZE,
+ "capture_id":fixture.CAPTURE,"observation_generation":fixture.H["97"],
+ "observation_generation_receipt":{"fixture":"current-selection-b"},
+ "observation_generation_receipt_path":"/sealed/generation-b.json",
+ "observation_generation_receipt_sha256":fixture.H["98"],
+ "drive_prefreeze_receipt_path":"/sealed/drive-prefreeze-b.json",
+ "drive_prefreeze_receipt_sha256":fixture.H["99"],
+ "generation_created_at":fixture.utc(500),
+ "selected_at":fixture.BASE.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+ "max_selection_age_seconds":300,
+ "labels":["diagnostic","noncanonical","nonreward"],"nodes":[]}
+assert digest(selection_b)!=authorization["live_observation_selection_sha256"]
+selection_path.write_bytes(canonical(selection_b));selection_path.chmod(0o400)
+identity_path.write_text(
+    f'{selection_b["observation_generation"]} '
+    f'{selection_b["drive_prefreeze_receipt_sha256"]}\n', encoding="utf-8"
+)
 PY
     # This is the post-release, post-rotation scan of the old attempt.  The
     # exact release makes its readiness/dispatch/result nonbinding.
@@ -1994,6 +2218,30 @@ PY
     set -e
     [ "$invalid_status" -ne 0 ] || return 1
     chmod 400 "$attempt/zero-progress-release.json"
+
+    # Cross-invocation scan: attempt A is bound to an older selection, while
+    # selection B is current.  A complete challenged release must be validated
+    # and skipped before comparing selection identities, so B rotates cleanly.
+    read -r current_generation current_drive < "$identity_b" || return 1
+    resume="$(live_observation_selection_resume_state "$selection_b" "$f" \
+        "$current_drive" "$freeze" "$capture")" || return 1
+    read -r state resumed_generation <<< "$resume"
+    [ "$state" = rotate ] && [ "$resumed_generation" = "$current_generation" ] || \
+        return 1
+
+    # Without the release, the old dispatched authorization is still binding
+    # and another selection must fail closed instead of being silently skipped.
+    mv -- "$attempt/zero-progress-release.json" \
+        "$attempt/zero-progress-release.saved"
+    set +e
+    live_observation_selection_resume_state "$selection_b" "$f" \
+        "$current_drive" "$freeze" "$capture" \
+        >"$f/unreleased.stdout" 2>"$f/unreleased.stderr"
+    unreleased_status=$?
+    set -e
+    [ "$unreleased_status" -ne 0 ] || return 1
+    mv -- "$attempt/zero-progress-release.saved" \
+        "$attempt/zero-progress-release.json"
     python3 - "$ORCHESTRATOR" <<'PY' || return 1
 import pathlib,sys
 text=pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
@@ -2002,6 +2250,188 @@ scan=text[text.index("run_quarantine_generation_rounds()"):
 assert 'quarantine_attempt_binds_live_observation_selection' in scan
 assert 'quarantine_attempt_has_valid_zero_progress_release' in text
 PY
+)
+
+later_round_zero_progress_release_requires_exact_remaining_subset_and_prefix() (
+    # shellcheck source=/dev/null
+    . "$ORCHESTRATOR" >/dev/null
+    local f rounds round_one attempt selection freeze capture generation drive state
+    f="$(mktemp -d)";trap 'chmod -R u+w "$f" 2>/dev/null || true; rm -rf -- "$f"' EXIT
+    rounds="$f/quarantine-rounds"
+    round_one="$rounds/round-1"
+    attempt="$rounds/round-2/attempt.released"
+    selection="$f/selection.json"
+    mkdir -p -- "$round_one" "$attempt/node-transitions"
+    chmod 700 "$rounds" "$round_one" "$rounds/round-2" \
+        "$attempt" "$attempt/node-transitions"
+
+    PYTHONPATH="$REPO_ROOT/scripts/recovery" command python3 - \
+        "$round_one" "$attempt" "$selection" > "$f/fixture-identities" <<'PY' || \
+        return 1
+import copy
+import datetime
+import hashlib
+import json
+import pathlib
+import sys
+
+import quarantine_round_driver as driver
+import test_quarantine_rounds as fixture
+
+round_one, attempt, selection_path = map(pathlib.Path, sys.argv[1:])
+qr = fixture.qr
+canonical = driver.canonical
+digest = lambda value: hashlib.sha256(canonical(value)).hexdigest()
+names = [name for name, _host in qr.FLEET]
+
+# The immutable first-round prefix secured two nodes.  Its positive result is
+# the causal proof that a later authorization may target only the remainder.
+selection = {
+    "schema": "arc.recovery.legacy-live-observation-selection.v1",
+    "source_main_commit": fixture.SOURCE,
+    "freeze_plan_sha256": fixture.FREEZE,
+    "capture_id": fixture.CAPTURE,
+    "observation_generation": fixture.H["92"],
+    "observation_generation_receipt": {"fixture": "bound"},
+    "observation_generation_receipt_path": "/sealed/generation.json",
+    "observation_generation_receipt_sha256": fixture.H["93"],
+    "drive_prefreeze_receipt_path": "/sealed/drive-prefreeze.json",
+    "drive_prefreeze_receipt_sha256": fixture.H["94"],
+    "generation_created_at": fixture.utc(1),
+    "selected_at": (fixture.BASE + datetime.timedelta(seconds=2)).strftime(
+        "%Y-%m-%dT%H:%M:%S.%fZ"
+    ),
+    "max_selection_age_seconds": 300,
+    "labels": ["diagnostic", "noncanonical", "nonreward"],
+    "nodes": [],
+}
+selection_sha = digest(selection)
+
+authorization_one = fixture.authorization(1, [], names, 0)
+authorization_one["live_observation_selection_sha256"] = selection_sha
+authorization_one["live_observation_selected_at"] = selection["selected_at"]
+first_transitions = [
+    fixture.applied(
+        authorization_one,
+        name,
+        20 + index,
+        fixture.authorized_height(authorization_one, name),
+    )
+    for index, name in enumerate(names[:2])
+]
+result_one = fixture.result(authorization_one, first_transitions, 330)
+remaining = names[2:]
+
+authorization_two = fixture.authorization(2, [result_one], remaining, 400)
+authorization_two["live_observation_selection_sha256"] = selection_sha
+authorization_two["live_observation_selected_at"] = selection["selected_at"]
+readiness_two = fixture.target_readiness(authorization_two)
+dispatch_two = fixture.mutation_dispatch(authorization_two, readiness_two)
+result_two = fixture.result(authorization_two, [], 703)
+challenge = "5" * 64
+proofs = []
+for name in remaining:
+    proof = fixture.remaining_target_inert_proof(
+        authorization_two, readiness_two, dispatch_two, name, challenge=challenge
+    )
+    proof["observed_at"] = fixture.utc(800)
+    proofs.append(qr.wrap(proof))
+release = {
+    "schema": qr.ZERO_PROGRESS_RELEASE_SCHEMA,
+    "capture_id": fixture.CAPTURE,
+    "freeze_plan_sha256": fixture.FREEZE,
+    "round_number": 2,
+    "round_authorization_sha256": digest(authorization_two),
+    "round_readiness_sha256": digest(readiness_two),
+    "mutation_dispatch_sha256": digest(dispatch_two),
+    "live_observation_selection_sha256": selection_sha,
+    "live_observation_generation": authorization_two["live_observation_generation"],
+    "observation_generation_receipt_sha256": authorization_two[
+        "observation_generation_receipt_sha256"
+    ],
+    "drive_prefreeze_receipt_sha256": authorization_two[
+        "drive_prefreeze_receipt_sha256"
+    ],
+    "challenge": challenge,
+    "released_at": fixture.utc(801),
+    "nodes": proofs,
+}
+
+missing = copy.deepcopy(release)
+missing["nodes"].pop()
+reordered = copy.deepcopy(release)
+reordered["nodes"][0], reordered["nodes"][1] = (
+    reordered["nodes"][1], reordered["nodes"][0]
+)
+tampered = copy.deepcopy(release)
+tampered_proof = copy.deepcopy(tampered["nodes"][0]["value"])
+tampered_proof["writer_live_unfenced"] = False
+tampered["nodes"][0] = qr.wrap(tampered_proof)
+
+assert [row["node"] for row in authorization_one["targets"]] == names
+assert [row["value"]["node"] for row in result_one["transitions"]] == names[:2]
+assert [row["node"] for row in authorization_two["targets"]] == remaining
+assert [row["value"]["node"] for row in release["nodes"]] == remaining
+for path, value in (
+    (selection_path, selection),
+    (round_one / "authorization.json", authorization_one),
+    (round_one / "result.json", result_one),
+    (attempt / "authorization.json", authorization_two),
+    (attempt / "readiness.json", readiness_two),
+    (attempt / "mutation-dispatch.json", dispatch_two),
+    (attempt / "result.json", result_two),
+    (attempt / "zero-progress-release.json", release),
+    (attempt / "zero-progress-release.missing.json", missing),
+    (attempt / "zero-progress-release.reordered.json", reordered),
+    (attempt / "zero-progress-release.tampered.json", tampered),
+):
+    path.write_bytes(canonical(value))
+    path.chmod(0o400)
+print(fixture.FREEZE, fixture.CAPTURE, fixture.H["92"], fixture.H["94"])
+PY
+    read -r freeze capture generation drive < "$f/fixture-identities" || return 1
+
+    quarantine_attempt_has_valid_zero_progress_release "$attempt" \
+        "$freeze" "$capture" || return 1
+    if quarantine_attempt_binds_live_observation_selection "$attempt" \
+            "$freeze" "$capture"; then
+        return 1
+    fi
+    for invalid in missing reordered tampered; do
+        local invalid_status
+        set +e
+        quarantine_attempt_has_valid_zero_progress_release "$attempt" \
+            "$freeze" "$capture" \
+            "$attempt/zero-progress-release.$invalid.json" \
+            >/dev/null 2>&1
+        invalid_status=$?
+        set -e
+        [ "$invalid_status" -ne 0 ] || return 1
+    done
+
+    # The released round-two attempt itself is nonbinding, but its exact
+    # positive round-one prefix still binds the observation selection.  This
+    # prevents a later release from erasing already-secured history.
+    read -r state generation < <(
+        live_observation_selection_resume_state "$selection" "$rounds" \
+            "$drive" "$freeze" "$capture"
+    ) || return 1
+    [ "$state" = bound ] && [ "$generation" = "$(printf '0%.0s' {1..62})5c" ] || \
+        return 1
+
+    # The later release is valid only while the complete immutable positive
+    # prefix exists.  Removing even one predecessor result must fail closed.
+    mv -- "$round_one/result.json" "$round_one/result.saved"
+    local missing_prefix_status
+    set +e
+    quarantine_attempt_has_valid_zero_progress_release "$attempt" \
+        "$freeze" "$capture" >/dev/null 2>&1
+    missing_prefix_status=$?
+    set -e
+    [ "$missing_prefix_status" -ne 0 ] || return 1
+    mv -- "$round_one/result.saved" "$round_one/result.json"
+    quarantine_attempt_has_valid_zero_progress_release "$attempt" \
+        "$freeze" "$capture" || return 1
 )
 
 remote_zero_progress_heals_only_reviewed_publish_orphans() (
@@ -2078,9 +2508,15 @@ assert 'exec 8<"$capture_state_lock_dir"' in fleet
 assert 'fcntl.LOCK_EX|fcntl.LOCK_NB' in fleet
 assert 'quarantine-round-zero-progress-proof' in fleet
 assert 'arc.recovery.quarantine-round-zero-progress-release.v1' in fleet
-assert 'set(value)!=proof_fields' in fleet and 'set(proof)!=proof_fields' in fleet
-assert 'authorization_accepted") is not True' in fleet
-assert 'observed_ns<=accepted_ns+300_000_000_000' in fleet
+assert 'for wrapper, name in zip(wrappers, state["target_names"])' in rounds
+assert 'set(proof) != proof_fields' in rounds
+assert 'proof.get("authorization_accepted") is not True' in rounds
+assert 'accepted != acceptance.get("accepted_monotonic_ns")' in rounds
+assert 'elapsed <= MAX_WINDOW_SECONDS * 1_000_000_000' in rounds
+assert 'len(wrappers) != len(state["target_names"])' in rounds
+assert 'context="$(quarantine_zero_progress_attempt_context \\' in fleet
+assert 'read -r round generation targets_csv <<< "$context"' in fleet
+assert 'IFS=\',\' read -r -a release_nodes <<< "$targets_csv"' in fleet
 assert 'exec 5<> "$attempt_root/round.lock"' in node
 assert 'time.clock_gettime_ns(time.CLOCK_BOOTTIME)' in node
 assert 'time.monotonic_ns()' not in node[node.index('def validate_readiness'):node.index('def input_bytes')]
@@ -3628,12 +4064,15 @@ run_test 'fleet observation retry rejects any stopped writer' fleet_live_observa
 run_test 'same-generation observation selection resume is byte-identical' live_observation_selection_resume_is_byte_identical
 run_test 'mutation dispatch publication is no-replace and crash-resumable' mutation_dispatch_publication_is_no_replace_and_resumable
 run_test 'readiness without dispatch does not bind a stale selection' readiness_without_dispatch_does_not_bind_stale_selection
+run_test 'dispatch-bound zero progress and expired selection stop before resample' dispatch_bound_zero_progress_and_expired_selection_stop_before_resample
+run_test 'authorization expiry names the actual limiting receipt' authorization_expiry_reports_the_actual_limiting_receipt
 run_test 'all local create-only post-link crashes heal before resume' local_create_only_post_link_crashes_are_reconciled_before_resume
 run_test 'positive round result is byte-identical after both publication crash windows' positive_round_result_resume_is_byte_identical
 run_test 'positive partial waits for late sixth status and resumes before prefix copy' positive_partial_waits_for_late_transition_before_sealing
 run_test 'sealed partial resume skips old-attempt status and preserves exact bytes' sealed_partial_resume_skips_old_attempt_status
 run_test 'zero-progress result remains attempt-local and never enters immutable prefix' zero_progress_result_never_enters_immutable_prefix
 run_test 'released zero-progress attempt does not bind rotated selection' released_zero_progress_attempt_does_not_bind_rotated_selection
+run_test 'later-round zero-progress release requires exact remaining subset and positive prefix' later_round_zero_progress_release_requires_exact_remaining_subset_and_prefix
 run_test 'remote zero-progress heals only reviewed publish orphans' remote_zero_progress_heals_only_reviewed_publish_orphans
 run_test 'capture lock and monotonic lease are portable and bound' capture_lock_and_monotonic_lease_are_portable_and_bound
 run_test 'canonical reference is independently required' reference_pair_is_independent_of_final_capture_classes


### PR DESCRIPTION
## Summary

- recognize the real systemd self-heal supervisor topology while preserving exact cgroup and direct-service PID checks
- separate public-receipt expiry from selection expiry and release zero-progress attempts safely at every quarantine round
- preserve immutable positive prefixes and validate exact remaining-node subsets before any retry
- prevent a previously released selection from poisoning a later selection
- harden create-only publication, canonical prefixes, identity-drift checks, and recovery documentation

## Validation

- `test_quarantine_rounds.py`: 20 passed
- `test_archive_node_quarantine_runtime.py`: 34 passed, 1 macOS-only skip
- `test_recovery_freeze.py`: 27 passed
- focused shell recovery contracts passed after the worktree was held immutable
- full local gate: all core, Rust, integration, desktop (212 passed / 4 platform skips), SDK, security, and packaging checks passed; the initial recovery-tail parse was invalidated by an in-flight source edit and is being replayed against this exact commit
- independent security/correctness review: GO, no remaining findings

## Production safety

This PR does not mutate validators, chain data, releases, tags, or public endpoints. The existing f5de recovery attempt remains inert and preserved. Production execution will regenerate every exact-main-SHA artifact in a fresh namespace after protected merge.