### PR TITLE
fix(recovery): preserve ARC history through production v3 cutover

### DIFF
--- a/.github/workflows/owner-emergency-recovery-approval.yml
+++ b/.github/workflows/owner-emergency-recovery-approval.yml
@@ -1,6 +1,6 @@
 name: Owner emergency recovery approval
 
-run-name: Owner recovery approval for ${{ inputs.expected_main_sha }} at ${{ inputs.checkpoint_manifest_hash }}
+run-name: Owner recovery approval for ${{ inputs.expected_main_sha }} H=${{ inputs.source_height }} at ${{ inputs.checkpoint_manifest_hash }}
 
 # This workflow is the authentication boundary for the one-person repository-
 # owner emergency decision. It has no secret, deployment, package, or write
@@ -15,6 +15,38 @@ on:
         type: string
       checkpoint_manifest_hash:
         description: Exact 0x-prefixed recovery checkpoint manifest hash
+        required: true
+        type: string
+      source_height:
+        description: Capture-derived canonical source height H (at or above reviewed anchor 137145)
+        required: true
+        type: string
+      transition_height:
+        description: Recovery transition height T (must equal H+1)
+        required: true
+        type: string
+      source_block_hash:
+        description: Strict-replayed source block hash at H
+        required: true
+        type: string
+      source_state_root:
+        description: Strict-replayed source state root at H
+        required: true
+        type: string
+      source_consensus_round:
+        description: Final frozen consensus round bound to the selected source
+        required: true
+        type: string
+      observed_cutoff_height:
+        description: Maximum frozen legacy head C across every fork
+        required: true
+        type: string
+      reopening_floor_height:
+        description: Public reopening floor F (must equal C+128)
+        required: true
+        type: string
+      legacy_maintenance_boundary_sha256:
+        description: SHA-256 of the canonical maintenance-boundary receipt
         required: true
         type: string
       validator_public_keys_sha256:
@@ -46,7 +78,7 @@ on:
         required: true
         type: string
       confirmation:
-        description: Type AUTHORIZE ARC OWNER EMERGENCY RECOVERY followed by one space and expected_main_sha
+        description: Type the exact H/T/source tuple/C/F, boundary, checkpoint, and protected-main authorization shown in the runbook
         required: true
         type: string
 
@@ -55,7 +87,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: owner-emergency-recovery-${{ inputs.expected_main_sha }}-${{ inputs.checkpoint_manifest_hash }}
+  group: owner-emergency-recovery-${{ inputs.expected_main_sha }}-${{ inputs.legacy_maintenance_boundary_sha256 }}-${{ inputs.checkpoint_manifest_hash }}
   cancel-in-progress: false
 
 jobs:
@@ -74,6 +106,14 @@ jobs:
           TRIGGERING_ACTOR_LOGIN: ${{ github.triggering_actor }}
           EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
           CHECKPOINT_MANIFEST_HASH: ${{ inputs.checkpoint_manifest_hash }}
+          SOURCE_HEIGHT: ${{ inputs.source_height }}
+          TRANSITION_HEIGHT: ${{ inputs.transition_height }}
+          SOURCE_BLOCK_HASH: ${{ inputs.source_block_hash }}
+          SOURCE_STATE_ROOT: ${{ inputs.source_state_root }}
+          SOURCE_CONSENSUS_ROUND: ${{ inputs.source_consensus_round }}
+          OBSERVED_CUTOFF_HEIGHT: ${{ inputs.observed_cutoff_height }}
+          REOPENING_FLOOR_HEIGHT: ${{ inputs.reopening_floor_height }}
+          LEGACY_MAINTENANCE_BOUNDARY_SHA256: ${{ inputs.legacy_maintenance_boundary_sha256 }}
           VALIDATOR_PUBLIC_KEYS_SHA256: ${{ inputs.validator_public_keys_sha256 }}
           NYC_PUBLIC_KEY: ${{ inputs.nyc_public_key }}
           LAX_PUBLIC_KEY: ${{ inputs.lax_public_key }}
@@ -91,10 +131,26 @@ jobs:
           [ "$ACTOR_LOGIN" = FerrumVir ]
           [ "$ACTOR_ID" = 111036403 ]
           [ "$TRIGGERING_ACTOR_LOGIN" = FerrumVir ]
-          [ "$CONFIRMATION" = "AUTHORIZE ARC OWNER EMERGENCY RECOVERY $EXPECTED_MAIN_SHA" ]
           [[ "$EXPECTED_MAIN_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$CHECKPOINT_MANIFEST_HASH" =~ ^0x[0-9a-f]{64}$ ]]
+          for exact_integer in \
+            "$SOURCE_HEIGHT" "$TRANSITION_HEIGHT" "$SOURCE_CONSENSUS_ROUND" \
+            "$OBSERVED_CUTOFF_HEIGHT" "$REOPENING_FLOOR_HEIGHT"
+          do
+            [[ "$exact_integer" =~ ^[1-9][0-9]{0,15}$ ]]
+            [ "$((10#$exact_integer))" -le 9007199254740991 ]
+          done
+          [[ "$SOURCE_BLOCK_HASH" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$SOURCE_STATE_ROOT" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$LEGACY_MAINTENANCE_BOUNDARY_SHA256" =~ ^[0-9a-f]{64}$ ]]
           [[ "$VALIDATOR_PUBLIC_KEYS_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          [ "$((10#$SOURCE_HEIGHT))" -ge 137145 ]
+          [ "$((10#$TRANSITION_HEIGHT))" -eq "$((10#$SOURCE_HEIGHT + 1))" ]
+          [ "$((10#$SOURCE_HEIGHT))" -le "$((10#$OBSERVED_CUTOFF_HEIGHT))" ]
+          [ "$((10#$REOPENING_FLOOR_HEIGHT))" -eq "$((10#$OBSERVED_CUTOFF_HEIGHT + 128))" ]
+          [ 137146 -le "$((10#$TRANSITION_HEIGHT))" ]
+          expected_confirmation="AUTHORIZE ARC OWNER EMERGENCY RECOVERY $EXPECTED_MAIN_SHA H=$SOURCE_HEIGHT T=$TRANSITION_HEIGHT HASH=$SOURCE_BLOCK_HASH STATE=$SOURCE_STATE_ROOT ROUND=$SOURCE_CONSENSUS_ROUND C=$OBSERVED_CUTOFF_HEIGHT F=$REOPENING_FLOOR_HEIGHT BOUNDARY=$LEGACY_MAINTENANCE_BOUNDARY_SHA256 CHECKPOINT=$CHECKPOINT_MANIFEST_HASH"
+          [ "$CONFIRMATION" = "$expected_confirmation" ]
           for public_key in \
             "$NYC_PUBLIC_KEY" "$LAX_PUBLIC_KEY" "$AMS_PUBLIC_KEY" \
             "$LHR_PUBLIC_KEY" "$NRT_PUBLIC_KEY" "$SGP_PUBLIC_KEY"
@@ -138,14 +194,22 @@ jobs:
             --arg approved_at "$approved_at" \
             --arg source "$EXPECTED_MAIN_SHA" \
             --arg checkpoint "$CHECKPOINT_MANIFEST_HASH" \
+            --arg source_block_hash "$SOURCE_BLOCK_HASH" \
+            --arg source_state_root "$SOURCE_STATE_ROOT" \
+            --arg boundary_sha "$LEGACY_MAINTENANCE_BOUNDARY_SHA256" \
             --arg public_keys_sha "$VALIDATOR_PUBLIC_KEYS_SHA256" \
             --arg nyc "$NYC_PUBLIC_KEY" --arg lax "$LAX_PUBLIC_KEY" \
             --arg ams "$AMS_PUBLIC_KEY" --arg lhr "$LHR_PUBLIC_KEY" \
             --arg nrt "$NRT_PUBLIC_KEY" --arg sgp "$SGP_PUBLIC_KEY" \
             --argjson run_id "$GITHUB_RUN_ID" \
-            --argjson run_attempt "$GITHUB_RUN_ATTEMPT" '
+            --argjson run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --argjson source_height "$SOURCE_HEIGHT" \
+            --argjson transition_height "$TRANSITION_HEIGHT" \
+            --argjson source_consensus_round "$SOURCE_CONSENSUS_ROUND" \
+            --argjson observed_cutoff_height "$OBSERVED_CUTOFF_HEIGHT" \
+            --argjson reopening_floor_height "$REOPENING_FLOOR_HEIGHT" '
             {
-              schema:"arc.recovery.owner-emergency-recovery.v2",
+              schema:"arc.recovery.owner-emergency-recovery.v3",
               decision:{
                 authorization_kind:"owner_emergency_recovery",
                 authority_basis:"repository-owner emergency authorization authenticated by an exact GitHub Actions run; not approval by six independent humans",
@@ -153,7 +217,7 @@ jobs:
                 approved_at:$approved_at,
                 reason_code:"legacy_fleet_divergence_history_preserving_v080_cutover",
                 reason:"The divergent public validator fleet requires the reviewed, history-preserving ARC v0.8 emergency cutover.",
-                risk_acknowledgement:"I authorize five reviewed ARC validator identities to sign the recovery checkpoint rooted at preserved source block 137145 and transition block 137146. I understand that the six legacy forks remain preserved read-only, that rollback cannot rewrite signed history, and that this receipt does not represent approval by six independent humans."
+                risk_acknowledgement:"I authorize five reviewed ARC validator identities to sign the recovery checkpoint rooted at the capture-derived preserved source block and its immediate successor transition. I understand that the six legacy forks remain preserved read-only, that rollback cannot rewrite signed history, and that this receipt does not represent approval by six independent humans."
               },
               github_authentication:{
                 repository:"FerrumVir/arc-chain",
@@ -166,7 +230,12 @@ jobs:
               scope:{
                 repository:"FerrumVir/arc-chain",protected_branch:"main",
                 source_main_sha:$source,checkpoint_manifest_hash:$checkpoint,
-                source_height:137145,transition_height:137146,
+                source_height:$source_height,transition_height:$transition_height,
+                source_block_hash:$source_block_hash,source_state_root:$source_state_root,
+                source_consensus_round:$source_consensus_round,
+                observed_cutoff_height:$observed_cutoff_height,
+                reopening_floor_height:$reopening_floor_height,
+                legacy_maintenance_boundary_sha256:$boundary_sha,
                 recovery_epoch:1,validator_set_id:1,
                 validator_public_keys_sha256:$public_keys_sha
               },

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ SSH/EC2/VPS operator can run:
 
 ```bash
 curl -fsSLO --proto '=https' --proto-redir '=https' --tlsv1.2 https://raw.githubusercontent.com/FerrumVir/arc-chain/v0.8.0/install.sh
-ARC_INSTALL_SHA256=4480a627e5f50f61a22b6a3b97ab4a8f102400c03f03a1c73d7d8abe79601151
+ARC_INSTALL_SHA256=0413fdd6088d0522841c472abfcf460b1ffaba67a6923355325d699c2f5b0242
 if command -v sha256sum >/dev/null 2>&1; then
   printf '%s  %s\n' "$ARC_INSTALL_SHA256" install.sh | sha256sum -c -
 else
@@ -49,7 +49,7 @@ bash install.sh --version 0.8.0
 ```
 
 Expected `install.sh` SHA-256 for this candidate:
-`4480a627e5f50f61a22b6a3b97ab4a8f102400c03f03a1c73d7d8abe79601151`.
+`0413fdd6088d0522841c472abfcf460b1ffaba67a6923355325d699c2f5b0242`.
 
 The unified release contract restores headless Linux amd64 and arm64, Intel
 and Apple Silicon macOS, Windows CLI binaries, signed desktop-updater payloads,
@@ -259,7 +259,7 @@ never used by the initial install command.
 
 ```bash
 curl -fsSLO --proto '=https' --proto-redir '=https' --tlsv1.2 https://raw.githubusercontent.com/FerrumVir/arc-chain/v0.8.0/install.sh
-ARC_INSTALL_SHA256=4480a627e5f50f61a22b6a3b97ab4a8f102400c03f03a1c73d7d8abe79601151
+ARC_INSTALL_SHA256=0413fdd6088d0522841c472abfcf460b1ffaba67a6923355325d699c2f5b0242
 if command -v sha256sum >/dev/null 2>&1; then
   printf '%s  %s\n' "$ARC_INSTALL_SHA256" install.sh | sha256sum -c -
 else
@@ -269,7 +269,7 @@ bash install.sh --version 0.8.0
 ```
 
 Expected `install.sh` SHA-256:
-`4480a627e5f50f61a22b6a3b97ab4a8f102400c03f03a1c73d7d8abe79601151`.
+`0413fdd6088d0522841c472abfcf460b1ffaba67a6923355325d699c2f5b0242`.
 
 The bootstrap installer comes from the owner-created protected source tag.
 It resolves an exact immutable, non-draft release, requires GitHub to identify
@@ -349,11 +349,13 @@ data lock nor its sibling namespace lock. The first upgrade must therefore stop
 the exact old node and updater and prove they are absent before any v0.8 node
 starts. A timeout is not a v0.7 drain: released v0.7 exits directly from its
 signal handler and has no admission-close/task-join barrier. The signed cutover
-policy therefore closes legacy admission at canonical height 137145, classifies
+policy therefore closes legacy admission at the capture-derived canonical
+height `H` (the highest strictly replayed captured descendant of the trusted
+137145 anchor), classifies
 unfinished legacy jobs as `expired_noncanonical_at_cutover`, and explicitly
 sets `legacy_exit_clean_claimed=false`. The installer authenticates that policy,
 the maintenance boundary, and the quorum recovery checkpoint; verifies all six
-exact v3 validators at height 137146 or later and the old claim/submit ports
+exact v3 validators at `H+1` or later and the old claim/submit ports
 closed; writes a create-only retirement intent; sends TERM but never KILL; and
 requires a matching offline-retirement receipt before v0.8 starts. The old
 `data/` tree remains untouched for forensics, while canonical block-level

--- a/crates/arc-crypto/src/secret_file.rs
+++ b/crates/arc-crypto/src/secret_file.rs
@@ -243,12 +243,23 @@ pub fn open_owned_nofollow_read(path: &Path) -> io::Result<File> {
     platform::open_owned_nofollow_read(path)
 }
 
+/// Open an owner-validated, non-reparse Windows file for a read-only inspection
+/// while an independently synchronized writer handle remains live.
+///
+/// The caller must exclude content mutation for the complete inspection. This
+/// opener requests no write access and its share flags grant no access; the
+/// already-open writer's own share mode continues to exclude a second writer.
+#[cfg(windows)]
+pub fn open_owned_nofollow_shared_read(path: &Path) -> io::Result<File> {
+    platform::open_owned_nofollow_shared_read(path)
+}
+
 /// Open an owner-validated, non-reparse Windows file only to compare its
 /// kernel identity with an already-open writer handle.
 ///
 /// The identity probe requests no write access but must share reads, writes,
 /// and deletes: the WAL append handle is intentionally live while its final
-/// pathname is rebound to the same file ID.  This narrowly scoped opener does
+/// pathname is rebound to the same file ID. This narrowly scoped opener does
 /// not weaken the append handle's own share mode, so a second writer remains
 /// excluded.
 #[cfg(windows)]
@@ -3828,7 +3839,7 @@ mod platform {
         Ok(file)
     }
 
-    pub(super) fn open_owned_nofollow_identity_probe(path: &Path) -> io::Result<File> {
+    pub(super) fn open_owned_nofollow_shared_read(path: &Path) -> io::Result<File> {
         let file = open_private_raw_with_access_and_share(
             path,
             GENERIC_READ | READ_CONTROL,
@@ -3837,12 +3848,16 @@ mod platform {
         let metadata = file.metadata()?;
         if !metadata.is_file() || metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
             return Err(permission_error(format!(
-                "owner-controlled identity probe is not a non-reparse regular file: {}",
+                "owner-controlled shared reader is not a non-reparse regular file: {}",
                 path.display()
             )));
         }
         validate_private_owner(&file, path, "file")?;
         Ok(file)
+    }
+
+    pub(super) fn open_owned_nofollow_identity_probe(path: &Path) -> io::Result<File> {
+        open_owned_nofollow_shared_read(path)
     }
 
     pub(super) fn tighten_open_owned_private(file: &File, path: &Path) -> io::Result<()> {

--- a/crates/arc-crypto/src/secret_file.rs
+++ b/crates/arc-crypto/src/secret_file.rs
@@ -243,6 +243,18 @@ pub fn open_owned_nofollow_read(path: &Path) -> io::Result<File> {
     platform::open_owned_nofollow_read(path)
 }
 
+/// Open an existing owner-controlled directory without following its final
+/// link and without changing its permission boundary.
+///
+/// The returned handle is an identity pin only. On Windows it uses directory
+/// backup semantics and shares reads, writes, and deletes so holding the pin
+/// does not create an OS-specific namespace lock that Unix callers would not
+/// receive. Callers that require a quiescent namespace must enforce that
+/// separately.
+pub fn open_owned_nofollow_directory(path: &Path) -> io::Result<File> {
+    platform::open_owned_nofollow_directory(path)
+}
+
 /// Open an owner-validated, non-reparse Windows file for a read-only inspection
 /// while an independently synchronized writer handle remains live.
 ///
@@ -402,7 +414,7 @@ pub fn same_private_directory_namespace(left: &Path, right: &Path) -> io::Result
         }
         let left_leaf = windows_canonical_namespace_leaf(&left_parent.join(left_leaf))?;
         let right_leaf = windows_canonical_namespace_leaf(&right_parent.join(right_leaf))?;
-        return windows_namespace_leaves_equal(&left_leaf, &right_leaf);
+        windows_namespace_leaves_equal(&left_leaf, &right_leaf)
     }
     #[cfg(target_os = "macos")]
     {
@@ -2360,6 +2372,19 @@ mod platform {
         Ok(file)
     }
 
+    pub(super) fn open_owned_nofollow_directory(path: &Path) -> io::Result<File> {
+        let directory = open_private_directory(path)?;
+        let metadata = directory.metadata()?;
+        if !metadata.is_dir() {
+            return Err(permission_error(format!(
+                "owner-controlled path is not a directory: {}",
+                path.display()
+            )));
+        }
+        validate_owner(&metadata, path, "directory")?;
+        Ok(directory)
+    }
+
     pub(super) fn tighten_open_owned_private(file: &File, path: &Path) -> io::Result<()> {
         let metadata = file.metadata()?;
         if !metadata.is_file() {
@@ -3335,6 +3360,31 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
+    fn windows_nofollow_directory_opener_accepts_directory_and_rejects_junction() {
+        let root = TestDir::new("nofollow-directory-open");
+        let directory = root.0.join("directory");
+        std::fs::create_dir(&directory).unwrap();
+        let handle = open_owned_nofollow_directory(&directory).unwrap();
+        assert!(handle.metadata().unwrap().is_dir());
+        drop(handle);
+
+        let linked = root.0.join("linked");
+        let status = std::process::Command::new("cmd")
+            .args(["/C", "mklink", "/J"])
+            .arg(&linked)
+            .arg(&directory)
+            .status()
+            .unwrap();
+        assert!(
+            status.success(),
+            "failed to create Windows junction fixture"
+        );
+        assert!(open_owned_nofollow_directory(&linked).is_err());
+        std::fs::remove_dir(&linked).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn windows_owned_inherited_directory_migrates_to_private_dacl() {
         let root = TestDir::new("windows-directory-migration");
         let inherited = root.0.join("legacy-app-data");
@@ -3839,6 +3889,19 @@ mod platform {
         Ok(file)
     }
 
+    pub(super) fn open_owned_nofollow_directory(path: &Path) -> io::Result<File> {
+        let directory = open_private_directory_raw_with_access(path, READ_CONTROL)?;
+        let metadata = directory.metadata()?;
+        if !metadata.is_dir() || metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(permission_error(format!(
+                "owner-controlled path is not a non-reparse directory: {}",
+                path.display()
+            )));
+        }
+        validate_private_owner(&directory, path, "directory")?;
+        Ok(directory)
+    }
+
     pub(super) fn open_owned_nofollow_shared_read(path: &Path) -> io::Result<File> {
         let file = open_private_raw_with_access_and_share(
             path,
@@ -4138,7 +4201,7 @@ mod platform {
                 path.display()
             )));
         }
-        validate_private_security(&directory, path, "directory")
+        validate_private_security(directory, path, "directory")
     }
 
     fn validate_private_owner(file: &File, path: &Path, object: &str) -> io::Result<()> {

--- a/crates/arc-node/src/legacy_retirement.rs
+++ b/crates/arc-node/src/legacy_retirement.rs
@@ -47,8 +47,9 @@ const POLICY_ASSET: &str = "arc-cutover-policy.json";
 const BOUNDARY_ASSET: &str = "arc-legacy-maintenance-boundary.json";
 const DESCRIPTOR_ASSET: &str = "arc-recovery-checkpoint-descriptor.json";
 const JOBS_DISPOSITION: &str = "expired_noncanonical_at_cutover";
-const SOURCE_HEIGHT: u64 = 137_145;
-const TRANSITION_HEIGHT: u64 = 137_146;
+const MINIMUM_SOURCE_HEIGHT: u64 = 137_145;
+const COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT: u64 = 137_146;
+const CONTINUITY_SAFETY_MARGIN: u64 = 128;
 const MAX_JSON_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_DESCRIPTOR_BYTES: u64 = 1024 * 1024;
 const MAX_EXECUTABLE_BYTES: u64 = 1024 * 1024 * 1024;
@@ -757,6 +758,7 @@ struct ReleaseBinding {
 #[derive(Clone, Debug)]
 struct BoundaryBinding {
     projected: Value,
+    observed_cutoff_height: u64,
     legacy_public_max_height: u64,
     freeze_plan_sha256: String,
     capture_id: String,
@@ -946,10 +948,17 @@ fn validate_boundary(value: &Value) -> Result<BoundaryBinding> {
     let observed = u64_field(object, "observed_cutoff_height", "maintenance boundary")?;
     let margin = u64_field(object, "continuity_safety_margin", "maintenance boundary")?;
     let public_max = u64_field(object, "legacy_public_max_height", "maintenance boundary")?;
-    ensure!(margin > 0, "maintenance continuity margin must be positive");
     ensure!(
-        observed.checked_add(margin) == Some(public_max) && public_max == SOURCE_HEIGHT,
-        "maintenance boundary must bind observed cutoff plus margin to H=137145"
+        observed >= MINIMUM_SOURCE_HEIGHT,
+        "maintenance observed cutoff is below the reviewed ARC history anchor"
+    );
+    ensure!(
+        margin == CONTINUITY_SAFETY_MARGIN,
+        "maintenance continuity margin must equal 128"
+    );
+    ensure!(
+        observed.checked_add(margin) == Some(public_max),
+        "maintenance boundary must bind the reopening floor to observed cutoff plus 128"
     );
     ensure!(
         !bool_field(object, "global_absence_claimed", "maintenance boundary")?,
@@ -1006,6 +1015,7 @@ fn validate_boundary(value: &Value) -> Result<BoundaryBinding> {
             "all_controlled_stopped_at": stopped,
             "global_absence_claimed": false,
         }),
+        observed_cutoff_height: observed,
         legacy_public_max_height: public_max,
         freeze_plan_sha256: freeze,
         capture_id: capture,
@@ -1033,6 +1043,7 @@ fn validate_descriptor_projection(
             "inspector_binary_sha256",
             "checkpoint_file",
             "canonical_inspection",
+            "canonical_source",
             "checkpoint_certificate",
             "approved_validators",
             "verified_quorum",
@@ -1104,14 +1115,17 @@ fn validate_descriptor_projection(
         ],
         "checkpoint canonical inspection",
     )?;
+    let source_height = u64_field(inspection, "source_height", "checkpoint inspection")?;
+    let transition_height = u64_field(inspection, "transition_height", "checkpoint inspection")?;
+    let expected_transition_height = source_height
+        .checked_add(1)
+        .context("checkpoint source height cannot have an H+1 transition")?;
     ensure!(
         u64_field(inspection, "format_version", "checkpoint inspection")? == 1
             && string_field(inspection, "chain_id", "checkpoint inspection")? == "0x415243"
-            && u64_field(inspection, "source_height", "checkpoint inspection")?
-                == boundary.legacy_public_max_height
-            && u64_field(inspection, "source_height", "checkpoint inspection")? == SOURCE_HEIGHT
-            && u64_field(inspection, "transition_height", "checkpoint inspection")?
-                == TRANSITION_HEIGHT
+            && source_height >= MINIMUM_SOURCE_HEIGHT
+            && source_height <= boundary.observed_cutoff_height
+            && transition_height == expected_transition_height
             && u64_field(inspection, "recovery_epoch", "checkpoint inspection")? == 1
             && u64_field(inspection, "validator_set_id", "checkpoint inspection")? == 1
             && u64_field(inspection, "validator_count", "checkpoint inspection")? == 6
@@ -1119,8 +1133,9 @@ fn validate_descriptor_projection(
                 inspection,
                 "community_rewards_v1_activation_height",
                 "checkpoint inspection",
-            )? == TRANSITION_HEIGHT,
-        "checkpoint canonical inspection differs from production cutover"
+            )? == COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT
+            && COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT <= transition_height,
+        "checkpoint canonical inspection differs from the capture-derived production cutover"
     );
     ensure!(
         string_field(inspection, "manifest_hash", "checkpoint inspection")?
@@ -1129,8 +1144,8 @@ fn validate_descriptor_projection(
                 == verified.network_genesis_hash
             && string_field(inspection, "recovery_domain", "checkpoint inspection")?
                 == verified.recovery_domain
-            && verified.source_height == SOURCE_HEIGHT
-            && verified.transition_height == TRANSITION_HEIGHT
+            && verified.source_height == source_height
+            && verified.transition_height == transition_height
             && verified.recovery_epoch == 1
             && verified.validator_set_id == 1
             && verified.validator_count == 6,
@@ -1152,6 +1167,56 @@ fn validate_descriptor_projection(
         string_field(inspection, "protocol_version", "checkpoint inspection")? == "3.0.0",
         "checkpoint protocol version differs"
     );
+    let canonical_source = object_exact(
+        object
+            .get("canonical_source")
+            .context("checkpoint canonical source is missing")?,
+        &[
+            "node",
+            "source_height",
+            "source_block_hash",
+            "source_state_root",
+            "source_consensus_round",
+            "snapshot_sha256",
+            "wal_sha256",
+            "persisted_head_sha256",
+            "legacy_dag_round_inspection_sha256",
+            "legacy_dag_wal_namespace_sha256",
+        ],
+        "checkpoint canonical source",
+    )?;
+    let canonical_source_node =
+        string_field(canonical_source, "node", "checkpoint canonical source")?;
+    ensure!(
+        FLEET.iter().any(|(name, _)| canonical_source_node == *name),
+        "checkpoint canonical source is not a controlled ARC fleet node"
+    );
+    ensure!(
+        canonical_source.get("source_height") == inspection.get("source_height")
+            && canonical_source.get("source_block_hash") == inspection.get("source_block_hash")
+            && canonical_source.get("source_state_root") == inspection.get("source_state_root")
+            && canonical_source.get("source_consensus_round")
+                == inspection.get("source_consensus_round")
+            && u64_field(
+                canonical_source,
+                "source_consensus_round",
+                "checkpoint canonical source",
+            )? > 0,
+        "checkpoint canonical source tuple differs from checkpoint inspection"
+    );
+    for field in [
+        "snapshot_sha256",
+        "wal_sha256",
+        "persisted_head_sha256",
+        "legacy_dag_round_inspection_sha256",
+        "legacy_dag_wal_namespace_sha256",
+    ] {
+        let hash = expect_hash_field(canonical_source, field, "checkpoint canonical source")?;
+        ensure!(
+            hash.bytes().any(|byte| byte != b'0'),
+            "checkpoint canonical source.{field} must not be zero"
+        );
+    }
     let certificate = object
         .get("checkpoint_certificate")
         .and_then(Value::as_object)
@@ -1193,6 +1258,10 @@ fn validate_descriptor_projection(
         (
             "checkpoint_file",
             object.get("checkpoint_file").expect("validated").clone(),
+        ),
+        (
+            "canonical_source",
+            object.get("canonical_source").expect("validated").clone(),
         ),
         (
             "approved_validators",
@@ -1245,6 +1314,9 @@ fn validate_policy(
             "legacy_admission_cutoff_utc",
             "canonical_boundary_height",
             "required_post_cutover_min_height",
+            "legacy_observed_cutoff_height",
+            "legacy_continuity_safety_margin",
+            "legacy_public_max_height",
             "required_recovery_epoch",
             "required_validator_set_id",
             "required_validator_count",
@@ -1332,14 +1404,32 @@ fn validate_policy(
             == boundary.all_controlled_stopped_at,
         "cutover admission cutoff differs from controlled stop"
     );
+    let source_height = u64_field(descriptor_object, "source_height", "checkpoint projection")?;
+    let transition_height = u64_field(
+        descriptor_object,
+        "transition_height",
+        "checkpoint projection",
+    )?;
     ensure!(
-        u64_field(object, "canonical_boundary_height", "cutover policy")? == SOURCE_HEIGHT
+        source_height >= MINIMUM_SOURCE_HEIGHT
+            && source_height <= boundary.observed_cutoff_height
+            && transition_height
+                == source_height
+                    .checked_add(1)
+                    .context("checkpoint source height cannot have an H+1 transition")?
+            && u64_field(object, "canonical_boundary_height", "cutover policy")? == source_height
             && u64_field(object, "required_post_cutover_min_height", "cutover policy",)?
-                == TRANSITION_HEIGHT
+                == transition_height
+            && u64_field(object, "legacy_observed_cutoff_height", "cutover policy")?
+                == boundary.observed_cutoff_height
+            && u64_field(object, "legacy_continuity_safety_margin", "cutover policy")?
+                == CONTINUITY_SAFETY_MARGIN
+            && u64_field(object, "legacy_public_max_height", "cutover policy")?
+                == boundary.legacy_public_max_height
             && u64_field(object, "required_recovery_epoch", "cutover policy")? == 1
             && u64_field(object, "required_validator_set_id", "cutover policy")? == 1
             && u64_field(object, "required_validator_count", "cutover policy")? == 6,
-        "cutover policy height/epoch/validator constants differ"
+        "cutover policy height/epoch/validator bindings differ"
     );
     for (policy_field, descriptor_field) in [
         ("checkpoint_format_version", "format_version"),
@@ -1435,15 +1525,18 @@ fn validate_policy(
         "legacy_maintenance_boundary_sha256": boundary_sha256,
         "recovery_checkpoint_descriptor_sha256": descriptor_sha256,
         "recovery_checkpoint_file_sha256": object["recovery_checkpoint_file_sha256"],
-        "canonical_boundary_height": SOURCE_HEIGHT,
-        "required_post_cutover_min_height": TRANSITION_HEIGHT,
+        "canonical_boundary_height": source_height,
+        "required_post_cutover_min_height": transition_height,
+        "legacy_observed_cutoff_height": boundary.observed_cutoff_height,
+        "legacy_continuity_safety_margin": CONTINUITY_SAFETY_MARGIN,
+        "legacy_public_max_height": boundary.legacy_public_max_height,
         "required_recovery_epoch": 1,
         "required_validator_set_id": 1,
         "required_validator_count": 6,
         "checkpoint_format_version": 1,
         "chain_id": "0x415243",
         "payload_hash": descriptor_object["payload_hash"],
-        "community_rewards_v1_activation_height": TRANSITION_HEIGHT,
+        "community_rewards_v1_activation_height": COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT,
         "legacy_validators": validators,
         "legacy_worker_rpc": object["legacy_worker_rpc"],
         "uncompleted_job_disposition": JOBS_DISPOSITION,
@@ -4361,6 +4454,28 @@ fn validate_receipt(value: &Value) -> Result<()> {
     let verified = u64_field(checkpoint, "verified_signature_count", "receipt checkpoint")?;
     let signed_stake = u64_field(checkpoint, "signed_stake", "receipt checkpoint")?;
     let total_stake = u64_field(checkpoint, "total_stake", "receipt checkpoint")?;
+    let boundary = object
+        .get("maintenance_boundary")
+        .and_then(Value::as_object)
+        .context("receipt maintenance boundary is malformed")?;
+    let observed_cutoff_height = u64_field(
+        boundary,
+        "observed_cutoff_height",
+        "receipt maintenance boundary",
+    )?;
+    let reopening_floor_height = u64_field(
+        boundary,
+        "legacy_public_max_height",
+        "receipt maintenance boundary",
+    )?;
+    ensure!(
+        observed_cutoff_height >= MINIMUM_SOURCE_HEIGHT
+            && observed_cutoff_height.checked_add(CONTINUITY_SAFETY_MARGIN)
+                == Some(reopening_floor_height),
+        "receipt maintenance boundary does not preserve the cutoff-plus-128 reopening floor"
+    );
+    let source_height = u64_field(checkpoint, "source_height", "receipt checkpoint")?;
+    let transition_height = u64_field(checkpoint, "transition_height", "receipt checkpoint")?;
     let signers = checkpoint
         .get("signed_validator_addresses")
         .and_then(Value::as_array)
@@ -4387,10 +4502,14 @@ fn validate_receipt(value: &Value) -> Result<()> {
                 checkpoint,
                 "community_rewards_v1_activation_height",
                 "receipt checkpoint",
-            )? == TRANSITION_HEIGHT
-            && u64_field(checkpoint, "source_height", "receipt checkpoint")? == SOURCE_HEIGHT
-            && u64_field(checkpoint, "transition_height", "receipt checkpoint")?
-                == TRANSITION_HEIGHT
+            )? == COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT
+            && source_height >= MINIMUM_SOURCE_HEIGHT
+            && source_height <= observed_cutoff_height
+            && transition_height
+                == source_height
+                    .checked_add(1)
+                    .context("receipt checkpoint source height cannot have an H+1 transition")?
+            && COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT <= transition_height
             && string_field(checkpoint, "canonical_history_source", "receipt checkpoint")?
                 == "signed_recovery_checkpoint",
         "receipt checkpoint certificate/quorum binding differs"
@@ -5233,6 +5352,12 @@ pub(crate) fn run(command: LegacyRetirementCommand) -> Result<()> {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+
+    const TEST_SOURCE_HEIGHT: u64 = 141_062;
+    const TEST_TRANSITION_HEIGHT: u64 = TEST_SOURCE_HEIGHT + 1;
+    // A taller noncanonical fork raises C/F without becoming canonical H.
+    const TEST_OBSERVED_CUTOFF_HEIGHT: u64 = 141_100;
+    const TEST_REOPENING_FLOOR_HEIGHT: u64 = TEST_OBSERVED_CUTOFF_HEIGHT + CONTINUITY_SAFETY_MARGIN;
     use clap::Parser as _;
     use std::cell::RefCell;
     use std::collections::HashMap;
@@ -5417,9 +5542,9 @@ mod tests {
                 &json!({
                     "schema": BOUNDARY_SCHEMA,
                     "source_main_commit": "a".repeat(40),
-                    "observed_cutoff_height": 137017,
-                    "continuity_safety_margin": 128,
-                    "legacy_public_max_height": SOURCE_HEIGHT,
+                    "observed_cutoff_height": TEST_OBSERVED_CUTOFF_HEIGHT,
+                    "continuity_safety_margin": CONTINUITY_SAFETY_MARGIN,
+                    "legacy_public_max_height": TEST_REOPENING_FLOOR_HEIGHT,
                     "freeze_plan_sha256": freeze,
                     "capture_id": capture,
                     "first_quarantine_started_at": "2026-01-01T00:00:00Z",
@@ -5489,19 +5614,31 @@ mod tests {
                     "payload_hash": payload,
                     "network_genesis_hash": network,
                     "full_state_root": full_root,
-                    "source_height": SOURCE_HEIGHT,
+                    "source_height": TEST_SOURCE_HEIGHT,
                     "source_consensus_round": 137200,
                     "created_at_unix_ms": 1767225660000u64,
                     "source_block_hash": source_block,
                     "source_state_root": source_root,
-                    "transition_height": TRANSITION_HEIGHT,
+                    "transition_height": TEST_TRANSITION_HEIGHT,
                     "transition_block_hash": transition_block,
                     "recovery_domain": recovery_domain,
                     "recovery_epoch": 1,
                     "validator_set_id": 1,
                     "protocol_version": "3.0.0",
                     "validator_count": 6,
-                    "community_rewards_v1_activation_height": TRANSITION_HEIGHT,
+                    "community_rewards_v1_activation_height": COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT,
+                },
+                "canonical_source": {
+                    "node": "nyc",
+                    "source_height": TEST_SOURCE_HEIGHT,
+                    "source_block_hash": source_block,
+                    "source_state_root": source_root,
+                    "source_consensus_round": 137200,
+                    "snapshot_sha256": hash_number(32),
+                    "wal_sha256": hash_number(33),
+                    "persisted_head_sha256": hash_number(34),
+                    "legacy_dag_round_inspection_sha256": hash_number(35),
+                    "legacy_dag_wal_namespace_sha256": hash_number(36),
                 },
                 "checkpoint_certificate": {
                     "signing_hash": signing,
@@ -5513,56 +5650,67 @@ mod tests {
             });
             let descriptor_sha = write_json(&descriptor_path, &descriptor);
             let policy_path = root.join(POLICY_ASSET);
-            let policy_sha = write_json(
-                &policy_path,
-                &json!({
-                    "schema_version": POLICY_SCHEMA,
-                    "repository": REPOSITORY,
-                    "release_tag": "v0.8.0",
-                    "release_commit": "b".repeat(40),
-                    "recovery_manifest_sha256": recovery_manifest_sha,
-                    "legacy_maintenance_boundary_sha256": boundary_sha,
-                    "recovery_checkpoint_descriptor_sha256": descriptor_sha,
-                    "recovery_checkpoint_file_sha256": checkpoint_file_sha,
-                    "freeze_plan_sha256": freeze,
-                    "capture_id": capture,
-                    "first_quarantine_started_at": "2026-01-01T00:00:00Z",
-                    "all_controlled_stopped_at": "2026-01-01T00:01:00Z",
-                    "legacy_admission_cutoff_utc": "2026-01-01T00:01:00Z",
-                    "canonical_boundary_height": SOURCE_HEIGHT,
-                    "required_post_cutover_min_height": TRANSITION_HEIGHT,
-                    "required_recovery_epoch": 1,
-                    "required_validator_set_id": 1,
-                    "required_validator_count": 6,
-                    "checkpoint_format_version": 1,
-                    "chain_id": "0x415243",
-                    "protocol_version": "3.0.0",
-                    "payload_hash": payload,
-                    "community_rewards_v1_activation_height": TRANSITION_HEIGHT,
-                    "network_genesis_hash": network,
-                    "source_block_hash": source_block,
-                    "source_state_root": source_root,
-                    "transition_block_hash": transition_block,
-                    "full_state_root": full_root,
-                    "recovery_domain": recovery_domain,
-                    "checkpoint_manifest_hash": manifest,
-                    "checkpoint_source_consensus_round": 137200,
-                    "checkpoint_created_at_unix_ms": 1767225660000u64,
-                    "checkpoint_quorum": quorum,
-                    "legacy_validators": validators,
-                    "legacy_worker_rpc": {
-                        "claim_path": "/community/claim_work",
-                        "submit_path": "/community/submit_work",
-                        "listener_ports": [9090, 3001],
-                    },
-                    "uncompleted_job_disposition": JOBS_DISPOSITION,
-                    "legacy_exit_clean_claimed": false,
-                    "legacy_restart_allowed": false,
-                    "global_legacy_absence_claimed": false,
-                    "offline_retirement_receipt_required": true,
-                    "v08_start_requires_offline_receipt": true,
-                }),
+            let mut policy = json!({
+                "schema_version": POLICY_SCHEMA,
+                "repository": REPOSITORY,
+                "release_tag": "v0.8.0",
+                "release_commit": "b".repeat(40),
+                "recovery_manifest_sha256": recovery_manifest_sha,
+                "legacy_maintenance_boundary_sha256": boundary_sha,
+                "recovery_checkpoint_descriptor_sha256": descriptor_sha,
+                "recovery_checkpoint_file_sha256": checkpoint_file_sha,
+                "freeze_plan_sha256": freeze,
+                "capture_id": capture,
+                "first_quarantine_started_at": "2026-01-01T00:00:00Z",
+                "all_controlled_stopped_at": "2026-01-01T00:01:00Z",
+                "legacy_admission_cutoff_utc": "2026-01-01T00:01:00Z",
+                "canonical_boundary_height": TEST_SOURCE_HEIGHT,
+                "required_post_cutover_min_height": TEST_TRANSITION_HEIGHT,
+                "required_recovery_epoch": 1,
+                "required_validator_set_id": 1,
+                "required_validator_count": 6,
+                "checkpoint_format_version": 1,
+                "chain_id": "0x415243",
+                "protocol_version": "3.0.0",
+                "payload_hash": payload,
+                "community_rewards_v1_activation_height": COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT,
+                "network_genesis_hash": network,
+                "source_block_hash": source_block,
+                "source_state_root": source_root,
+                "transition_block_hash": transition_block,
+                "full_state_root": full_root,
+                "recovery_domain": recovery_domain,
+                "checkpoint_manifest_hash": manifest,
+                "checkpoint_source_consensus_round": 137200,
+                "checkpoint_created_at_unix_ms": 1767225660000u64,
+                "checkpoint_quorum": quorum,
+                "legacy_validators": validators,
+                "legacy_worker_rpc": {
+                    "claim_path": "/community/claim_work",
+                    "submit_path": "/community/submit_work",
+                    "listener_ports": [9090, 3001],
+                },
+                "uncompleted_job_disposition": JOBS_DISPOSITION,
+                "legacy_exit_clean_claimed": false,
+                "legacy_restart_allowed": false,
+                "global_legacy_absence_claimed": false,
+                "offline_retirement_receipt_required": true,
+                "v08_start_requires_offline_receipt": true,
+            });
+            let policy_object = policy.as_object_mut().expect("test policy object");
+            policy_object.insert(
+                "legacy_observed_cutoff_height".into(),
+                TEST_OBSERVED_CUTOFF_HEIGHT.into(),
             );
+            policy_object.insert(
+                "legacy_continuity_safety_margin".into(),
+                CONTINUITY_SAFETY_MARGIN.into(),
+            );
+            policy_object.insert(
+                "legacy_public_max_height".into(),
+                TEST_REOPENING_FLOOR_HEIGHT.into(),
+            );
+            let policy_sha = write_json(&policy_path, &policy);
             let release_path = root.join("arc-release-installer-binding.json");
             let release_sha = write_json(
                 &release_path,
@@ -5589,8 +5737,8 @@ mod tests {
                 recovery_domain,
                 recovery_epoch: 1,
                 validator_set_id: 1,
-                source_height: SOURCE_HEIGHT,
-                transition_height: TRANSITION_HEIGHT,
+                source_height: TEST_SOURCE_HEIGHT,
+                transition_height: TEST_TRANSITION_HEIGHT,
                 validator_count: 6,
                 verified_signature_count: 5,
                 signed_stake: 50,

--- a/crates/arc-node/src/main.rs
+++ b/crates/arc-node/src/main.rs
@@ -503,6 +503,13 @@ enum RecoveryCommand {
         #[arg(long, default_value_t = false)]
         allow_unbound_legacy_wal: bool,
     },
+    /// Derive the exact durable legacy DAG cursor from a stopped, immutable
+    /// segmented WAL. This never starts a node, opens a listener, or writes
+    /// the source namespace.
+    InspectLegacyDagRound {
+        #[arg(long)]
+        dag_wal_dir: String,
+    },
     /// Materialize and strictly replay-validate the exact WAL prefix committed
     /// by a live `/sync/snapshot` capture.  The source directory is read-only;
     /// OUTPUT_DATA_DIR is create-only and contains an immutable snapshot/WAL
@@ -912,6 +919,20 @@ struct LegacySourceCaptureReceipt {
     allow_unbound_legacy_wal: bool,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct RecoveryLegacyDagSegment {
+    name: String,
+    sha256: String,
+    size: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct RecoveryLegacyDagNamespace {
+    schema: String,
+    segment_names: Vec<String>,
+    inspected_tail: Vec<RecoveryLegacyDagSegment>,
+}
+
 /// Stable no-follow metadata identity projected in
 /// `(device, inode, mode, uid, gid, nlink, mtime_ns, ctime_ns)` order.
 type RecoveryMetadataProjection = (u64, u64, u32, u32, u32, u64, i64, i64);
@@ -1061,6 +1082,171 @@ fn recovery_directory_input(metadata: &std::fs::Metadata) -> Result<RecoveryRead
         mtime_ns: projection.6,
         ctime_ns: projection.7,
     })
+}
+
+fn recovery_legacy_dag_segment_names(directory: &Path) -> Result<Vec<String>> {
+    let mut names = Vec::new();
+    for entry in std::fs::read_dir(directory)
+        .with_context(|| format!("failed to enumerate legacy DAG WAL {}", directory.display()))?
+    {
+        let entry = entry
+            .with_context(|| format!("failed to enumerate an entry in {}", directory.display()))?;
+        let name = entry
+            .file_name()
+            .into_string()
+            .map_err(|_| anyhow::anyhow!("legacy DAG WAL contains a non-UTF-8 entry"))?;
+        if !(name.starts_with("wal-") && name.ends_with(".bin")) {
+            continue;
+        }
+        let digits = name
+            .strip_prefix("wal-")
+            .and_then(|value| value.strip_suffix(".bin"))
+            .expect("prefix and suffix checked");
+        ensure!(
+            digits.len() == 8 && digits.bytes().all(|byte| byte.is_ascii_digit()),
+            "legacy DAG WAL segment name is noncanonical: {name}"
+        );
+        names.push(name);
+    }
+    names.sort();
+    Ok(names)
+}
+
+fn build_legacy_dag_round_inspection(dag_wal_dir: &str) -> Result<serde_json::Value> {
+    use sha2::{Digest, Sha256};
+
+    let requested = Path::new(dag_wal_dir);
+    let path_metadata = std::fs::symlink_metadata(requested)
+        .with_context(|| format!("failed to stat legacy DAG WAL {dag_wal_dir}"))?;
+    ensure!(
+        path_metadata.is_dir() && !path_metadata.file_type().is_symlink(),
+        "legacy DAG WAL is not a regular no-follow directory"
+    );
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW);
+    }
+    let handle = options
+        .open(requested)
+        .with_context(|| format!("failed to no-follow open legacy DAG WAL {dag_wal_dir}"))?;
+    let open_metadata = handle
+        .metadata()
+        .context("failed to inspect open legacy DAG WAL directory")?;
+    let directory_projection = recovery_metadata_projection(&open_metadata)?;
+    ensure!(
+        directory_projection == recovery_metadata_projection(&path_metadata)?,
+        "legacy DAG WAL directory pathname changed before its no-follow open"
+    );
+    ensure!(
+        directory_projection.2 & 0o022 == 0,
+        "legacy DAG WAL directory is group/world writable"
+    );
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    let pinned_directory = {
+        use std::os::fd::AsRawFd;
+        PathBuf::from(format!("/proc/self/fd/{}", handle.as_raw_fd()))
+    };
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    let pinned_directory = requested.to_path_buf();
+
+    let names_before = recovery_legacy_dag_segment_names(&pinned_directory)?;
+    ensure!(
+        !names_before.is_empty(),
+        "legacy DAG WAL contains no segments"
+    );
+    let inspection = arc_state::wal::inspect_wal_dir_tail_strict(&pinned_directory)
+        .context("legacy DAG WAL tail failed strict replay")?;
+    ensure!(
+        inspection.source_consensus_round > 0 && inspection.inspected_entry_count > 0,
+        "legacy DAG WAL has no durable positive consensus cursor"
+    );
+    ensure!(
+        inspection.segment_count == u64::try_from(names_before.len())?,
+        "legacy DAG WAL segment count changed during strict replay"
+    );
+    let inspected_count = usize::try_from(inspection.inspected_segment_count)
+        .context("legacy DAG WAL inspected segment count exceeds usize")?;
+    ensure!(
+        inspected_count > 0 && inspected_count <= names_before.len(),
+        "legacy DAG WAL inspected tail is malformed"
+    );
+    let inspected_names = &names_before[names_before.len() - inspected_count..];
+    let mut identities = Vec::with_capacity(inspected_names.len());
+    let mut content = Vec::with_capacity(inspected_names.len());
+    for name in inspected_names {
+        let identity = recovery_read_only_input(
+            &pinned_directory.join(name),
+            &format!("legacy DAG WAL segment {name}"),
+        )?;
+        ensure!(
+            identity.mode & 0o022 == 0,
+            "legacy DAG WAL segment {name} is group/world writable"
+        );
+        content.push(RecoveryLegacyDagSegment {
+            name: name.clone(),
+            sha256: identity.sha256.clone(),
+            size: identity.size,
+        });
+        identities.push(identity);
+    }
+    let namespace = RecoveryLegacyDagNamespace {
+        schema: "arc.recovery.legacy-dag-wal-namespace.v1".to_string(),
+        segment_names: names_before.clone(),
+        inspected_tail: content,
+    };
+    // Hash the same key-sorted JSON Value that is emitted below.  Consumers
+    // can therefore reproduce the root from the embedded object without
+    // depending on Rust struct field declaration order.
+    let namespace_value = serde_json::to_value(&namespace)?;
+    let namespace_bytes = serde_json::to_vec(&namespace_value)?;
+    let namespace_sha256 = hex::encode(Sha256::digest(&namespace_bytes));
+
+    ensure!(
+        names_before == recovery_legacy_dag_segment_names(&pinned_directory)?,
+        "legacy DAG WAL namespace changed during inspection"
+    );
+    for (name, before) in inspected_names.iter().zip(&identities) {
+        ensure!(
+            *before
+                == recovery_read_only_input(
+                    &pinned_directory.join(name),
+                    &format!("legacy DAG WAL segment {name} final recheck"),
+                )?,
+            "legacy DAG WAL segment {name} changed during inspection"
+        );
+    }
+    ensure!(
+        directory_projection == recovery_metadata_projection(&handle.metadata()?)?
+            && directory_projection
+                == recovery_metadata_projection(&std::fs::symlink_metadata(requested)?)?,
+        "legacy DAG WAL directory changed during inspection"
+    );
+
+    let output = serde_json::json!({
+        "schema": "arc.recovery.legacy-dag-round-inspection.v1",
+        "status": "VERIFIED_STOPPED_DAG_CURSOR",
+        "source_consensus_round": inspection.source_consensus_round,
+        "first_segment": inspection.first_segment,
+        "last_segment": inspection.last_segment,
+        "segment_count": inspection.segment_count,
+        "inspected_first_segment": inspection.inspected_first_segment,
+        "inspected_segment_count": inspection.inspected_segment_count,
+        "inspected_entry_count": inspection.inspected_entry_count,
+        "namespace_sha256": namespace_sha256,
+        "namespace": namespace_value,
+        "read_only": true,
+    });
+    Ok(output)
+}
+
+fn inspect_legacy_dag_round(dag_wal_dir: &str) -> Result<()> {
+    let output = build_legacy_dag_round_inspection(dag_wal_dir)?;
+    println!("{}", serde_json::to_string(&output)?);
+    Ok(())
 }
 
 fn recovery_copy_input_create_new(
@@ -3194,6 +3380,9 @@ fn run_recovery_operator_command(command: RecoveryCommand) -> Result<()> {
             ]);
             println!("{}", serde_json::to_string(&output)?);
             Ok(())
+        }
+        RecoveryCommand::InspectLegacyDagRound { dag_wal_dir } => {
+            inspect_legacy_dag_round(&dag_wal_dir)
         }
         RecoveryCommand::CaptureLegacySource {
             data_dir,
@@ -8037,6 +8226,65 @@ mod tests {
             .is_err(),
             "floating recovery inputs must not parse"
         );
+    }
+
+    #[test]
+    fn inspect_legacy_dag_round_cli_requires_an_explicit_directory() {
+        let cli = Cli::try_parse_from([
+            "arc-node",
+            "recovery",
+            "inspect-legacy-dag-round",
+            "--dag-wal-dir",
+            "/stopped/arc-data/dag-wal",
+        ])
+        .expect("stopped legacy DAG inspection should parse");
+        let Some(OperatorCommand::Recovery {
+            command: RecoveryCommand::InspectLegacyDagRound { dag_wal_dir },
+        }) = cli.operator_command
+        else {
+            panic!("wrong operator command parsed")
+        };
+        assert_eq!(dag_wal_dir, "/stopped/arc-data/dag-wal");
+        assert!(
+            Cli::try_parse_from(["arc-node", "recovery", "inspect-legacy-dag-round"]).is_err(),
+            "a floating legacy DAG namespace must not parse"
+        );
+    }
+
+    #[test]
+    fn legacy_dag_round_inspection_root_is_reproducible_from_embedded_namespace() {
+        use sha2::{Digest, Sha256};
+
+        let dag_wal = std::env::temp_dir().join(format!(
+            "arc-legacy-dag-inspection-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir(&dag_wal).unwrap();
+        {
+            let writer = arc_state::WalWriter::with_segments(&dag_wal, 1024).unwrap();
+            for round in 1..=64 {
+                writer.append(arc_state::WalOp::Checkpoint(Hash256::ZERO), round);
+            }
+            writer.sync().unwrap();
+        }
+
+        let value = build_legacy_dag_round_inspection(dag_wal.to_str().unwrap()).unwrap();
+        assert_eq!(value["status"], "VERIFIED_STOPPED_DAG_CURSOR");
+        assert_eq!(value["source_consensus_round"], 64);
+        let namespace_bytes = serde_json::to_vec(&value["namespace"]).unwrap();
+        assert_eq!(
+            value["namespace_sha256"],
+            hex::encode(Sha256::digest(namespace_bytes))
+        );
+        assert_eq!(
+            value["namespace"]["inspected_tail"]
+                .as_array()
+                .unwrap()
+                .len(),
+            value["inspected_segment_count"].as_u64().unwrap() as usize
+        );
+
+        std::fs::remove_dir_all(dag_wal).unwrap();
     }
 
     #[test]

--- a/crates/arc-node/src/main.rs
+++ b/crates/arc-node/src/main.rs
@@ -1122,15 +1122,7 @@ fn build_legacy_dag_round_inspection(dag_wal_dir: &str) -> Result<serde_json::Va
         path_metadata.is_dir() && !path_metadata.file_type().is_symlink(),
         "legacy DAG WAL is not a regular no-follow directory"
     );
-    let mut options = OpenOptions::new();
-    options.read(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW);
-    }
-    let handle = options
-        .open(requested)
+    let handle = arc_crypto::secret_file::open_owned_nofollow_directory(requested)
         .with_context(|| format!("failed to no-follow open legacy DAG WAL {dag_wal_dir}"))?;
     let open_metadata = handle
         .metadata()
@@ -3221,17 +3213,11 @@ fn run_recovery_operator_command(command: RecoveryCommand) -> Result<()> {
                 data_dir_metadata.is_dir() && !data_dir_metadata.file_type().is_symlink(),
                 "legacy data directory is not a regular no-follow directory"
             );
-            let mut directory_options = OpenOptions::new();
-            directory_options.read(true);
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::OpenOptionsExt;
-                directory_options
-                    .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW);
-            }
-            let data_dir_handle = directory_options
-                .open(data_dir_path)
-                .with_context(|| format!("failed to no-follow open data directory {data_dir}"))?;
+            let data_dir_handle =
+                arc_crypto::secret_file::open_owned_nofollow_directory(data_dir_path)
+                    .with_context(|| {
+                        format!("failed to no-follow open data directory {data_dir}")
+                    })?;
             let data_dir_open_metadata = data_dir_handle
                 .metadata()
                 .context("failed to inspect open legacy data directory")?;
@@ -3424,17 +3410,11 @@ fn run_recovery_operator_command(command: RecoveryCommand) -> Result<()> {
                 data_dir_metadata.is_dir() && !data_dir_metadata.file_type().is_symlink(),
                 "legacy data directory is not a regular no-follow directory"
             );
-            let mut directory_options = OpenOptions::new();
-            directory_options.read(true);
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::OpenOptionsExt;
-                directory_options
-                    .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW);
-            }
-            let data_dir_handle = directory_options
-                .open(data_dir_path)
-                .with_context(|| format!("failed to no-follow open data directory {data_dir}"))?;
+            let data_dir_handle =
+                arc_crypto::secret_file::open_owned_nofollow_directory(data_dir_path)
+                    .with_context(|| {
+                        format!("failed to no-follow open data directory {data_dir}")
+                    })?;
             let data_dir_open_metadata = data_dir_handle
                 .metadata()
                 .context("failed to inspect open legacy data directory")?;

--- a/crates/arc-node/src/recovery_descriptor.rs
+++ b/crates/arc-node/src/recovery_descriptor.rs
@@ -24,8 +24,7 @@ const DESCRIPTOR_SCHEMA: &str = "arc-recovery-checkpoint-descriptor/v1";
 const DESCRIPTOR_MAX_BYTES: u64 = 1024 * 1024;
 const EXPECTED_REPOSITORY: &str = "FerrumVir/arc-chain";
 const EXPECTED_CHAIN_ID: &str = "0x415243";
-const EXPECTED_SOURCE_HEIGHT: u64 = 137_145;
-const EXPECTED_TRANSITION_HEIGHT: u64 = 137_146;
+const MINIMUM_SOURCE_HEIGHT: u64 = 137_145;
 const EXPECTED_RECOVERY_EPOCH: u64 = 1;
 const EXPECTED_VALIDATOR_SET_ID: u64 = 1;
 const EXPECTED_REWARD_ACTIVATION_HEIGHT: u64 = 137_146;
@@ -81,6 +80,7 @@ struct RecoveryCheckpointDescriptor {
     inspector_binary_sha256: String,
     checkpoint_file: DescriptorCheckpointFile,
     canonical_inspection: DescriptorInspection,
+    canonical_source: DescriptorCanonicalSource,
     checkpoint_certificate: DescriptorCertificate,
     approved_validators: Vec<DescriptorApprovedValidator>,
     verified_quorum: DescriptorQuorum,
@@ -117,6 +117,21 @@ struct DescriptorInspection {
     validator_count: usize,
     #[serde(deserialize_with = "deserialize_explicit_optional_u64")]
     community_rewards_v1_activation_height: Option<u64>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct DescriptorCanonicalSource {
+    node: String,
+    source_height: u64,
+    source_block_hash: String,
+    source_state_root: String,
+    source_consensus_round: u64,
+    snapshot_sha256: String,
+    wal_sha256: String,
+    persisted_head_sha256: String,
+    legacy_dag_round_inspection_sha256: String,
+    legacy_dag_wal_namespace_sha256: String,
 }
 
 /// JSON must contain the activation field even when its value is `null`.
@@ -353,16 +368,64 @@ fn verify_descriptor_with_expected(
         inspection.validator_count == RECOVERY_VALIDATOR_SET_SIZE,
         "descriptor inspection has the wrong validator count"
     );
+    let expected_transition_height = inspection
+        .source_height
+        .checked_add(1)
+        .context("descriptor source height cannot have an H+1 transition")?;
     ensure!(
         inspection.chain_id == EXPECTED_CHAIN_ID
-            && inspection.source_height == EXPECTED_SOURCE_HEIGHT
-            && inspection.transition_height == EXPECTED_TRANSITION_HEIGHT
+            && inspection.source_height >= MINIMUM_SOURCE_HEIGHT
+            && inspection.transition_height == expected_transition_height
             && inspection.recovery_epoch == EXPECTED_RECOVERY_EPOCH
             && inspection.validator_set_id == EXPECTED_VALIDATOR_SET_ID
             && inspection.community_rewards_v1_activation_height
-                == Some(EXPECTED_REWARD_ACTIVATION_HEIGHT),
-        "descriptor does not bind the fixed ARC H=137145 to H+1=137146 recovery policy"
+                == Some(EXPECTED_REWARD_ACTIVATION_HEIGHT)
+            && EXPECTED_REWARD_ACTIVATION_HEIGHT <= inspection.transition_height,
+        "descriptor does not bind a capture-derived ARC H at or above 137145 to H+1 while preserving the 137146 rewards floor"
     );
+
+    let canonical_source = &descriptor.canonical_source;
+    ensure!(
+        EXPECTED_FLEET
+            .iter()
+            .any(|(name, _, _, _)| canonical_source.node == *name),
+        "descriptor canonical source is not a controlled ARC fleet node"
+    );
+    ensure!(
+        canonical_source.source_height == inspection.source_height
+            && canonical_source.source_block_hash == inspection.source_block_hash
+            && canonical_source.source_state_root == inspection.source_state_root
+            && canonical_source.source_consensus_round == inspection.source_consensus_round
+            && canonical_source.source_consensus_round > 0,
+        "descriptor canonical source tuple differs from the validator-signed checkpoint source"
+    );
+    for (value, label) in [
+        (
+            canonical_source.snapshot_sha256.as_str(),
+            "canonical source snapshot SHA-256",
+        ),
+        (
+            canonical_source.wal_sha256.as_str(),
+            "canonical source WAL SHA-256",
+        ),
+        (
+            canonical_source.persisted_head_sha256.as_str(),
+            "canonical source persisted-head SHA-256",
+        ),
+        (
+            canonical_source.legacy_dag_round_inspection_sha256.as_str(),
+            "canonical source legacy DAG-round inspection SHA-256",
+        ),
+        (
+            canonical_source.legacy_dag_wal_namespace_sha256.as_str(),
+            "canonical source legacy DAG-WAL namespace SHA-256",
+        ),
+    ] {
+        ensure!(
+            is_lower_hex(value, 64) && value.bytes().any(|byte| byte != b'0'),
+            "descriptor {label} must be one non-zero lowercase 32-byte hexadecimal value"
+        );
+    }
     let protocol_version = parse_protocol_version(&inspection.protocol_version)?;
 
     let descriptor_genesis_hash = parse_hash(
@@ -676,7 +739,7 @@ mod tests {
         verify_descriptor_with_expected(descriptor, Some(genesis), &expected)
     }
 
-    fn fixture() -> (RecoveryCheckpointDescriptor, config::GenesisConfig) {
+    fn fixture_at(source_height: u64) -> (RecoveryCheckpointDescriptor, config::GenesisConfig) {
         let keys = (0..RECOVERY_VALIDATOR_SET_SIZE)
             .map(|_| KeyPair::generate_ed25519())
             .collect::<Vec<_>>();
@@ -720,7 +783,7 @@ mod tests {
             format_version: ARCCHKPT_FORMAT_VERSION,
             chain_id: genesis.chain.chain_id.clone(),
             genesis_hash: genesis.network_hash(false).unwrap(),
-            source_height: 137_145,
+            source_height,
             source_block_hash: hash_bytes(b"descriptor source block"),
             source_state_root: hash_bytes(b"descriptor source state"),
             source_consensus_round: 91,
@@ -814,6 +877,18 @@ mod tests {
                 community_rewards_v1_activation_height: manifest
                     .community_rewards_v1_activation_height,
             },
+            canonical_source: DescriptorCanonicalSource {
+                node: "nyc".into(),
+                source_height: manifest.source_height,
+                source_block_hash: manifest.source_block_hash.to_hex(),
+                source_state_root: manifest.source_state_root.to_hex(),
+                source_consensus_round: manifest.source_consensus_round,
+                snapshot_sha256: "1".repeat(64),
+                wal_sha256: "2".repeat(64),
+                persisted_head_sha256: "3".repeat(64),
+                legacy_dag_round_inspection_sha256: "4".repeat(64),
+                legacy_dag_wal_namespace_sha256: "5".repeat(64),
+            },
             checkpoint_certificate: DescriptorCertificate {
                 signing_hash: signing_hash.to_hex(),
                 validators: validators
@@ -843,6 +918,10 @@ mod tests {
         (descriptor, genesis)
     }
 
+    fn fixture() -> (RecoveryCheckpointDescriptor, config::GenesisConfig) {
+        fixture_at(MINIMUM_SOURCE_HEIGHT)
+    }
+
     #[test]
     fn certificate_reconstructs_and_verifies_the_exact_manifest() {
         let (descriptor, genesis) = fixture();
@@ -859,11 +938,28 @@ mod tests {
         let error = verify_fixture_descriptor(&descriptor, &genesis)
             .unwrap_err()
             .to_string();
-        assert!(error.contains("fixed ARC H=137145 to H+1=137146 recovery policy"));
+        assert!(error.contains("capture-derived ARC H at or above 137145"));
 
         let (mut descriptor, genesis) = fixture();
         descriptor.canonical_inspection.full_state_root = hash_bytes(b"forged").to_hex();
         assert!(verify_fixture_descriptor(&descriptor, &genesis).is_err());
+    }
+
+    #[test]
+    fn canonical_source_must_match_the_signed_tuple_and_bind_capture_evidence() {
+        let (mut descriptor, genesis) = fixture();
+        descriptor.canonical_source.source_consensus_round += 1;
+        let error = verify_fixture_descriptor(&descriptor, &genesis)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("canonical source tuple differs"));
+
+        let (mut descriptor, genesis) = fixture();
+        descriptor.canonical_source.persisted_head_sha256 = "0".repeat(64);
+        let error = verify_fixture_descriptor(&descriptor, &genesis)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("persisted-head SHA-256"));
     }
 
     #[test]
@@ -894,5 +990,22 @@ mod tests {
         let (mut descriptor, genesis) = fixture();
         descriptor.release_tag = "v0.7.99".into();
         assert!(verify_fixture_descriptor(&descriptor, &genesis).is_err());
+    }
+
+    #[test]
+    fn capture_derived_source_above_the_reviewed_anchor_is_accepted() {
+        let (descriptor, genesis) = fixture_at(141_062);
+        let summary = verify_fixture_descriptor(&descriptor, &genesis).unwrap();
+        assert_eq!(summary.source_height, 141_062);
+        assert_eq!(summary.transition_height, 141_063);
+    }
+
+    #[test]
+    fn source_below_the_reviewed_anchor_is_rejected() {
+        let (descriptor, genesis) = fixture_at(MINIMUM_SOURCE_HEIGHT - 1);
+        let error = verify_fixture_descriptor(&descriptor, &genesis)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("capture-derived ARC H at or above 137145"));
     }
 }

--- a/crates/arc-state/Cargo.toml
+++ b/crates/arc-state/Cargo.toml
@@ -31,7 +31,7 @@ uuid.workspace = true
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 [lints]
 workspace = true

--- a/crates/arc-state/src/wal.rs
+++ b/crates/arc-state/src/wal.rs
@@ -375,6 +375,61 @@ fn cleanup_removed_wal_tombstones(directory: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+#[cfg(windows)]
+const WINDOWS_WAL_RETIREMENT_MOVE_ATTEMPTS: usize = 400;
+#[cfg(windows)]
+const WINDOWS_WAL_RETIREMENT_MOVE_RETRY_DELAY: std::time::Duration =
+    std::time::Duration::from_millis(5);
+
+#[cfg(windows)]
+fn retry_windows_wal_retirement_move<Move, Sleep>(
+    mut move_once: Move,
+    mut sleep: Sleep,
+) -> std::io::Result<()>
+where
+    Move: FnMut() -> std::io::Result<()>,
+    Sleep: FnMut(std::time::Duration),
+{
+    use windows_sys::Win32::Foundation::{ERROR_LOCK_VIOLATION, ERROR_SHARING_VIOLATION};
+
+    // Antivirus, backup, and indexing software can briefly open a just-closed
+    // WAL segment without FILE_SHARE_DELETE. Retry only those two transient
+    // Windows errors. Namespace conflicts, permission errors, and every other
+    // failure remain fail-closed.
+    let mut last_transient = None;
+    for attempt in 0..WINDOWS_WAL_RETIREMENT_MOVE_ATTEMPTS {
+        match move_once() {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if matches!(
+                    error.raw_os_error(),
+                    Some(code)
+                        if code == ERROR_SHARING_VIOLATION as i32
+                            || code == ERROR_LOCK_VIOLATION as i32
+                ) =>
+            {
+                last_transient = Some(error);
+                if attempt + 1 < WINDOWS_WAL_RETIREMENT_MOVE_ATTEMPTS {
+                    sleep(WINDOWS_WAL_RETIREMENT_MOVE_RETRY_DELAY);
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Err(last_transient.expect("a bounded WAL retirement retry always records its transient error"))
+}
+
+#[cfg(windows)]
+fn move_wal_segment_to_tombstone_create_only_with_retry(
+    source: &Path,
+    destination: &Path,
+) -> std::io::Result<()> {
+    retry_windows_wal_retirement_move(
+        || move_file_create_only_write_through(source, destination),
+        std::thread::sleep,
+    )
+}
+
 fn durably_remove_wal_segment(path: &Path) -> std::io::Result<()> {
     #[cfg(windows)]
     {
@@ -384,7 +439,7 @@ fn durably_remove_wal_segment(path: &Path) -> std::io::Result<()> {
             .and_then(|name| name.to_str())
             .unwrap_or("wal");
         let tombstone = parent.join(format!(".{file_name}.removed-{}.tmp", uuid::Uuid::new_v4()));
-        move_file_create_only_write_through(path, &tombstone)?;
+        move_wal_segment_to_tombstone_create_only_with_retry(path, &tombstone)?;
         remove_wal_tombstone_best_effort(&tombstone);
         Ok(())
     }
@@ -4079,6 +4134,119 @@ mod tests {
         drop(writer);
 
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_wal_retirement_retry_accepts_only_sharing_and_lock_violations() {
+        use std::collections::VecDeque;
+
+        let mut outcomes = VecDeque::from([
+            Err(std::io::Error::from_raw_os_error(32)),
+            Err(std::io::Error::from_raw_os_error(33)),
+            Ok(()),
+        ]);
+        let mut sleeps = Vec::new();
+        retry_windows_wal_retirement_move(
+            || outcomes.pop_front().expect("one configured move outcome"),
+            |duration| sleeps.push(duration),
+        )
+        .unwrap();
+        assert!(outcomes.is_empty());
+        assert_eq!(
+            sleeps,
+            vec![
+                WINDOWS_WAL_RETIREMENT_MOVE_RETRY_DELAY,
+                WINDOWS_WAL_RETIREMENT_MOVE_RETRY_DELAY,
+            ]
+        );
+
+        let mut move_attempts = 0;
+        let mut sleep_attempts = 0;
+        let error = retry_windows_wal_retirement_move(
+            || {
+                move_attempts += 1;
+                Err(std::io::Error::from_raw_os_error(5))
+            },
+            |_| sleep_attempts += 1,
+        )
+        .unwrap_err();
+        assert_eq!(error.raw_os_error(), Some(5));
+        assert_eq!(move_attempts, 1);
+        assert_eq!(sleep_attempts, 0);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_wal_retirement_retry_is_bounded() {
+        let mut move_attempts = 0;
+        let mut sleep_attempts = 0;
+        let error = retry_windows_wal_retirement_move(
+            || {
+                move_attempts += 1;
+                Err(std::io::Error::from_raw_os_error(32))
+            },
+            |_| sleep_attempts += 1,
+        )
+        .unwrap_err();
+        assert_eq!(error.raw_os_error(), Some(32));
+        assert_eq!(move_attempts, WINDOWS_WAL_RETIREMENT_MOVE_ATTEMPTS);
+        assert_eq!(sleep_attempts, WINDOWS_WAL_RETIREMENT_MOVE_ATTEMPTS - 1);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_wal_retirement_move_retries_a_real_sharing_violation() {
+        use std::os::windows::fs::OpenOptionsExt as _;
+        use windows_sys::Win32::Storage::FileSystem::{FILE_SHARE_READ, FILE_SHARE_WRITE};
+
+        let dir = tmp_dir("wal_create_only_move_sharing_violation");
+        let source = dir.join("wal-00000000.bin");
+        let destination = dir.join(".wal-00000000.bin.removed-test.tmp");
+        fs::write(&source, b"immutable WAL segment").unwrap();
+
+        // Deliberately omit FILE_SHARE_DELETE so MoveFileExW must return a
+        // sharing violation until this independently owned handle closes.
+        let mut blocker = Some(
+            OpenOptions::new()
+                .read(true)
+                .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+                .open(&source)
+                .unwrap(),
+        );
+        let mut sleep_attempts = 0;
+
+        retry_windows_wal_retirement_move(
+            || move_file_create_only_write_through(&source, &destination),
+            |_| {
+                sleep_attempts += 1;
+                drop(blocker.take());
+            },
+        )
+        .unwrap();
+        assert_eq!(sleep_attempts, 1);
+        assert!(!source.exists());
+        assert_eq!(fs::read(&destination).unwrap(), b"immutable WAL segment");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_wal_retirement_move_never_replaces_a_destination() {
+        let dir = tmp_dir("wal_create_only_move_existing_destination");
+        let source = dir.join("wal-00000000.bin");
+        let destination = dir.join(".wal-00000000.bin.removed-existing.tmp");
+        fs::write(&source, b"live WAL segment").unwrap();
+        fs::write(&destination, b"existing tombstone").unwrap();
+
+        let error = move_wal_segment_to_tombstone_create_only_with_retry(&source, &destination)
+            .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_ne!(error.raw_os_error(), Some(32));
+        assert_ne!(error.raw_os_error(), Some(33));
+        assert_eq!(fs::read(&source).unwrap(), b"live WAL segment");
+        assert_eq!(fs::read(&destination).unwrap(), b"existing tombstone");
+        fs::remove_dir_all(dir).unwrap();
     }
 
     #[cfg(windows)]

--- a/crates/arc-state/src/wal.rs
+++ b/crates/arc-state/src/wal.rs
@@ -1179,7 +1179,7 @@ impl WalWriter {
         sync_result.map_err(|error| std::io::Error::new(error.kind(), error))?;
 
         synchronized();
-        Self::delete_segments_before_in_dir(&self.wal_dir, wal_sequence, 2)
+        Self::delete_segments_before_live_writer_fenced(&self.wal_dir, wal_sequence, 2)
     }
 
     /// Offline-only static version: scan an inactive `wal_dir` for segment
@@ -1191,6 +1191,27 @@ impl WalWriter {
         wal_dir: &Path,
         wal_sequence: u64,
         min_retain: usize,
+    ) -> std::io::Result<u32> {
+        Self::delete_segments_before_in_dir_inner(wal_dir, wal_sequence, min_retain, false)
+    }
+
+    /// The admission lock and successful Sync acknowledgement must remain in
+    /// force for this complete call. On Windows only the final segment uses a
+    /// read-only opener compatible with the still-live append handle; every
+    /// offline/recovery reader retains its exclusive fail-closed open.
+    fn delete_segments_before_live_writer_fenced(
+        wal_dir: &Path,
+        wal_sequence: u64,
+        min_retain: usize,
+    ) -> std::io::Result<u32> {
+        Self::delete_segments_before_in_dir_inner(wal_dir, wal_sequence, min_retain, true)
+    }
+
+    fn delete_segments_before_in_dir_inner(
+        wal_dir: &Path,
+        wal_sequence: u64,
+        min_retain: usize,
+        live_writer_fenced: bool,
     ) -> std::io::Result<u32> {
         cleanup_removed_wal_tombstones(wal_dir)?;
         let min_retain = if min_retain < 2 { 2 } else { min_retain };
@@ -1214,7 +1235,16 @@ impl WalWriter {
         for (segment_index, seg_path) in segments.iter().enumerate() {
             // Pruning is destructive, so a corrupt frame or cross-segment
             // sequence gap must abort before any namespace entry is removed.
+            #[cfg(windows)]
+            let entries = if live_writer_fenced && segment_index + 1 == segments.len() {
+                read_wal_strict_live_writer_segment(seg_path, &mut expected_sequence)?
+            } else {
+                read_wal_strict_segment(seg_path, &mut expected_sequence)?
+            };
+            #[cfg(not(windows))]
             let entries = read_wal_strict_segment(seg_path, &mut expected_sequence)?;
+            #[cfg(not(windows))]
+            let _ = live_writer_fenced;
             if !entries.is_empty() {
                 last_nonempty_segment = Some(segment_index);
             }
@@ -2450,6 +2480,22 @@ fn read_wal_strict_segment(
     expected_sequence: &mut Option<u64>,
 ) -> std::io::Result<Vec<WalEntry>> {
     let file = arc_crypto::secret_file::open_owned_nofollow_read(path)?;
+    read_wal_strict_segment_from_file(file, expected_sequence)
+}
+
+#[cfg(windows)]
+fn read_wal_strict_live_writer_segment(
+    path: &Path,
+    expected_sequence: &mut Option<u64>,
+) -> std::io::Result<Vec<WalEntry>> {
+    let file = arc_crypto::secret_file::open_owned_nofollow_shared_read(path)?;
+    read_wal_strict_segment_from_file(file, expected_sequence)
+}
+
+fn read_wal_strict_segment_from_file(
+    file: File,
+    expected_sequence: &mut Option<u64>,
+) -> std::io::Result<Vec<WalEntry>> {
     let original_bytes = file.metadata()?.len();
     let mut reader = BufReader::new(file);
     let mut entries = Vec::new();
@@ -3443,18 +3489,32 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn live_wal_identity_probe_allows_reopen_but_keeps_writer_exclusive() {
-        let dir = tmp_dir("windows_live_identity_probe");
+    fn live_wal_shared_read_is_narrow_and_keeps_writer_exclusive() {
+        use windows_sys::Win32::Foundation::ERROR_SHARING_VIOLATION;
+
+        let dir = tmp_dir("windows_live_shared_read");
         let path = dir.join("state.wal");
 
         let writer = WalWriter::new(&path).unwrap();
         writer.append(WalOp::Checkpoint(hash_bytes(b"first")), 1);
         writer.sync().unwrap();
 
+        let exclusive_error = read_wal_strict(&path).unwrap_err();
+        assert_eq!(
+            exclusive_error.raw_os_error(),
+            Some(ERROR_SHARING_VIOLATION as i32)
+        );
+
+        let mut expected_sequence = Some(0);
+        let live_entries =
+            read_wal_strict_live_writer_segment(&path, &mut expected_sequence).unwrap();
+        assert_eq!(live_entries.len(), 1);
+        assert_eq!(live_entries[0].sequence, 0);
+
         let second = WalWriter::new(&path);
         assert!(
             second.is_err(),
-            "the compatible identity probe must not admit a second writer"
+            "the compatible shared reader must not admit a second writer"
         );
         drop(writer);
 

--- a/crates/arc-state/src/wal.rs
+++ b/crates/arc-state/src/wal.rs
@@ -2394,7 +2394,7 @@ fn read_wal_strict_segment(
     path: &Path,
     expected_sequence: &mut Option<u64>,
 ) -> std::io::Result<Vec<WalEntry>> {
-    let file = File::open(path)?;
+    let file = arc_crypto::secret_file::open_owned_nofollow_read(path)?;
     let original_bytes = file.metadata()?.len();
     let mut reader = BufReader::new(file);
     let mut entries = Vec::new();
@@ -2524,6 +2524,119 @@ pub fn read_wal_dir_strict(dir: impl AsRef<Path>) -> std::io::Result<Vec<WalEntr
         all_entries.extend(read_wal_strict_segment(&segment, &mut expected_sequence)?);
     }
     Ok(all_entries)
+}
+
+/// A bounded, fail-closed view of the durable tail of a segmented legacy DAG
+/// WAL.  Legacy startup historically derives its resume cursor from the last
+/// three segments so an empty post-rotation segment cannot hide the preceding
+/// round.  Recovery uses the same bounded window, while additionally requiring
+/// a contiguous segment namespace and strict frame/checksum/sequence decoding.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StrictWalTailInspection {
+    pub first_segment: u64,
+    pub last_segment: u64,
+    pub segment_count: u64,
+    pub inspected_first_segment: u64,
+    pub inspected_segment_count: u64,
+    pub inspected_entry_count: u64,
+    pub source_consensus_round: u64,
+}
+
+/// Strictly inspect the bounded legacy DAG-WAL tail used to derive a recovery
+/// consensus cursor.
+///
+/// Unlike [`latest_block_height_in_wal_dir`], this is fallible: namespace
+/// gaps, malformed frames, checksum failures, and sequence discontinuities in
+/// the inspected tail abort the operation.  Only the final three segments are
+/// decoded, matching the bounded legacy restart rule and avoiding an
+/// unbounded replay of historical DAG traffic during an offline cutover.
+pub fn inspect_wal_dir_tail_strict(
+    dir: impl AsRef<Path>,
+) -> std::io::Result<StrictWalTailInspection> {
+    const MAX_SEGMENTS_TO_SCAN: usize = 3;
+
+    let segments = WalWriter::list_segments_strict(dir.as_ref())?;
+    let first_segment = WalWriter::validate_segment_namespace(&segments)?;
+    let segment_count = u64::try_from(segments.len()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "WAL segment count exceeds u64",
+        )
+    })?;
+    if segments.is_empty() {
+        return Ok(StrictWalTailInspection {
+            first_segment: 0,
+            last_segment: 0,
+            segment_count: 0,
+            inspected_first_segment: 0,
+            inspected_segment_count: 0,
+            inspected_entry_count: 0,
+            source_consensus_round: 0,
+        });
+    }
+
+    let start = segments.len().saturating_sub(MAX_SEGMENTS_TO_SCAN);
+    let inspected = &segments[start..];
+    let inspected_first_segment =
+        WalWriter::parse_segment_number(&inspected[0]).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid WAL segment name: {}", inspected[0].display()),
+            )
+        })?;
+    let last_segment = WalWriter::parse_segment_number(segments.last().expect("non-empty"))
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "final WAL segment name is malformed",
+            )
+        })?;
+    let mut expected_sequence = (inspected_first_segment == 0).then_some(0);
+    let mut inspected_entry_count = 0u64;
+    let mut source_consensus_round = 0u64;
+    for segment in inspected {
+        let entries = read_wal_strict_segment(segment, &mut expected_sequence)?;
+        inspected_entry_count = inspected_entry_count
+            .checked_add(u64::try_from(entries.len()).map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "WAL tail entry count exceeds u64",
+                )
+            })?)
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "WAL tail entry count overflows u64",
+                )
+            })?;
+        source_consensus_round = entries
+            .iter()
+            .map(|entry| entry.block_height)
+            .max()
+            .unwrap_or(source_consensus_round)
+            .max(source_consensus_round);
+    }
+    if segment_count > MAX_SEGMENTS_TO_SCAN as u64 && inspected_entry_count == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "latest three WAL segments are all empty",
+        ));
+    }
+
+    Ok(StrictWalTailInspection {
+        first_segment,
+        last_segment,
+        segment_count,
+        inspected_first_segment,
+        inspected_segment_count: u64::try_from(inspected.len()).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "inspected WAL segment count exceeds u64",
+            )
+        })?,
+        inspected_entry_count,
+        source_consensus_round,
+    })
 }
 
 /// Find the highest `block_height` recorded in any WAL segment under `dir`.
@@ -4110,6 +4223,48 @@ mod tests {
             latest, 199,
             "helper must find max round even when newest segment is the empty post-rotation file"
         );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn strict_tail_inspection_returns_the_exact_durable_round() {
+        let dir = tmp_dir("strict_tail_round");
+        {
+            let writer = WalWriter::with_segments(&dir, 1024).expect("create");
+            for round in 0u64..200 {
+                writer.append(WalOp::Checkpoint(Hash256::ZERO), round);
+            }
+            writer.sync().unwrap();
+            drop(writer);
+        }
+
+        let inspection = inspect_wal_dir_tail_strict(&dir).unwrap();
+        assert_eq!(inspection.source_consensus_round, 199);
+        assert!(inspection.segment_count >= inspection.inspected_segment_count);
+        assert!((1..=3).contains(&inspection.inspected_segment_count));
+        assert!(inspection.inspected_entry_count > 0);
+        assert_eq!(inspection.first_segment, 0);
+        assert!(inspection.last_segment >= inspection.inspected_first_segment);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn strict_tail_inspection_rejects_a_corrupt_final_segment() {
+        let dir = tmp_dir("strict_tail_corrupt");
+        {
+            let writer = WalWriter::with_segments(&dir, u64::MAX).expect("create");
+            writer.append(WalOp::Checkpoint(Hash256::ZERO), 77);
+            writer.sync().unwrap();
+            drop(writer);
+        }
+        let segment = dir.join("wal-00000000.bin");
+        let mut bytes = fs::read(&segment).unwrap();
+        *bytes.last_mut().expect("encoded WAL entry") ^= 0x80;
+        fs::write(&segment, bytes).unwrap();
+
+        let error = inspect_wal_dir_tail_strict(&dir).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("checksum"));
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/docs/COMMUNITY-NODE-WALKTHROUGH.md
+++ b/docs/COMMUNITY-NODE-WALKTHROUGH.md
@@ -77,7 +77,7 @@ Narration: “This is a plain server over SSH—no desktop and no GUI.”
 
 ```bash
 curl -fsSLO --proto '=https' --proto-redir '=https' --tlsv1.2 https://raw.githubusercontent.com/FerrumVir/arc-chain/v0.8.0/install.sh
-ARC_INSTALL_SHA256=4480a627e5f50f61a22b6a3b97ab4a8f102400c03f03a1c73d7d8abe79601151
+ARC_INSTALL_SHA256=0413fdd6088d0522841c472abfcf460b1ffaba67a6923355325d699c2f5b0242
 if command -v sha256sum >/dev/null 2>&1; then
   printf '%s  %s\n' "$ARC_INSTALL_SHA256" install.sh | sha256sum -c -
 else
@@ -87,7 +87,7 @@ bash install.sh --version 0.8.0 --model /absolute/path/to/model.gguf
 ```
 
 The pinned installer SHA-256 is
-`4480a627e5f50f61a22b6a3b97ab4a8f102400c03f03a1c73d7d8abe79601151`.
+`0413fdd6088d0522841c472abfcf460b1ffaba67a6923355325d699c2f5b0242`.
 
 The protected source-tag installer resolves one exact semantic-versioned
 release and verifies the owner signature on `SHA256SUMS` before trusting any

--- a/docs/HEADLESS_INSTALL.md
+++ b/docs/HEADLESS_INSTALL.md
@@ -48,7 +48,7 @@ verified installer below.
 
 ```bash
 curl -fsSLO --proto '=https' --proto-redir '=https' --tlsv1.2 https://raw.githubusercontent.com/FerrumVir/arc-chain/v0.8.0/install.sh
-ARC_INSTALL_SHA256=4480a627e5f50f61a22b6a3b97ab4a8f102400c03f03a1c73d7d8abe79601151
+ARC_INSTALL_SHA256=0413fdd6088d0522841c472abfcf460b1ffaba67a6923355325d699c2f5b0242
 if command -v sha256sum >/dev/null 2>&1; then
   printf '%s  %s\n' "$ARC_INSTALL_SHA256" install.sh | sha256sum -c -
 else
@@ -261,8 +261,9 @@ v0.8. Never run the generations concurrently, even with separate data paths.
 Released v0.7 cannot prove quiescence: its signal handler exits immediately and
 does not close inference admission, join producer tasks, or establish a final
 WAL barrier. Waiting longer does not turn that behavior into a drain. The
-signed cutover policy instead fixes canonical height 137145, requires the v3
-fleet at height 137146 or later, records unfinished v0.7 work as
+signed cutover policy instead fixes the capture-derived canonical height `H`
+at the highest strictly replayed captured descendant of the trusted 137145
+anchor, requires the v3 fleet at `H+1` or later, records unfinished v0.7 work as
 `expired_noncanonical_at_cutover`, and explicitly sets
 `legacy_exit_clean_claimed=false`. Before TERM, the installer authenticates the
 policy, maintenance boundary, and quorum checkpoint, verifies all six exact v3

--- a/docs/MACOS-PRETAG-COMMUNITY-CANARY.md
+++ b/docs/MACOS-PRETAG-COMMUNITY-CANARY.md
@@ -132,6 +132,13 @@ controller compares macOS `ps` output to one unambiguous complete argv. Move a
 model or materialized candidate to a simple absolute path before planning if
 needed.
 
+The commands below assume that `HOME` is protected by FileVault. Do not stage
+the selected artifact, generated worker key, chain data, or acceptance evidence
+on an unencrypted home volume. On a FileVault-disabled operator host, use the
+dedicated encrypted APFS sparsebundle boundary and fail-closed mount
+gate in `scripts/recovery/README.md`; it scopes `HOME`, `TMPDIR`, and
+`RUNNER_TEMP` into the mounted image before verification or installation.
+
 ## Materialize the exact selected preflight bytes
 
 Start from the reviewed successful `release-signing-preflight.yml` run on the

--- a/docs/PRODUCTION-RECOVERY-AUDIT-2026-08-26.md
+++ b/docs/PRODUCTION-RECOVERY-AUDIT-2026-08-26.md
@@ -159,7 +159,8 @@ independent humans approved the cutover. Immediately before offline signing,
 the repository owner must manually dispatch the read-only, no-secret
 `owner-emergency-recovery-approval.yml` workflow on the exact protected-main
 commit with the inspected checkpoint manifest hash, public-key manifest hash,
-all six ordered public keys, and exact reviewed confirmation. The operator
+the sealed capture-derived H/T/source tuple/final round/C/F/maintenance-boundary
+root, all six ordered public keys, and exact reviewed confirmation. The operator
 API-selects one new exact workflow/path/event/branch/SHA run and attempt whose
 actor and triggering actor are both the pinned owner, waits for that attempt to
 succeed, and preserves the workflow, run, exact-attempt jobs, artifact metadata,
@@ -169,11 +170,13 @@ directory.
 `owner-emergency-recovery.py verify-github-artifact` receives no GitHub token.
 It authenticates those GitHub API facts, the single successful named job, and
 the one-member artifact, then materializes a fresh, create-only
-`arc.recovery.owner-emergency-recovery.v2` receipt owned by the operator at mode
+`arc.recovery.owner-emergency-recovery.v3` receipt owned by the operator at mode
 `0400` with an exact mode-`0400` SHA-256 sidecar. That receipt records the pinned
 repository owner's GitHub-authenticated `owner_emergency_recovery` decision and
 UTC time, fixed reason and risk acknowledgement, protected-main commit,
-checkpoint manifest, H=137145/H+1=137146, recovery epoch/set 1/1, ordered
+checkpoint manifest, capture-derived `H`, `T=H+1`, source block/state/final
+round, observed cutoff `C`, reopening floor `F=C+128`, maintenance-boundary
+SHA-256, recovery epoch/set 1/1, ordered
 validator public identities/stakes, exact five-signature order, unused sixth
 member, and strict stake-supermajority threshold. Matching locally authored
 text is not authorization. This owner emergency receipt is transparent about

--- a/docs/VALIDATOR-FLEET-ROLLOUT.md
+++ b/docs/VALIDATOR-FLEET-ROLLOUT.md
@@ -888,19 +888,27 @@ argv/output hashes must verify before any new validator key is installed.
    not create a second full local data-tree copy. Confirm each capture inventory
    binds the immutable pre-freeze observation root/receipt and that all three
    outcomes remain labelled diagnostic, noncanonical, and nonreward.
-5. Run the recovery README's exact root/mode/size/SHA-256, four-row
-   `SHA256SUMS`, and metadata verification for the independently preserved
-   shared reference pair first. It binds block height 137145, block hash
+5. Run the recovery README's `build-production-manifest.py select-source`
+   phase over the complete sealed six-node capture first. It treats height
+   137145, block hash
    `8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90`,
    and state root
-   `d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d`.
-   Source consensus round 9774808 is distinct recovery metadata, not the block
-   height. Then use `arc-node recovery export --data-dir <reference-pair>
+   `d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d`
+   as the trusted minimum ancestry anchor, verifies every embedded anchor and
+   durable DAG-WAL inspection, and selects the highest strictly replayed
+   anchor-descendant tuple as `H`. Equal-height replicas are permitted only
+   when their block/state tuple agrees. Download the exact selected pair and
+   verify its size and SHA-256 against the create-only preselection receipt.
+   The final consensus round comes from that selected node's stopped DAG-WAL
+   proof, never from a live endpoint. Then use
+   `arc-node recovery export --data-dir <reference-pair>
    --snapshot <reference-pair/state.snapshot.lz4> --legacy-validator-set
    <legacy-validator-set-40m.json> ...` to reproduce the candidate from that
    exact pair. Successful export—not
    endpoint metadata or a later validator capture—must prove that the decoded
-   snapshot H/root equals its complete WAL block/checkpoint boundary.
+   snapshot H/root equals its complete WAL block/checkpoint boundary and the
+   preselection receipt. The transition is `T=H+1`; a taller conflicting fork
+   may make `C>H`, and public reopening remains held until `F=C+128`.
    The audited legacy WAL needs the explicit `--allow-unbound-legacy-wal`
    exception because it predates the genesis network hash; record that fact.
 6. In the one reviewed, root-only operator enclave that contains the six-key

--- a/install.sh
+++ b/install.sh
@@ -3141,6 +3141,9 @@ RETIREMENT_RECOVERY_EPOCH=""
 RETIREMENT_VALIDATOR_SET_ID=""
 RETIREMENT_SOURCE_HEIGHT=""
 RETIREMENT_TRANSITION_HEIGHT=""
+RETIREMENT_OBSERVED_CUTOFF_HEIGHT=""
+RETIREMENT_CONTINUITY_SAFETY_MARGIN=""
+RETIREMENT_LEGACY_PUBLIC_MAX_HEIGHT=""
 
 write_release_installer_binding() {
     local records="$TMP_DIR/release-binding-files" sorted="$TMP_DIR/release-binding-files-sorted"
@@ -3214,16 +3217,34 @@ verify_recovery_descriptor_for_retirement() {
         || die "Recovery descriptor verifier omitted source_height"
     RETIREMENT_TRANSITION_HEIGHT="$(top_level_json_bare "$output" transition_height)" \
         || die "Recovery descriptor verifier omitted transition_height"
+    RETIREMENT_OBSERVED_CUTOFF_HEIGHT="$(top_level_json_bare \
+        "$TMP_DIR/$CUTOVER_POLICY_ASSET" legacy_observed_cutoff_height)" \
+        || die "Cutover policy omitted legacy_observed_cutoff_height"
+    RETIREMENT_CONTINUITY_SAFETY_MARGIN="$(top_level_json_bare \
+        "$TMP_DIR/$CUTOVER_POLICY_ASSET" legacy_continuity_safety_margin)" \
+        || die "Cutover policy omitted legacy_continuity_safety_margin"
+    RETIREMENT_LEGACY_PUBLIC_MAX_HEIGHT="$(top_level_json_bare \
+        "$TMP_DIR/$CUTOVER_POLICY_ASSET" legacy_public_max_height)" \
+        || die "Cutover policy omitted legacy_public_max_height"
     canonical_uint "$RETIREMENT_RECOVERY_EPOCH" \
         && canonical_uint "$RETIREMENT_VALIDATOR_SET_ID" \
         && canonical_uint "$RETIREMENT_SOURCE_HEIGHT" \
         && canonical_uint "$RETIREMENT_TRANSITION_HEIGHT" \
+        && canonical_uint "$RETIREMENT_OBSERVED_CUTOFF_HEIGHT" \
+        && canonical_uint "$RETIREMENT_CONTINUITY_SAFETY_MARGIN" \
+        && canonical_uint "$RETIREMENT_LEGACY_PUBLIC_MAX_HEIGHT" \
         || die "Recovery descriptor verifier returned malformed numeric identity"
-    [ "$RETIREMENT_SOURCE_HEIGHT" -eq 137145 ] \
-        && [ "$RETIREMENT_TRANSITION_HEIGHT" -eq 137146 ] \
+    [ "$RETIREMENT_SOURCE_HEIGHT" -ge 137145 ] \
+        && [ "$RETIREMENT_TRANSITION_HEIGHT" \
+            -eq "$((RETIREMENT_SOURCE_HEIGHT + 1))" ] \
+        && [ "$RETIREMENT_OBSERVED_CUTOFF_HEIGHT" \
+            -ge "$RETIREMENT_SOURCE_HEIGHT" ] \
+        && [ "$RETIREMENT_CONTINUITY_SAFETY_MARGIN" -eq 128 ] \
+        && [ "$RETIREMENT_LEGACY_PUBLIC_MAX_HEIGHT" \
+            -eq "$((RETIREMENT_OBSERVED_CUTOFF_HEIGHT + RETIREMENT_CONTINUITY_SAFETY_MARGIN))" ] \
         && [ "$RETIREMENT_RECOVERY_EPOCH" -eq 1 ] \
         && [ "$RETIREMENT_VALIDATOR_SET_ID" -eq 1 ] \
-        || die "Recovery descriptor differs from the fixed ARC cutover boundary"
+        || die "Recovery assets differ from the capture-derived ARC cutover boundary"
 }
 
 ensure_legacy_retirement_evidence_dirs() {
@@ -3463,7 +3484,7 @@ verify_legacy_v07_network_retirement() {
             || die "Recovered validator returned malformed numeric identity: $origin"
         [ "$recovery_epoch" -eq "$RETIREMENT_RECOVERY_EPOCH" ] \
             && [ "$validator_set_id" -eq "$RETIREMENT_VALIDATOR_SET_ID" ] \
-            && [ "$height" -ge "$RETIREMENT_TRANSITION_HEIGHT" ] \
+            && [ "$height" -gt "$RETIREMENT_LEGACY_PUBLIC_MAX_HEIGHT" ] \
             || die "Validator has not crossed the approved v0.7 retirement boundary: $origin"
 
         validator_address="$(top_level_json_string "$info_file" validator_address)" \
@@ -3521,7 +3542,7 @@ verify_legacy_v07_network_retirement() {
             die "Legacy v0.7 RPC is still reachable at ${probe_labels[$index]}; the old node was not stopped"
         fi
     done
-    ok "All six exact validators match the signed checkpoint at or above block $RETIREMENT_TRANSITION_HEIGHT and legacy claim/submit ports are unreachable"
+    ok "All six exact validators match the signed checkpoint above legacy reopening floor $RETIREMENT_LEGACY_PUBLIC_MAX_HEIGHT and legacy claim/submit ports are unreachable"
 }
 
 prepare_absent_v08_data_dir_for_retirement() {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,7 +84,7 @@ commands below are release-shape examples, not a claim that GitHub's current
 ```bash
 # Example only after the v0.8.0 release is explicitly approved and published:
 curl -fsSLO --proto '=https' --proto-redir '=https' --tlsv1.2 https://raw.githubusercontent.com/FerrumVir/arc-chain/v0.8.0/install.sh
-ARC_INSTALL_SHA256=4480a627e5f50f61a22b6a3b97ab4a8f102400c03f03a1c73d7d8abe79601151
+ARC_INSTALL_SHA256=0413fdd6088d0522841c472abfcf460b1ffaba67a6923355325d699c2f5b0242
 if command -v sha256sum >/dev/null 2>&1; then
   printf '%s  %s\n' "$ARC_INSTALL_SHA256" install.sh | sha256sum -c -
 else
@@ -182,7 +182,7 @@ ARC_COORDINATOR=http://127.0.0.1:9944 bash scripts/arc-verify.sh --latest
 ```bash
 # Only after v0.8.0 is explicitly approved and published:
 curl -fsSLO --proto '=https' --proto-redir '=https' --tlsv1.2 https://raw.githubusercontent.com/FerrumVir/arc-chain/v0.8.0/install.sh
-ARC_INSTALL_SHA256=4480a627e5f50f61a22b6a3b97ab4a8f102400c03f03a1c73d7d8abe79601151
+ARC_INSTALL_SHA256=0413fdd6088d0522841c472abfcf460b1ffaba67a6923355325d699c2f5b0242
 if command -v sha256sum >/dev/null 2>&1; then
   printf '%s  %s\n' "$ARC_INSTALL_SHA256" install.sh | sha256sum -c -
 else

--- a/scripts/migration/arc-v07-retirement-verifier.py
+++ b/scripts/migration/arc-v07-retirement-verifier.py
@@ -20,6 +20,7 @@ separately from that inference-job disposition.
 from __future__ import annotations
 
 import argparse
+import copy
 import datetime as dt
 import hashlib
 import json
@@ -54,8 +55,9 @@ CUTOVER_POLICY_SCHEMA = "arc-cutover-policy/v1"
 CUTOVER_POLICY_ASSET = "arc-cutover-policy.json"
 BOUNDARY_ASSET = "arc-legacy-maintenance-boundary.json"
 CHECKPOINT_DESCRIPTOR_ASSET = "arc-recovery-checkpoint-descriptor.json"
-CANONICAL_BOUNDARY_HEIGHT = 137_145
-REQUIRED_POST_CUTOVER_MIN_HEIGHT = 137_146
+TRUSTED_CHECKPOINT_MIN_HEIGHT = 137_145
+COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT = 137_146
+LEGACY_CONTINUITY_SAFETY_MARGIN = 128
 RECOVERY_CHAIN_ID = "0x415243"
 PRODUCTION_FLEET = (
     ("nyc", "149.28.32.76"),
@@ -1186,6 +1188,8 @@ def validate_boundary(value: Mapping[str, Any]) -> dict[str, Any]:
     public_maximum = require_uint(value.get("legacy_public_max_height"), "legacy public maximum height")
     if public_maximum != cutoff + margin:
         fail("legacy public maximum height is not cutoff plus the continuity margin")
+    if margin != LEGACY_CONTINUITY_SAFETY_MARGIN:
+        fail("legacy maintenance boundary continuity margin is not 128")
     freeze_plan_sha256 = require_hash(
         value.get("freeze_plan_sha256"), "legacy maintenance freeze-plan sha256"
     )
@@ -1203,6 +1207,14 @@ def validate_boundary(value: Mapping[str, Any]) -> dict[str, Any]:
     origin_scope = value.get("official_origin_scope")
     if not isinstance(origin_scope, dict) or origin_scope.get("global_absence_claimed") is not False:
         fail("legacy maintenance boundary official-origin scope is dishonest")
+    nodes = value.get("nodes")
+    if not isinstance(nodes, list) or len(nodes) != len(PRODUCTION_FLEET):
+        fail("legacy maintenance boundary does not contain the production fleet")
+    for (name, host), row in zip(PRODUCTION_FLEET, nodes):
+        if not isinstance(row, dict) or (
+            row.get("node"), row.get("host"), row.get("origin")
+        ) != (name, host, f"http://{host}:9090"):
+            fail(f"legacy maintenance boundary node {name} differs")
     threat_model = value.get("threat_model")
     if not isinstance(threat_model, dict) or threat_model.get("hostile_root_containment_claimed") is not False:
         fail("legacy maintenance boundary threat model is unsupported")
@@ -1253,12 +1265,10 @@ def validate_checkpoint_identity(value: Mapping[str, Any], boundary: Mapping[str
     transition_height = require_uint(value.get("transition_height"), "checkpoint transition height", positive=True)
     if transition_height != source_height + 1:
         fail("checkpoint transition height is not exactly source height plus one")
-    if (
-        source_height != boundary["legacy_public_max_height"]
-        or source_height != CANONICAL_BOUNDARY_HEIGHT
-        or transition_height != REQUIRED_POST_CUTOVER_MIN_HEIGHT
-    ):
-        fail("checkpoint does not bind the canonical H=137145 to H+1=137146 cutover")
+    if source_height > boundary["observed_cutoff_height"]:
+        fail("checkpoint source height is above the captured legacy cutoff")
+    if source_height < TRUSTED_CHECKPOINT_MIN_HEIGHT:
+        fail("checkpoint source height predates the trusted recovery anchor")
     if require_uint(value.get("format_version"), "checkpoint format version", positive=True) != 1:
         fail("checkpoint descriptor format version is not ARCCHKPT v1")
     if value.get("chain_id") != RECOVERY_CHAIN_ID:
@@ -1267,8 +1277,16 @@ def validate_checkpoint_identity(value: Mapping[str, Any], boundary: Mapping[str
         fail("checkpoint descriptor is not exact recovery protocol 3.0.0")
     if value.get("validator_count") != 6:
         fail("checkpoint descriptor does not bind exactly six validators")
-    if value.get("community_rewards_v1_activation_height") != REQUIRED_POST_CUTOVER_MIN_HEIGHT:
-        fail("checkpoint descriptor community rewards activation differs from H+1")
+    activation_height = require_uint(
+        value.get("community_rewards_v1_activation_height"),
+        "checkpoint descriptor community rewards activation",
+        positive=True,
+    )
+    if (
+        activation_height != COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT
+        or activation_height > transition_height
+    ):
+        fail("checkpoint descriptor community rewards activation is invalid for H+1")
     return {
         "format_version": 1,
         "chain_id": RECOVERY_CHAIN_ID,
@@ -1292,7 +1310,7 @@ def validate_checkpoint_identity(value: Mapping[str, Any], boundary: Mapping[str
         ),
         "protocol_version": value["protocol_version"],
         "validator_count": 6,
-        "community_rewards_v1_activation_height": REQUIRED_POST_CUTOVER_MIN_HEIGHT,
+        "community_rewards_v1_activation_height": activation_height,
     }
 
 
@@ -1301,12 +1319,13 @@ def validate_checkpoint_descriptor(
     *,
     release_binding: Mapping[str, Any],
     boundary: Mapping[str, Any],
+    boundary_nodes: Any = None,
 ) -> dict[str, Any]:
     if set(value) != {
         "schema_version", "repository", "release_tag", "release_commit",
         "recovery_manifest_sha256", "freeze_plan_sha256", "capture_id",
         "inspector_binary_sha256", "checkpoint_file", "canonical_inspection",
-        "checkpoint_certificate", "approved_validators", "verified_quorum",
+        "canonical_source", "checkpoint_certificate", "approved_validators", "verified_quorum",
     } or value.get("schema_version") != CHECKPOINT_DESCRIPTOR_SCHEMA:
         fail("checkpoint descriptor has missing, unknown, or unsupported fields")
     if (
@@ -1337,6 +1356,73 @@ def validate_checkpoint_descriptor(
     if not isinstance(identity_raw, dict):
         fail("checkpoint descriptor canonical inspection is missing")
     identity = validate_checkpoint_identity(identity_raw, boundary)
+    canonical_source = value.get("canonical_source")
+    if not isinstance(canonical_source, dict) or set(canonical_source) != {
+        "node",
+        "source_height",
+        "source_block_hash",
+        "source_state_root",
+        "source_consensus_round",
+        "snapshot_sha256",
+        "wal_sha256",
+        "persisted_head_sha256",
+        "legacy_dag_round_inspection_sha256",
+        "legacy_dag_wal_namespace_sha256",
+    }:
+        fail("checkpoint descriptor canonical source is malformed")
+    if canonical_source.get("node") not in {name for name, _host in PRODUCTION_FLEET}:
+        fail("checkpoint descriptor canonical source node differs")
+    for field in (
+        "source_block_hash",
+        "source_state_root",
+        "snapshot_sha256",
+        "wal_sha256",
+        "persisted_head_sha256",
+        "legacy_dag_round_inspection_sha256",
+        "legacy_dag_wal_namespace_sha256",
+    ):
+        require_hash(canonical_source.get(field), f"canonical source {field}")
+    require_uint(canonical_source.get("source_height"), "canonical source height")
+    require_uint(
+        canonical_source.get("source_consensus_round"),
+        "canonical source consensus round",
+    )
+    if any(
+        canonical_source.get(field) != identity[field]
+        for field in (
+            "source_height",
+            "source_block_hash",
+            "source_state_root",
+            "source_consensus_round",
+        )
+    ):
+        fail("checkpoint descriptor canonical source differs from checkpoint identity")
+    if not isinstance(boundary_nodes, list):
+        fail("checkpoint descriptor validation requires captured boundary nodes")
+    source_node = next(
+        (
+            row
+            for row in boundary_nodes
+            if row.get("node") == canonical_source["node"]
+        ),
+        None,
+    )
+    source_head_wrapper = (
+        source_node.get("final_persisted_head", {})
+        if isinstance(source_node, dict)
+        else {}
+    )
+    source_head = source_head_wrapper.get("tuple", {})
+    if (
+        source_head_wrapper.get("evidence_sha256")
+        != canonical_source["persisted_head_sha256"]
+        or source_head.get("height") != identity["source_height"]
+        or str(source_head.get("block_hash", "")).removeprefix("0x")
+        != str(identity["source_block_hash"]).removeprefix("0x")
+        or str(source_head.get("state_root", "")).removeprefix("0x")
+        != str(identity["source_state_root"]).removeprefix("0x")
+    ):
+        fail("checkpoint descriptor canonical source differs from captured persisted head")
     validators = value.get("approved_validators")
     if not isinstance(validators, list) or len(validators) != 6:
         fail("checkpoint descriptor must bind six approved validators")
@@ -1524,6 +1610,9 @@ def validate_cutover_policy(
         "legacy_admission_cutoff_utc",
         "canonical_boundary_height",
         "required_post_cutover_min_height",
+        "legacy_observed_cutoff_height",
+        "legacy_continuity_safety_margin",
+        "legacy_public_max_height",
         "required_recovery_epoch",
         "required_validator_set_id",
         "required_validator_count",
@@ -1589,6 +1678,9 @@ def validate_cutover_policy(
     for field in (
         "canonical_boundary_height",
         "required_post_cutover_min_height",
+        "legacy_observed_cutoff_height",
+        "legacy_continuity_safety_margin",
+        "legacy_public_max_height",
         "required_recovery_epoch",
         "required_validator_set_id",
         "required_validator_count",
@@ -1597,13 +1689,19 @@ def validate_cutover_policy(
     ):
         require_uint(value.get(field), f"cutover policy {field}", positive=True)
     if (
-        value.get("canonical_boundary_height") != CANONICAL_BOUNDARY_HEIGHT
-        or value.get("required_post_cutover_min_height") != REQUIRED_POST_CUTOVER_MIN_HEIGHT
+        value.get("canonical_boundary_height") != checkpoint["source_height"]
+        or value.get("required_post_cutover_min_height") != checkpoint["transition_height"]
+        or value.get("legacy_observed_cutoff_height")
+        != boundary["observed_cutoff_height"]
+        or value.get("legacy_continuity_safety_margin")
+        != boundary["continuity_safety_margin"]
+        or value.get("legacy_public_max_height")
+        != boundary["legacy_public_max_height"]
         or value.get("required_recovery_epoch") != 1
         or value.get("required_validator_set_id") != 1
         or value.get("required_validator_count") != 6
     ):
-        fail("cutover policy height/epoch/validator constants differ")
+        fail("cutover policy checkpoint/cutoff/floor/epoch/validator identity differs")
     if checkpoint["recovery_epoch"] != 1 or checkpoint["validator_set_id"] != 1:
         fail("inspected checkpoint recovery epoch/validator-set id differs from cutover policy")
     comparisons = {
@@ -1696,15 +1794,20 @@ def validate_cutover_policy(
         "legacy_maintenance_boundary_sha256": boundary_sha256,
         "recovery_checkpoint_descriptor_sha256": checkpoint_descriptor_sha256,
         "recovery_checkpoint_file_sha256": checkpoint["checkpoint_file"]["sha256"],
-        "canonical_boundary_height": CANONICAL_BOUNDARY_HEIGHT,
-        "required_post_cutover_min_height": REQUIRED_POST_CUTOVER_MIN_HEIGHT,
+        "canonical_boundary_height": checkpoint["source_height"],
+        "required_post_cutover_min_height": checkpoint["transition_height"],
+        "legacy_observed_cutoff_height": boundary["observed_cutoff_height"],
+        "legacy_continuity_safety_margin": boundary["continuity_safety_margin"],
+        "legacy_public_max_height": boundary["legacy_public_max_height"],
         "required_recovery_epoch": 1,
         "required_validator_set_id": 1,
         "required_validator_count": 6,
         "checkpoint_format_version": 1,
         "chain_id": RECOVERY_CHAIN_ID,
         "payload_hash": checkpoint["payload_hash"],
-        "community_rewards_v1_activation_height": REQUIRED_POST_CUTOVER_MIN_HEIGHT,
+        "community_rewards_v1_activation_height": checkpoint[
+            "community_rewards_v1_activation_height"
+        ],
         "legacy_validators": expected_validators,
         "legacy_worker_rpc": worker_rpc,
         "uncompleted_job_disposition": JOBS_DISPOSITION,
@@ -2133,6 +2236,7 @@ def prepare_intent(
         checkpoint_descriptor,
         release_binding=release_binding,
         boundary=boundary_binding,
+        boundary_nodes=boundary.get("nodes"),
     )
     policy, policy_raw, _policy_record = load_canonical_json(
         request.cutover_policy,
@@ -2563,6 +2667,30 @@ def validate_receipt(value: Mapping[str, Any]) -> None:
     verified_count = checkpoint.get("verified_signature_count")
     signed_stake = require_uint(checkpoint.get("signed_stake"), "receipt signed stake", positive=True)
     total_stake = require_uint(checkpoint.get("total_stake"), "receipt total stake", positive=True)
+    source_height = require_uint(
+        checkpoint.get("source_height"), "receipt checkpoint source height", positive=True
+    )
+    transition_height = require_uint(
+        checkpoint.get("transition_height"),
+        "receipt checkpoint transition height",
+        positive=True,
+    )
+    activation_height = require_uint(
+        checkpoint.get("community_rewards_v1_activation_height"),
+        "receipt checkpoint reward activation height",
+        positive=True,
+    )
+    maintenance_boundary = value.get("maintenance_boundary")
+    if not isinstance(maintenance_boundary, dict):
+        fail("retirement receipt maintenance boundary is malformed")
+    observed_cutoff = require_uint(
+        maintenance_boundary.get("observed_cutoff_height"),
+        "receipt maintenance observed cutoff",
+    )
+    legacy_public_max = require_uint(
+        maintenance_boundary.get("legacy_public_max_height"),
+        "receipt maintenance public maximum",
+    )
     if (
         checkpoint.get("certificate_cryptographically_verified") is not True
         or isinstance(verified_count, bool)
@@ -2575,10 +2703,13 @@ def validate_receipt(value: Mapping[str, Any]) -> None:
         or signed_stake * 3 <= total_stake * 2
         or checkpoint.get("format_version") != 1
         or checkpoint.get("chain_id") != RECOVERY_CHAIN_ID
-        or checkpoint.get("community_rewards_v1_activation_height")
-        != REQUIRED_POST_CUTOVER_MIN_HEIGHT
-        or checkpoint.get("source_height") != CANONICAL_BOUNDARY_HEIGHT
-        or checkpoint.get("transition_height") != REQUIRED_POST_CUTOVER_MIN_HEIGHT
+        or activation_height != COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT
+        or activation_height > transition_height
+        or source_height < TRUSTED_CHECKPOINT_MIN_HEIGHT
+        or source_height > observed_cutoff
+        or transition_height != source_height + 1
+        or legacy_public_max
+        != observed_cutoff + LEGACY_CONTINUITY_SAFETY_MARGIN
         or checkpoint.get("canonical_history_source") != "signed_recovery_checkpoint"
     ):
         fail("retirement receipt checkpoint certificate/quorum binding differs")
@@ -2873,6 +3004,7 @@ def finalize(
         checkpoint_descriptor,
         release_binding=release_binding,
         boundary=boundary_binding,
+        boundary_nodes=boundary.get("nodes"),
     )
     for field, expected in current_checkpoint.items():
         if intent["checkpoint"].get(field) != expected:

--- a/scripts/migration/test_arc_v07_retirement_verifier.py
+++ b/scripts/migration/test_arc_v07_retirement_verifier.py
@@ -105,6 +105,10 @@ class Fixture:
     source_state_root = "5" * 64
     transition_block_hash = "6" * 64
     recovery_domain = "7" * 64
+    source_height = 141_062
+    transition_height = source_height + 1
+    observed_cutoff_height = source_height
+    legacy_public_max_height = observed_cutoff_height + 128
 
     def __init__(self, root: Path, *, mode: str = "term_only") -> None:
         self.root = root
@@ -163,11 +167,27 @@ class Fixture:
                     for name, host in verifier.PRODUCTION_FLEET
                 ],
             },
-            "observed_cutoff_height": 137_017,
+            "observed_cutoff_height": self.observed_cutoff_height,
             "continuity_safety_margin": 128,
-            "legacy_public_max_height": verifier.CANONICAL_BOUNDARY_HEIGHT,
+            "legacy_public_max_height": self.legacy_public_max_height,
             "global_absence_claimed": False,
             "threat_model": {"hostile_root_containment_claimed": False},
+            "nodes": [
+                {
+                    "node": name,
+                    "host": host,
+                    "origin": f"http://{host}:9090",
+                    "final_persisted_head": {
+                        "tuple": {
+                            "height": self.source_height if index == 0 else self.source_height - index,
+                            "block_hash": self.source_block_hash if index == 0 else f"{index + 8:x}" * 64,
+                            "state_root": self.source_state_root if index == 0 else f"{index + 1:x}" * 64,
+                        },
+                        "evidence_sha256": "a" * 64 if index == 0 else f"{index + 1:x}" * 64,
+                    },
+                }
+                for index, (name, host) in enumerate(verifier.PRODUCTION_FLEET)
+            ],
         }
         self.boundary = root / verifier.BOUNDARY_ASSET
         self.boundary_sha = write(self.boundary, canonical(self.boundary_value))
@@ -217,21 +237,19 @@ class Fixture:
             "payload_hash": self.payload_hash,
             "network_genesis_hash": self.network_genesis_hash,
             "full_state_root": self.full_state_root,
-            "source_height": verifier.CANONICAL_BOUNDARY_HEIGHT,
+            "source_height": self.source_height,
             "source_consensus_round": 77,
             "created_at_unix_ms": 1_788_000_000_000,
             "source_block_hash": self.source_block_hash,
             "source_state_root": self.source_state_root,
-            "transition_height": verifier.REQUIRED_POST_CUTOVER_MIN_HEIGHT,
+            "transition_height": self.transition_height,
             "transition_block_hash": self.transition_block_hash,
             "recovery_domain": self.recovery_domain,
             "recovery_epoch": 1,
             "validator_set_id": 1,
             "protocol_version": "3.0.0",
             "validator_count": 6,
-            "community_rewards_v1_activation_height": (
-                verifier.REQUIRED_POST_CUTOVER_MIN_HEIGHT
-            ),
+            "community_rewards_v1_activation_height": 137_146,
         }
         self.descriptor_value = {
             "schema_version": verifier.CHECKPOINT_DESCRIPTOR_SCHEMA,
@@ -248,6 +266,18 @@ class Fixture:
                 "sha256": self.full_checkpoint_sha,
             },
             "canonical_inspection": self.identity,
+            "canonical_source": {
+                "node": "nyc",
+                "source_height": self.source_height,
+                "source_block_hash": self.source_block_hash,
+                "source_state_root": self.source_state_root,
+                "source_consensus_round": self.identity["source_consensus_round"],
+                "snapshot_sha256": "8" * 64,
+                "wal_sha256": "9" * 64,
+                "persisted_head_sha256": "a" * 64,
+                "legacy_dag_round_inspection_sha256": "b" * 64,
+                "legacy_dag_wal_namespace_sha256": "c" * 64,
+            },
             "checkpoint_certificate": {
                 "signing_hash": signing_hash.hex(),
                 "validators": certificate_validators,
@@ -283,8 +313,11 @@ class Fixture:
             "first_quarantine_started_at": self.boundary_value["first_quarantine_started_at"],
             "all_controlled_stopped_at": self.boundary_value["all_controlled_stopped_at"],
             "legacy_admission_cutoff_utc": self.boundary_value["all_controlled_stopped_at"],
-            "canonical_boundary_height": verifier.CANONICAL_BOUNDARY_HEIGHT,
-            "required_post_cutover_min_height": verifier.REQUIRED_POST_CUTOVER_MIN_HEIGHT,
+            "canonical_boundary_height": self.source_height,
+            "required_post_cutover_min_height": self.transition_height,
+            "legacy_observed_cutoff_height": self.observed_cutoff_height,
+            "legacy_continuity_safety_margin": 128,
+            "legacy_public_max_height": self.legacy_public_max_height,
             "required_recovery_epoch": 1,
             "required_validator_set_id": 1,
             "required_validator_count": 6,
@@ -292,9 +325,7 @@ class Fixture:
             "chain_id": verifier.RECOVERY_CHAIN_ID,
             "protocol_version": "3.0.0",
             "payload_hash": self.payload_hash,
-            "community_rewards_v1_activation_height": (
-                verifier.REQUIRED_POST_CUTOVER_MIN_HEIGHT
-            ),
+            "community_rewards_v1_activation_height": 137_146,
             "network_genesis_hash": self.network_genesis_hash,
             "source_block_hash": self.source_block_hash,
             "source_state_root": self.source_state_root,
@@ -511,14 +542,19 @@ class RetirementTests(unittest.TestCase):
                             candidate,
                             release_binding=release_binding,
                             boundary=verifier.validate_boundary(fixture.boundary_value),
+                            boundary_nodes=fixture.boundary_value["nodes"],
                         )
 
     def test_boundary_hashes_and_canonical_public_maximum_are_cross_bound(self) -> None:
         temporary, fixture = self.fixture()
         with temporary:
             boundary = verifier.validate_boundary(fixture.boundary_value)
-            self.assertEqual(boundary["legacy_public_max_height"], 137_145)
-            self.assertEqual(boundary["observed_cutoff_height"], 137_017)
+            self.assertEqual(
+                boundary["legacy_public_max_height"], fixture.legacy_public_max_height
+            )
+            self.assertEqual(
+                boundary["observed_cutoff_height"], fixture.observed_cutoff_height
+            )
             release_binding = {
                 "tag": fixture.tag,
                 "commit": fixture.commit,
@@ -528,6 +564,7 @@ class RetirementTests(unittest.TestCase):
                 fixture.descriptor_value,
                 release_binding=release_binding,
                 boundary=boundary,
+                boundary_nodes=fixture.boundary_value["nodes"],
             )
             for field in ("freeze_plan_sha256", "capture_id"):
                 candidate = copy.deepcopy(fixture.descriptor_value)
@@ -537,6 +574,7 @@ class RetirementTests(unittest.TestCase):
                         candidate,
                         release_binding=release_binding,
                         boundary=boundary,
+                        boundary_nodes=fixture.boundary_value["nodes"],
                     )
 
     def test_forensic_retirement_is_honest_and_does_not_mutate_old_tree(self) -> None:
@@ -649,7 +687,7 @@ class RetirementTests(unittest.TestCase):
                     input_roots[name] = {"sha256": record["sha256"]}
                 result = {
                     "schema": verifier.LEGACY_BLOCK_INSPECTION_SCHEMA,
-                    "height": verifier.CANONICAL_BOUNDARY_HEIGHT,
+                    "height": fixture.source_height,
                     "block_hash": fixture.source_block_hash,
                     "state_root": fixture.source_state_root,
                     "input_roots": input_roots,

--- a/scripts/recovery/README.md
+++ b/scripts/recovery/README.md
@@ -6513,6 +6513,7 @@ public_truth_status_sha="$(arc_sha256 "$public_truth_status")"
   | /usr/bin/cmp -s - "$acceptance_receipt"
 /usr/bin/jq -e --slurpfile receipt "$acceptance_receipt" \
   --slurpfile manifest "$final_manifest" \
+  --slurpfile config "$deployed_config" \
   --arg acceptance_sha "$public_truth_acceptance_sha" \
   --arg source "$protected_main_sha" --arg accepted_config "$frontend_main_sha" '
   .schema == "arc.public-production-status.v1" and .state == "recovered"
@@ -6526,7 +6527,11 @@ public_truth_status_sha="$(arc_sha256 "$public_truth_status")"
   and .checkpoint.legacyPublicMaxHeight == $manifest[0].chain.legacy_public_max_height
   and .checkpoint.recoveryHeight == (.checkpoint.height + 1)
   and (.checkpoint.protocolVersion | test("^3\\.[0-9]+\\.[0-9]+$"))
-  and .fleet.validatorCount == 6 and .fleet.legacyForkCount == 6
+  and .fleet.validatorCount == 6
+  and .fleet.legacyForkCount ==
+    ([$config[0].sources[] | select(.kind == "legacy-fork")] | length)
+  and .fleet.legacyForkNodes ==
+    [$config[0].sources[] | select(.kind == "legacy-fork") | .archive.node]
   and .fleet.requiredHealthyValidators == 6
   and .rewards.canaryReceiptCount == 2
   and .rewards.rewardPerReceiptBase == 2500000000

--- a/scripts/recovery/README.md
+++ b/scripts/recovery/README.md
@@ -2455,18 +2455,30 @@ port, so this is deliberately a sequential handoff rather than two concurrent
 workers. The old root remains on local disk with its key, chain data, model,
 logs, and append-only evidence; only its gracefully stopped launchd
 registration is cleaned. The final root is a new content-addressed direct child
-of `HOME`, so no prior bytes can be mistaken for the release candidate.
+of a dedicated encrypted canary home, so no prior bytes can be mistaken for
+the release candidate.
 
 This is the first of two **native macOS shell** blocks in the production
 procedure; the second is the post-cutover desktop live-product gate. Run this
 block in a separate `/bin/bash` terminal as the logged-in non-root canary user;
 leave the Lima root shell open and untouched. The protected checkout is an
-absolute host path. Both input and evidence transfers remain on the
-FileVault-protected local Mac disk—not a Lima shared mount, cloud-synchronized
-directory, `/tmp`, or removable FAT/exFAT volume. The final acceptance transfer
-uses `$HOME/.arc-recovery-transfer/v0.8.0-<protected-main-sha>`: its private
-parent is mode 0700 and the per-release directory must be new. Changing the
-acceptance copy to mode 0400 must not change the create-only mode-0600 source.
+absolute host path. Both input and evidence transfers remain on a dedicated,
+pre-provisioned encrypted APFS sparsebundle—not a Lima shared mount,
+cloud-synchronized directory, `/tmp`, or removable FAT/exFAT volume. This is
+required even when host FileVault is disabled. The mount is re-proved against
+its exact backing image before every helper action. That live proof establishes
+that encryption is active and the mount/image/device mapping is exact; cipher
+selection is an independently reviewed image-provisioning prerequisite, not a
+property exposed by `hdiutil info`. `HOME`, `TMPDIR`, the selected final model,
+generated key, runtime data, and evidence are scoped into that mount. The old
+canary remains under the real user home and is retired before the encrypted
+helper namespace is activated because both roots share one launchd label but
+not one lock.
+The final acceptance transfer uses
+`$ARC_MACOS_SECURE_HOME/.arc-recovery-transfer/v0.8.0-<protected-main-sha>`:
+its private parent is mode 0700 and the per-release directory must be new.
+Changing the acceptance copy to mode 0400 must not change the create-only
+mode-0600 source.
 
 `ARC_OPERATOR_LIMA_INSTANCE` is the exact reviewed instance name shown by
 `limactl list`; the literal placeholder fails its allowlist and cannot
@@ -2485,11 +2497,17 @@ ARC_MACOS_PROTECTED_MAIN_SHA='<exact 40-character protected-main SHA after merge
 ARC_MACOS_PROTECTED_CHECKOUT='<absolute protected-main checkout on the canary Mac>'
 ARC_OPERATOR_LIMA_INSTANCE='<exact reviewed Lima instance name>'
 ARC_MACOS_OLD_CANARY_SHA='c5ca31acecd0a48dd49c9236040dda442abe29a8'
+ARC_MACOS_USER_HOME="$HOME"
+ARC_MACOS_SECURE_IMAGE='<absolute pre-provisioned encrypted APFS sparsebundle path>'
+ARC_MACOS_SECURE_HOME='<absolute mounted APFS canary home path>'
 [[ "$ARC_MACOS_PROTECTED_MAIN_SHA" =~ ^[0-9a-f]{40}$ ]]
 [[ "$ARC_OPERATOR_LIMA_INSTANCE" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$ ]]
 case "$ARC_MACOS_PROTECTED_CHECKOUT" in /*) ;; *) exit 1 ;; esac
-case "$HOME" in /*) ;; *) exit 1 ;; esac
-test -d "$HOME" && test ! -L "$HOME"
+case "$ARC_MACOS_USER_HOME" in /*) ;; *) exit 1 ;; esac
+case "$ARC_MACOS_SECURE_IMAGE" in /*) ;; *) exit 1 ;; esac
+case "$ARC_MACOS_SECURE_HOME" in /*) ;; *) exit 1 ;; esac
+[[ "$ARC_MACOS_SECURE_HOME" =~ ^/[A-Za-z0-9._/+@:-]+$ ]]
+test -d "$ARC_MACOS_USER_HOME" && test ! -L "$ARC_MACOS_USER_HOME"
 test -d "$ARC_MACOS_PROTECTED_CHECKOUT" \
   && test ! -L "$ARC_MACOS_PROTECTED_CHECKOUT"
 test "$(/usr/bin/git -C "$ARC_MACOS_PROTECTED_CHECKOUT" rev-parse HEAD)" = \
@@ -2503,6 +2521,89 @@ test "$(/usr/bin/git -C "$ARC_MACOS_PROTECTED_CHECKOUT" hash-object \
   "$macos_canary_helper")" = \
   "$(/usr/bin/git -C "$ARC_MACOS_PROTECTED_CHECKOUT" rev-parse \
     "$ARC_MACOS_PROTECTED_MAIN_SHA:scripts/release/macos-community-canary.py")"
+
+arc_require_macos_secure_canary_mount() {
+  /usr/bin/python3 -I - \
+    "$ARC_MACOS_SECURE_IMAGE" \
+    "$ARC_MACOS_SECURE_HOME" \
+    "$ARC_MACOS_USER_HOME" \
+    "$(/usr/bin/id -u)" <<'PY'
+import os
+import pathlib
+import plistlib
+import stat
+import subprocess
+import sys
+
+image_path, mount_path, user_home = map(pathlib.Path, sys.argv[1:4])
+uid = int(sys.argv[4])
+blocked_parts = (
+    "/Library/CloudStorage/",
+    "/Library/Mobile Documents/",
+    "/Dropbox/",
+    "/Google Drive/",
+    "/OneDrive/",
+)
+for path, label in ((image_path, "encrypted image"), (mount_path, "encrypted mount")):
+    raw = str(path)
+    if not path.is_absolute() or any(part in raw for part in blocked_parts):
+        raise SystemExit(f"{label} is not one absolute non-cloud path")
+    metadata = path.lstat()
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != uid
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise SystemExit(f"{label} is not one private operator-owned directory")
+if mount_path.parent != user_home or mount_path.stat().st_dev == user_home.stat().st_dev:
+    raise SystemExit("encrypted canary home is not a separate direct-child filesystem")
+
+hdiutil = plistlib.loads(
+    subprocess.run(
+        ["/usr/bin/hdiutil", "info", "-plist"],
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+)
+images = [row for row in hdiutil.get("images", []) if row.get("image-path") == str(image_path)]
+if len(images) != 1:
+    raise SystemExit("encrypted canary image is not mounted exactly once")
+image = images[0]
+mounts = [
+    row
+    for row in image.get("system-entities", [])
+    if row.get("mount-point") == str(mount_path)
+]
+if (
+    image.get("image-encrypted") is not True
+    or image.get("writeable") is not True
+    or image.get("image-type") != "sparse bundle disk image"
+    or image.get("owner-uid") != uid
+    or len(mounts) != 1
+    or mounts[0].get("content-hint") != "41504653-0000-11AA-AA11-00306543ECAC"
+):
+    raise SystemExit("mounted canary image is not the exact encrypted APFS sparsebundle")
+
+disk = plistlib.loads(
+    subprocess.run(
+        ["/usr/sbin/diskutil", "info", "-plist", str(mount_path)],
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+)
+if (
+    disk.get("FilesystemType") != "apfs"
+    or disk.get("BusProtocol") != "Disk Image"
+    or disk.get("MountPoint") != str(mount_path)
+    or disk.get("DeviceNode") != mounts[0].get("dev-entry")
+    or disk.get("Writable") is not True
+    or disk.get("GlobalPermissionsEnabled") is not True
+):
+    raise SystemExit("APFS volume identity does not match the encrypted image mount")
+PY
+}
+arc_require_macos_secure_canary_mount
 
 ARC_LIMACTL_COMMAND="$(command -v limactl)"
 case "$ARC_LIMACTL_COMMAND" in /*) ;; *) exit 1 ;; esac
@@ -2519,15 +2620,17 @@ test "$("$ARC_LIMACTL" shell "$ARC_OPERATOR_LIMA_INSTANCE" \
 test "$("$ARC_LIMACTL" shell "$ARC_OPERATOR_LIMA_INSTANCE" \
   /usr/bin/uname -m)" = x86_64
 
-ARC_MACOS_FINAL_INPUT_ROOT="$HOME/.arc-pretag-community-canary-input-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"
-ARC_MACOS_OLD_CANARY_ROOT="$HOME/.arc-pretag-community-canary"
-ARC_MACOS_FINAL_CANARY_ROOT="$HOME/.arc-pretag-community-canary-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"
+ARC_MACOS_FINAL_INPUT_ROOT="$ARC_MACOS_SECURE_HOME/.arc-pretag-community-canary-input-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"
+ARC_MACOS_OLD_CANARY_ROOT="$ARC_MACOS_USER_HOME/.arc-pretag-community-canary"
+ARC_MACOS_FINAL_CANARY_ROOT="$ARC_MACOS_SECURE_HOME/.arc-pretag-community-canary-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"
+ARC_MACOS_PRIVATE_TMP="$ARC_MACOS_SECURE_HOME/.arc-pretag-community-canary-tmp-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"
+test "$(/usr/bin/dirname "$ARC_MACOS_OLD_CANARY_ROOT")" = "$ARC_MACOS_USER_HOME"
 for macos_canary_direct_child in \
   "$ARC_MACOS_FINAL_INPUT_ROOT" \
-  "$ARC_MACOS_OLD_CANARY_ROOT" \
-  "$ARC_MACOS_FINAL_CANARY_ROOT"
+  "$ARC_MACOS_FINAL_CANARY_ROOT" \
+  "$ARC_MACOS_PRIVATE_TMP"
 do
-  test "$(/usr/bin/dirname "$macos_canary_direct_child")" = "$HOME"
+  test "$(/usr/bin/dirname "$macos_canary_direct_child")" = "$ARC_MACOS_SECURE_HOME"
 done
 test -d "$ARC_MACOS_OLD_CANARY_ROOT" \
   && test ! -L "$ARC_MACOS_OLD_CANARY_ROOT"
@@ -2535,9 +2638,23 @@ test ! -e "$ARC_MACOS_FINAL_INPUT_ROOT" \
   && test ! -L "$ARC_MACOS_FINAL_INPUT_ROOT"
 test ! -e "$ARC_MACOS_FINAL_CANARY_ROOT" \
   && test ! -L "$ARC_MACOS_FINAL_CANARY_ROOT"
+test ! -e "$ARC_MACOS_PRIVATE_TMP" \
+  && test ! -L "$ARC_MACOS_PRIVATE_TMP"
+arc_require_macos_secure_canary_mount
 /bin/mkdir -m 0700 "$ARC_MACOS_FINAL_INPUT_ROOT"
+/bin/mkdir -m 0700 "$ARC_MACOS_PRIVATE_TMP"
 test "$(/usr/bin/stat -f '%Lp:%l:%u' "$ARC_MACOS_FINAL_INPUT_ROOT")" = \
   "700:1:$(/usr/bin/id -u)"
+test "$(/usr/bin/stat -f '%Lp:%l:%u' "$ARC_MACOS_PRIVATE_TMP")" = \
+  "700:1:$(/usr/bin/id -u)"
+
+arc_macos_secure_canary() {
+  arc_require_macos_secure_canary_mount || return 1
+  HOME="$ARC_MACOS_SECURE_HOME" \
+  TMPDIR="$ARC_MACOS_PRIVATE_TMP" \
+  RUNNER_TEMP="$ARC_MACOS_PRIVATE_TMP" \
+    "$macos_canary_helper" "$@"
+}
 macos_final_handoff_guest="/var/tmp/arc-macos-final-canary-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"
 macos_final_actions_zip="$ARC_MACOS_FINAL_INPUT_ROOT/headless-macos-arm64-actions.zip"
 macos_final_handoff_receipt="$ARC_MACOS_FINAL_INPUT_ROOT/FINAL-CANARY-HANDOFF.json"
@@ -2557,11 +2674,13 @@ do
       "$macos_final_handoff_guest/$macos_final_handoff_name")" = \
     root:root:444:1
 done
+arc_require_macos_secure_canary_mount
 "$ARC_LIMACTL" copy --backend=scp \
   "$ARC_OPERATOR_LIMA_INSTANCE:$macos_final_handoff_guest/headless-macos-arm64-actions.zip" \
   "$ARC_OPERATOR_LIMA_INSTANCE:$macos_final_handoff_guest/FINAL-CANARY-HANDOFF.json" \
   "$ARC_OPERATOR_LIMA_INSTANCE:$macos_final_handoff_guest/SHA256SUMS" \
   "$ARC_MACOS_FINAL_INPUT_ROOT/"
+arc_require_macos_secure_canary_mount
 for macos_final_input in \
   "$macos_final_actions_zip" \
   "$macos_final_handoff_receipt" \
@@ -2787,8 +2906,8 @@ else
   old_canary_status_rc=$?
 fi
 test "$old_canary_status_rc" -eq 3
-test ! -e "$HOME/Library/LaunchAgents/network.arc.pretag-community-canary.plist" \
-  && test ! -L "$HOME/Library/LaunchAgents/network.arc.pretag-community-canary.plist"
+test ! -e "$ARC_MACOS_USER_HOME/Library/LaunchAgents/network.arc.pretag-community-canary.plist" \
+  && test ! -L "$ARC_MACOS_USER_HOME/Library/LaunchAgents/network.arc.pretag-community-canary.plist"
 old_canary_ps_rows=''
 old_canary_ps_rc=0
 if old_canary_ps_rows="$(/bin/ps -p "$old_canary_pid" -o pid= 2>&1)"; then
@@ -2819,6 +2938,26 @@ test "$(/usr/bin/stat -f '%d:%i:%z:%m:%c:%Lp:%l:%u' \
 test "$(/usr/bin/stat -f '%d:%i:%z:%m:%c:%Lp:%l:%u' \
   "$macos_old_model")" = "$old_canary_model_identity"
 
+# Stage the canonical public model into the encrypted image only after the
+# historical helper namespace is fully retired. Plan reads this exact file.
+# After plan it is atomically moved into the final managed model path, so the
+# 4 GB model occupies the encrypted sparsebundle only once; install's
+# create-only resume path revalidates the already-present exact destination.
+macos_final_model="$ARC_MACOS_FINAL_INPUT_ROOT/llama-2-7b-chat.Q4_K_M.gguf"
+test ! -e "$macos_final_model" && test ! -L "$macos_final_model"
+arc_require_macos_secure_canary_mount
+/bin/cp -p "$macos_old_model" "$macos_final_model"
+/bin/chmod 0400 "$macos_final_model"
+/bin/sync
+test "$(/usr/bin/stat -f '%Lp:%l:%u:%z:%d' "$macos_final_model")" = \
+  "400:1:$(/usr/bin/id -u):4081004224:$(/usr/bin/stat -f '%d' "$ARC_MACOS_SECURE_HOME")"
+test "$(/usr/bin/shasum -a 256 "$macos_final_model" \
+  | /usr/bin/cut -d ' ' -f 1)" = \
+  08a5566d61d7cb6b420c3e4387a39e0078e1f2fe5f055f3a03887385304d4bfa
+test "$(/usr/bin/stat -f '%d:%i:%z:%m:%c:%Lp:%l:%u' \
+  "$macos_old_model")" = "$old_canary_model_identity"
+arc_require_macos_secure_canary_mount
+
 ARC_MACOS_CANARY_CURL=/usr/bin/curl
 ARC_MACOS_CANARY_CA_BUNDLE=/private/etc/ssl/cert.pem
 test -x "$ARC_MACOS_CANARY_CURL" && test ! -L "$ARC_MACOS_CANARY_CURL"
@@ -2830,10 +2969,10 @@ ARC_MACOS_CANARY_CA_BUNDLE_SHA256="$(/usr/bin/shasum -a 256 \
   "$ARC_MACOS_CANARY_CA_BUNDLE" | /usr/bin/cut -d ' ' -f 1)"
 [[ "$ARC_MACOS_CANARY_CURL_SHA256" =~ ^[0-9a-f]{64}$ ]]
 [[ "$ARC_MACOS_CANARY_CA_BUNDLE_SHA256" =~ ^[0-9a-f]{64}$ ]]
-"$macos_canary_helper" plan \
+arc_macos_secure_canary plan \
   --root "$ARC_MACOS_FINAL_CANARY_ROOT" \
   --raw-actions-zip "$macos_final_actions_zip" \
-  --model "$macos_old_model" \
+  --model "$macos_final_model" \
   --expected-commit "$ARC_MACOS_PROTECTED_MAIN_SHA" \
   --expected-run-id "$ARC_MACOS_FINAL_RUN_ID" \
   --expected-run-attempt "$ARC_MACOS_FINAL_RUN_ATTEMPT" \
@@ -2844,10 +2983,24 @@ ARC_MACOS_CANARY_CA_BUNDLE_SHA256="$(/usr/bin/shasum -a 256 \
   --ca-bundle-sha256 "$ARC_MACOS_CANARY_CA_BUNDLE_SHA256"
 test ! -e "$ARC_MACOS_FINAL_CANARY_ROOT" \
   && test ! -L "$ARC_MACOS_FINAL_CANARY_ROOT"
-"$macos_canary_helper" install \
+macos_final_model_destination="$ARC_MACOS_FINAL_CANARY_ROOT/model/llama-2-7b-chat.Q4_K_M.gguf"
+arc_require_macos_secure_canary_mount
+/bin/mkdir -m 0700 "$ARC_MACOS_FINAL_CANARY_ROOT"
+/bin/mkdir -m 0700 "$ARC_MACOS_FINAL_CANARY_ROOT/model"
+/bin/mv "$macos_final_model" "$macos_final_model_destination"
+/bin/sync
+test ! -e "$macos_final_model" && test ! -L "$macos_final_model"
+macos_final_model="$macos_final_model_destination"
+test "$(/usr/bin/stat -f '%Lp:%l:%u:%z:%d' "$macos_final_model")" = \
+  "400:1:$(/usr/bin/id -u):4081004224:$(/usr/bin/stat -f '%d' "$ARC_MACOS_SECURE_HOME")"
+test "$(/usr/bin/shasum -a 256 "$macos_final_model" \
+  | /usr/bin/cut -d ' ' -f 1)" = \
+  08a5566d61d7cb6b420c3e4387a39e0078e1f2fe5f055f3a03887385304d4bfa
+arc_require_macos_secure_canary_mount
+arc_macos_secure_canary install \
   --root "$ARC_MACOS_FINAL_CANARY_ROOT" \
   --raw-actions-zip "$macos_final_actions_zip" \
-  --model "$macos_old_model" \
+  --model "$macos_final_model" \
   --expected-commit "$ARC_MACOS_PROTECTED_MAIN_SHA" \
   --expected-run-id "$ARC_MACOS_FINAL_RUN_ID" \
   --expected-run-attempt "$ARC_MACOS_FINAL_RUN_ATTEMPT" \
@@ -2856,9 +3009,9 @@ test ! -e "$ARC_MACOS_FINAL_CANARY_ROOT" \
   --curl-sha256 "$ARC_MACOS_CANARY_CURL_SHA256" \
   --ca-bundle "$ARC_MACOS_CANARY_CA_BUNDLE" \
   --ca-bundle-sha256 "$ARC_MACOS_CANARY_CA_BUNDLE_SHA256"
-"$macos_canary_helper" start --root "$ARC_MACOS_FINAL_CANARY_ROOT"
-"$macos_canary_helper" status --root "$ARC_MACOS_FINAL_CANARY_ROOT"
-"$macos_canary_helper" accept --root "$ARC_MACOS_FINAL_CANARY_ROOT"
+arc_macos_secure_canary start --root "$ARC_MACOS_FINAL_CANARY_ROOT"
+arc_macos_secure_canary status --root "$ARC_MACOS_FINAL_CANARY_ROOT"
+arc_macos_secure_canary accept --root "$ARC_MACOS_FINAL_CANARY_ROOT"
 macos_canary_acceptance_source="$ARC_MACOS_FINAL_CANARY_ROOT/evidence/ACCEPTED.json"
 /usr/bin/python3 -I - \
   "$ARC_MACOS_FINAL_CANARY_ROOT/config/canary.json" \
@@ -2905,7 +3058,8 @@ if (
     raise SystemExit("final macOS acceptance does not bind the exact root/artifact tuple")
 PY
 
-ARC_CANARY_TRANSFER_PARENT="$HOME/.arc-recovery-transfer"
+arc_require_macos_secure_canary_mount
+ARC_CANARY_TRANSFER_PARENT="$ARC_MACOS_SECURE_HOME/.arc-recovery-transfer"
 if [ ! -e "$ARC_CANARY_TRANSFER_PARENT" ]; then
   /bin/mkdir -m 0700 "$ARC_CANARY_TRANSFER_PARENT"
 fi
@@ -2914,7 +3068,7 @@ test -d "$ARC_CANARY_TRANSFER_PARENT" \
 test "$(/usr/bin/stat -f '%Lp:%l:%u' "$ARC_CANARY_TRANSFER_PARENT")" = \
   "700:1:$(/usr/bin/id -u)"
 ARC_CANARY_TRANSFER_ROOT="$ARC_CANARY_TRANSFER_PARENT/v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"
-case "$ARC_CANARY_TRANSFER_ROOT" in "$HOME"/*) ;; *) exit 1 ;; esac
+case "$ARC_CANARY_TRANSFER_ROOT" in "$ARC_MACOS_SECURE_HOME"/*) ;; *) exit 1 ;; esac
 macos_canary_acceptance_transfer_root="$ARC_CANARY_TRANSFER_ROOT"
 macos_canary_acceptance_transfer="$macos_canary_acceptance_transfer_root/MACOS-CANARY-ACCEPTANCE.json"
 test -f "$macos_canary_acceptance_source" && test ! -L "$macos_canary_acceptance_source"
@@ -2953,6 +3107,7 @@ lima_canary_drop_root=/var/tmp/arc-macos-canary-import-v0.8.0
   /usr/bin/test '!' -e "$lima_canary_drop_root"
 "$ARC_LIMACTL" shell "$ARC_OPERATOR_LIMA_INSTANCE" \
   /usr/bin/install -d -m 0700 "$lima_canary_drop_root"
+arc_require_macos_secure_canary_mount
 "$ARC_LIMACTL" copy --backend=scp \
   "$macos_canary_acceptance_transfer" \
   "$macos_canary_acceptance_transfer.sha256" \

--- a/scripts/recovery/README.md
+++ b/scripts/recovery/README.md
@@ -1556,58 +1556,150 @@ test "$("$caddy_binary" version | /usr/bin/awk '{print $1}')" = v2.11.4
 ```
 
 
-The sealed prearchive production manifest carries the independently preserved
-block-height-137145 source snapshot and its paired reference WAL as
-SHA-256-bound artifacts. Source consensus round `9774808` is distinct recovery
-checkpoint metadata; it is not the block height. Before export, prove the exact
-root-owned pair, its two metadata records, and the complete four-row
-`SHA256SUMS` mapping. Then build the unsigned candidate with the exact recovery
-exporter; successful export decodes the snapshot, recomputes its
-account/storage/code root, and requires it to equal the complete WAL
-block/checkpoint boundary:
+The sealed prearchive production manifest carries the capture-derived
+canonical source snapshot and its paired WAL as SHA-256-bound artifacts. The
+trusted block at height 137145 is only the minimum ancestry anchor. The
+canonical checkpoint height `H` is the highest strictly replayed captured
+descendant of that anchor; `T=H+1`. A taller conflicting fork can make the
+observed cutoff `C` greater than `H`, and public reopening is held until
+`F=C+128`. The final durable consensus round is derived from the selected
+node's stopped DAG-WAL proof; it is never copied from a moving `/stats` value.
+
+Seal that decision before downloading, exporting, approving, or signing a
+checkpoint. `select-source` revalidates the complete six-node evidence bundle,
+every embedded anchor inspection and DAG-WAL inspection, the generation ledger,
+and the standalone maintenance boundary. It emits a create-only mode-0400
+receipt plus sidecar. A retry may reuse only the exact sealed receipt.
 
 ```bash
-reference_pair=/secure/operator/reference-pair
-reference_source_consensus_round=9774808
-reference_block_height=137145
+canonical_source_preselection=/secure/operator/canonical-source-preselection.json
+test ! -e "$canonical_source_preselection" \
+  && test ! -L "$canonical_source_preselection"
+"$ARC_RECOVERY_PYTHON_PATH" -I \
+  scripts/recovery/build-production-manifest.py select-source \
+  --source-main-sha "$protected_main_sha" \
+  --freeze-plan /secure/operator/arc-freeze.lock.json \
+  --freeze-plan-sha256 "$freeze_sha256" \
+  --legacy-public-height-receipt "$legacy_public_height_receipt" \
+  --legacy-maintenance-evidence-bundle "$legacy_maintenance_evidence_bundle" \
+  --legacy-maintenance-boundary "$legacy_maintenance_boundary" \
+  --binary "$arc_node_linux" \
+  --genesis "$operator_genesis" \
+  --validator-public-keys "$validator_public_keys" \
+  --legacy-validator-set "$legacy_validator_set" \
+  --output "$canonical_source_preselection"
+
+test -f "$canonical_source_preselection" \
+  && test ! -L "$canonical_source_preselection"
+test -f "$canonical_source_preselection.sha256" \
+  && test ! -L "$canonical_source_preselection.sha256"
+test "$(/usr/bin/stat --format='%U:%G:%a:%h' \
+  "$canonical_source_preselection")" = root:root:400:1
+test "$(/usr/bin/stat --format='%U:%G:%a:%h' \
+  "$canonical_source_preselection.sha256")" = root:root:400:1
+printf '%s  %s\n' "$(arc_sha256 "$canonical_source_preselection")" \
+  "${canonical_source_preselection##*/}" \
+  | /usr/bin/cmp --silent - "$canonical_source_preselection.sha256"
+trusted_anchor_block_hash=8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90
+trusted_anchor_state_root=d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d
+test "$(/usr/bin/jq -er '.canonical_source_selection.value.trusted_anchor.block_hash' \
+  "$canonical_source_preselection")" = "$trusted_anchor_block_hash"
+test "$(/usr/bin/jq -er '.canonical_source_selection.value.trusted_anchor.state_root' \
+  "$canonical_source_preselection")" = "$trusted_anchor_state_root"
+
+reference_source_node="$(/usr/bin/jq -er '.selected_source_pair.node' \
+  "$canonical_source_preselection")"
+reference_source_consensus_round="$(/usr/bin/jq -er \
+  '.source_consensus_round | select(type == "number" and . > 0)' \
+  "$canonical_source_preselection")"
+reference_block_height="$(/usr/bin/jq -er \
+  '.source_height | select(type == "number" and . >= 137145)' \
+  "$canonical_source_preselection")"
+transition_height="$(/usr/bin/jq -er '.transition_height' \
+  "$canonical_source_preselection")"
+source_block_hash="$(/usr/bin/jq -er '.source_block_hash' \
+  "$canonical_source_preselection")"
+source_state_root="$(/usr/bin/jq -er '.source_state_root' \
+  "$canonical_source_preselection")"
+observed_cutoff_height="$(/usr/bin/jq -er '.observed_cutoff_height' \
+  "$canonical_source_preselection")"
+reopening_floor_height="$(/usr/bin/jq -er '.reopening_floor_height' \
+  "$canonical_source_preselection")"
+test "$transition_height" -eq "$((reference_block_height + 1))"
+test "$reference_block_height" -le "$observed_cutoff_height"
+test "$reopening_floor_height" -eq "$((observed_cutoff_height + 128))"
+[[ "$source_block_hash" =~ ^[0-9a-f]{64}$ ]]
+[[ "$source_state_root" =~ ^[0-9a-f]{64}$ ]]
+
+reference_source_host=''
+case "$reference_source_node" in
+  nyc) reference_source_host=149.28.32.76 ;;
+  lax) reference_source_host=140.82.16.112 ;;
+  ams) reference_source_host=136.244.109.1 ;;
+  lhr) reference_source_host=104.238.171.11 ;;
+  nrt) reference_source_host=202.182.107.41 ;;
+  sgp) reference_source_host=149.28.153.31 ;;
+  *) printf 'unsupported selected source node: %s\n' "$reference_source_node" >&2; exit 1 ;;
+esac
+reference_remote_wal_path="$(
+  /usr/bin/jq -er --arg node "$reference_source_node" '
+    .nodes[] | select(.node == $node) | .persisted_head.value |
+    if (.schema == "arc.recovery.persisted-legacy-head.v3"
+        or .schema == "arc.recovery.persisted-legacy-head.v4")
+    then .state_wal_path else .source_inputs.fixed_state_wal.path end' \
+    "$legacy_maintenance_evidence_bundle"
+)"
+reference_remote_snapshot_path="$(
+  /usr/bin/jq -er --arg node "$reference_source_node" '
+    .nodes[] | select(.node == $node) | .persisted_head.value |
+    if (.schema == "arc.recovery.persisted-legacy-head.v3"
+        or .schema == "arc.recovery.persisted-legacy-head.v4")
+    then .snapshot_path else .source_inputs.fixed_snapshot.path end' \
+    "$legacy_maintenance_evidence_bundle"
+)"
+for reference_remote_path in \
+  "$reference_remote_wal_path" "$reference_remote_snapshot_path"
+do
+  [[ "$reference_remote_path" =~ ^/[A-Za-z0-9._/-]+$ ]]
+  [[ "$reference_remote_path" != *'/../'* ]]
+done
+
+reference_wal_sha256="$(/usr/bin/jq -er \
+  '.selected_source_pair.state_wal.sha256' "$canonical_source_preselection")"
+reference_wal_size="$(/usr/bin/jq -er \
+  '.selected_source_pair.state_wal.size' "$canonical_source_preselection")"
+reference_snapshot_sha256="$(/usr/bin/jq -er \
+  '.selected_source_pair.snapshot.sha256' "$canonical_source_preselection")"
+reference_snapshot_size="$(/usr/bin/jq -er \
+  '.selected_source_pair.snapshot.size' "$canonical_source_preselection")"
+reference_pair="$(/usr/bin/mktemp -d \
+  /secure/operator/canonical-source-pair.XXXXXXXX)"
+scp_tool=/secure/operator/tools/scp
+printf '%s  %s\n' "$ARC_RESTORE_SCP_SHA256" "$scp_tool" \
+  | /usr/bin/sha256sum --check --strict
+"$scp_tool" -q -B -i "$ssh_identity" \
+  -o UserKnownHostsFile="$known_hosts" -o StrictHostKeyChecking=yes \
+  -- "root@${reference_source_host}:${reference_remote_wal_path}" \
+  "$reference_pair/state.wal"
+"$scp_tool" -q -B -i "$ssh_identity" \
+  -o UserKnownHostsFile="$known_hosts" -o StrictHostKeyChecking=yes \
+  -- "root@${reference_source_host}:${reference_remote_snapshot_path}" \
+  "$reference_pair/state.snapshot.lz4"
+chmod 0400 "$reference_pair/state.wal" "$reference_pair/state.snapshot.lz4"
 "$ARC_RECOVERY_PYTHON_PATH" -I - \
-  "$reference_pair" "$reference_block_height" <<'PY'
+  "$reference_pair" "$reference_wal_size" "$reference_wal_sha256" \
+  "$reference_snapshot_size" "$reference_snapshot_sha256" <<'PY'
 import hashlib
-import json
 import os
 import pathlib
-import re
 import stat
 import sys
 
 root = pathlib.Path(sys.argv[1])
-expected_height = int(sys.argv[2])
 expected_files = {
-    "state.snapshot.lz4": (
-        1_160_246,
-        "ecb4e39d45e6711cffcd78183851587e4deb37ad63163f541ef6c1f821a4ce47",
-    ),
-    "state.wal": (
-        83_385_625,
-        "3820e112af1684567f0336abe73ae9aafc4228d0e02a5fccb1ff32f64dfed44c",
-    ),
-    "latest.json": (
-        687,
-        "0c9bcafd99375de7e3167c271350279c4d267dd9cf91de37aa830a2b817f80af",
-    ),
-    "snapshot-info.json": (
-        138,
-        "98f327fb9c4405cd0f6e7c31052d571a024738df5bf6987ad78d9b1ba5856b49",
-    ),
+    "state.wal": (int(sys.argv[2]), sys.argv[3]),
+    "state.snapshot.lz4": (int(sys.argv[4]), sys.argv[5]),
 }
-
-def reject_duplicates(pairs):
-    value = {}
-    for key, child in pairs:
-        if key in value:
-            raise SystemExit(f"reference metadata duplicates key {key!r}")
-        value[key] = child
-    return value
 
 def identity(value):
     return (
@@ -1662,47 +1754,10 @@ try:
         or stat.S_IMODE(root_metadata.st_mode) & 0o022
     ):
         raise SystemExit("reference-pair directory is not protected root storage")
-    payloads = {
-        name: read_locked(root_fd, name, size, digest)
-        for name, (size, digest) in expected_files.items()
-    }
-    sums = read_locked(root_fd, "SHA256SUMS", 324)
+    for name, (size, digest) in expected_files.items():
+        read_locked(root_fd, name, size, digest)
 finally:
     os.close(root_fd)
-
-if not sums.endswith(b"\n") or b"\r" in sums:
-    raise SystemExit("reference-pair SHA256SUMS is not canonical LF text")
-rows = {}
-for line in sums.decode("ascii").splitlines():
-    match = re.fullmatch(r"([0-9a-f]{64})  ([A-Za-z0-9._-]+)", line)
-    if match is None or match.group(2) in rows:
-        raise SystemExit("reference-pair SHA256SUMS has malformed or duplicate rows")
-    rows[match.group(2)] = match.group(1)
-if rows != {name: digest for name, (_size, digest) in expected_files.items()}:
-    raise SystemExit("reference-pair SHA256SUMS differs from the reviewed four-file map")
-
-latest = json.loads(payloads["latest.json"], object_pairs_hook=reject_duplicates)
-snapshot = json.loads(
-    payloads["snapshot-info.json"], object_pairs_hook=reject_duplicates
-)
-header = latest.get("header") if isinstance(latest, dict) else None
-expected_state_root = "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d"
-if (
-    set(latest) != {"header", "tx_hashes", "hash"}
-    or not isinstance(header, dict)
-    or header.get("height") != expected_height
-    or header.get("state_root") != expected_state_root
-    or latest.get("hash")
-    != "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90"
-):
-    raise SystemExit("reference latest metadata differs at the recovery boundary")
-if snapshot != {
-    "account_count": 78_025,
-    "available": True,
-    "height": expected_height,
-    "state_root": "0x" + expected_state_root,
-}:
-    raise SystemExit("reference snapshot metadata differs at the recovery boundary")
 PY
 
 candidate_checkpoint=/secure/operator/candidate.arcchkpt
@@ -1768,9 +1823,10 @@ use. This emergency cutover instead records one explicit
 owner's GitHub actor and triggering-actor identities. The no-secret, read-only
 `owner-emergency-recovery-approval.yml` workflow must be manually dispatched by
 `FerrumVir` on the exact protected `main` commit with the checkpoint manifest
-hash, public-key manifest hash, and all six public keys. The workflow accepts
-only the exact reviewed confirmation and emits a short-lived
-`arc.recovery.owner-emergency-recovery.v2` artifact; matching text created
+hash, the sealed H/T/source tuple/final round/C/F/boundary root, public-key
+manifest hash, and all six public keys. The workflow accepts only the exact
+reviewed confirmation and emits a short-lived
+`arc.recovery.owner-emergency-recovery.v3` artifact; matching text created
 locally is not authorization.
 
 The operator snapshots the matching run set before dispatch, selects exactly
@@ -1778,10 +1834,11 @@ one new workflow/path/event/branch/SHA/owner run and attempt, waits for that
 attempt, and downloads the workflow, run, exact-attempt jobs, artifact metadata,
 and digest-bound ZIP into a new root-owned mode-0700 attempt directory. Every
 input file becomes root-owned mode 0400. The protected-main helper then verifies
-those API facts and the one-member ZIP, binds H=137145/H+1=137146, recovery
-epoch/set 1/1, all six ordered validator address/public-key/stake identities,
-the exact five signers, the unused recovery member, and the strict-stake
-threshold, checks a maximum age of 900 seconds, and creates the canonical
+those API facts and the one-member ZIP, binds the preselected
+`H/T=H+1/hash/state/final-round/C/F/boundary/checkpoint` tuple, recovery
+epoch/set 1/1, all six ordered validator address/public-key/stake identities, the exact
+five signers, the unused recovery member, and the strict-stake threshold,
+checks a maximum age of 900 seconds, and creates the canonical
 mode-0400 receipt plus sidecar. It receives no GitHub token. The wrapper permits
 only root/mode/link checks and explicit receipt/sidecar/directory durability
 syncs after `verify-github-artifact`; the wrapper call is immediately followed
@@ -1912,7 +1969,7 @@ owner_recovery_run_candidates() {
     'repos/FerrumVir/arc-chain/actions/workflows/owner-emergency-recovery-approval.yml/runs?event=workflow_dispatch&branch=main&per_page=100' \
     --jq '.workflow_runs[]' \
     | /usr/bin/jq -cs --arg sha "$protected_main_sha" \
-        --arg title "Owner recovery approval for $protected_main_sha at $checkpoint_manifest_hash" \
+        --arg title "Owner recovery approval for $protected_main_sha H=$reference_block_height at $checkpoint_manifest_hash" \
         --argjson workflow_id "$owner_recovery_workflow_id" '
         [.[] | select(.workflow_id == $workflow_id and .head_sha == $sha
           and .head_branch == "main"
@@ -1930,6 +1987,14 @@ arc_scoped_gh "$owner_recovery_gh_token" workflow run \
   --repo FerrumVir/arc-chain --ref main \
   -f expected_main_sha="$protected_main_sha" \
   -f checkpoint_manifest_hash="$checkpoint_manifest_hash" \
+  -f source_height="$reference_block_height" \
+  -f transition_height="$transition_height" \
+  -f source_block_hash="$source_block_hash" \
+  -f source_state_root="$source_state_root" \
+  -f source_consensus_round="$reference_source_consensus_round" \
+  -f observed_cutoff_height="$observed_cutoff_height" \
+  -f reopening_floor_height="$reopening_floor_height" \
+  -f legacy_maintenance_boundary_sha256="$legacy_maintenance_boundary_sha256" \
   -f validator_public_keys_sha256="$validator_public_keys_sha256" \
   -f nyc_public_key="$owner_recovery_nyc_public_key" \
   -f lax_public_key="$owner_recovery_lax_public_key" \
@@ -1937,7 +2002,7 @@ arc_scoped_gh "$owner_recovery_gh_token" workflow run \
   -f lhr_public_key="$owner_recovery_lhr_public_key" \
   -f nrt_public_key="$owner_recovery_nrt_public_key" \
   -f sgp_public_key="$owner_recovery_sgp_public_key" \
-  -f confirmation="AUTHORIZE ARC OWNER EMERGENCY RECOVERY $protected_main_sha"
+  -f confirmation="AUTHORIZE ARC OWNER EMERGENCY RECOVERY $protected_main_sha H=$reference_block_height T=$transition_height HASH=$source_block_hash STATE=$source_state_root ROUND=$reference_source_consensus_round C=$observed_cutoff_height F=$reopening_floor_height BOUNDARY=$legacy_maintenance_boundary_sha256 CHECKPOINT=$checkpoint_manifest_hash"
 owner_recovery_new_runs='[]'
 for _ in {1..30}; do
   /usr/bin/sleep 2
@@ -2046,6 +2111,14 @@ verify_owner_recovery_authorization() {
     --artifact-digest "$owner_recovery_artifact_digest" \
     --source-main-sha "$protected_main_sha" \
     --checkpoint-manifest-hash "$checkpoint_manifest_hash" \
+    --source-height "$reference_block_height" \
+    --transition-height "$transition_height" \
+    --source-block-hash "$source_block_hash" \
+    --source-state-root "$source_state_root" \
+    --source-consensus-round "$reference_source_consensus_round" \
+    --observed-cutoff-height "$observed_cutoff_height" \
+    --reopening-floor-height "$reopening_floor_height" \
+    --legacy-maintenance-boundary-sha256 "$legacy_maintenance_boundary_sha256" \
     --validator-public-keys "$validator_public_keys" \
     --validator-public-keys-sha256 "$validator_public_keys_sha256" \
     --output "$owner_recovery_receipt" \
@@ -3134,6 +3207,7 @@ if [ "$prearchive_existing" = 0 ]; then
       --freeze-plan-sha256 "$freeze_sha256" \
       --legacy-public-height-receipt "$legacy_public_height_receipt" \
       --legacy-maintenance-evidence-bundle "$legacy_maintenance_evidence_bundle" \
+      --canonical-source-preselection "$canonical_source_preselection" \
       --legacy-maintenance-boundary "$legacy_maintenance_boundary" \
       --legacy-late-fork-source-set "$offline_stop_output.legacy-late-fork-source-set.json" \
       --offline-stop-evidence "$offline_stop_evidence" \
@@ -6438,6 +6512,7 @@ public_truth_status_sha="$(arc_sha256 "$public_truth_status")"
 /usr/bin/jq -cS . "$acceptance_receipt" \
   | /usr/bin/cmp -s - "$acceptance_receipt"
 /usr/bin/jq -e --slurpfile receipt "$acceptance_receipt" \
+  --slurpfile manifest "$final_manifest" \
   --arg acceptance_sha "$public_truth_acceptance_sha" \
   --arg source "$protected_main_sha" --arg accepted_config "$frontend_main_sha" '
   .schema == "arc.public-production-status.v1" and .state == "recovered"
@@ -6446,7 +6521,10 @@ public_truth_status_sha="$(arc_sha256 "$public_truth_status")"
   and .release.sourceCommit == $source and .release.tag == "v0.8.0"
   and .release.immutable == true
   and .pages.acceptedConfigCommit == $accepted_config
-  and .checkpoint.height == 137145 and .checkpoint.recoveryHeight == 137146
+  and .checkpoint.height == $manifest[0].chain.source_height
+  and .checkpoint.recoveryHeight == $manifest[0].chain.transition_height
+  and .checkpoint.legacyPublicMaxHeight == $manifest[0].chain.legacy_public_max_height
+  and .checkpoint.recoveryHeight == (.checkpoint.height + 1)
   and (.checkpoint.protocolVersion | test("^3\\.[0-9]+\\.[0-9]+$"))
   and .fleet.validatorCount == 6 and .fleet.legacyForkCount == 6
   and .fleet.requiredHealthyValidators == 6

--- a/scripts/recovery/archive-fleet-to-drive.sh
+++ b/scripts/recovery/archive-fleet-to-drive.sh
@@ -12340,6 +12340,8 @@ seal_phase() {
     maintenance_evidence_bundle_sha="$(manifest_field "$manifest" artifacts.legacy_maintenance_evidence_bundle.sha256)"
     maintenance_evidence_bundle_sidecar="$(manifest_field "$manifest" artifacts.legacy_maintenance_evidence_bundle_sidecar.path)"
     maintenance_evidence_bundle_sidecar_sha="$(manifest_field "$manifest" artifacts.legacy_maintenance_evidence_bundle_sidecar.sha256)"
+    local canonical_source_preselection canonical_source_preselection_sha
+    local canonical_source_preselection_sidecar canonical_source_preselection_sidecar_sha
     canonical_source_preselection="$(manifest_field "$manifest" artifacts.canonical_source_preselection.path)"
     canonical_source_preselection_sha="$(manifest_field "$manifest" artifacts.canonical_source_preselection.sha256)"
     canonical_source_preselection_sidecar="$(manifest_field "$manifest" artifacts.canonical_source_preselection_sidecar.path)"

--- a/scripts/recovery/archive-fleet-to-drive.sh
+++ b/scripts/recovery/archive-fleet-to-drive.sh
@@ -12340,6 +12340,10 @@ seal_phase() {
     maintenance_evidence_bundle_sha="$(manifest_field "$manifest" artifacts.legacy_maintenance_evidence_bundle.sha256)"
     maintenance_evidence_bundle_sidecar="$(manifest_field "$manifest" artifacts.legacy_maintenance_evidence_bundle_sidecar.path)"
     maintenance_evidence_bundle_sidecar_sha="$(manifest_field "$manifest" artifacts.legacy_maintenance_evidence_bundle_sidecar.sha256)"
+    canonical_source_preselection="$(manifest_field "$manifest" artifacts.canonical_source_preselection.path)"
+    canonical_source_preselection_sha="$(manifest_field "$manifest" artifacts.canonical_source_preselection.sha256)"
+    canonical_source_preselection_sidecar="$(manifest_field "$manifest" artifacts.canonical_source_preselection_sidecar.path)"
+    canonical_source_preselection_sidecar_sha="$(manifest_field "$manifest" artifacts.canonical_source_preselection_sidecar.sha256)"
     maintenance_boundary="$(manifest_field "$manifest" artifacts.legacy_maintenance_boundary.path)"
     maintenance_boundary_sha="$(manifest_field "$manifest" artifacts.legacy_maintenance_boundary.sha256)"
     maintenance_boundary_sidecar="$(manifest_field "$manifest" artifacts.legacy_maintenance_boundary_sidecar.path)"
@@ -12627,6 +12631,11 @@ PY
     register_shared_input "$maintenance_evidence_bundle_sidecar" \
         "$maintenance_evidence_bundle_sidecar_sha" \
         "$shared_root" legacy-maintenance-evidence-bundle.json.sha256
+    register_shared_input "$canonical_source_preselection" "$canonical_source_preselection_sha" \
+        "$shared_root" canonical-source-preselection.json
+    register_shared_input "$canonical_source_preselection_sidecar" \
+        "$canonical_source_preselection_sidecar_sha" "$shared_root" \
+        canonical-source-preselection.json.sha256
     register_shared_input "$maintenance_boundary" "$maintenance_boundary_sha" \
         "$shared_root" legacy-maintenance-boundary.json
     register_shared_input "$maintenance_boundary_sidecar" "$maintenance_boundary_sidecar_sha" \

--- a/scripts/recovery/archive-fleet-to-drive.sh
+++ b/scripts/recovery/archive-fleet-to-drive.sh
@@ -6124,6 +6124,61 @@ inventory=[]
 def sealed(value,raw,node,role):
     root=digest(raw);inventory.append({"node":node,"role":role,"sha256":root,"size":len(raw)})
     return {"value":value,"sha256":root}
+def validate_dag_and_anchor(persisted,node):
+    dag=persisted.get("legacy_dag_round")
+    try:rounds.validate_legacy_dag_round(dag,f"maintenance evidence bundle {node}")
+    except rounds.QuarantineRoundError as error:
+        raise SystemExit(
+            f"maintenance evidence bundle persisted DAG round differs: {node}: {error}"
+        ) from error
+    head=persisted.get("head",{});anchor=persisted.get("trusted_anchor_ancestry")
+    inspection=anchor.get("inspection") if isinstance(anchor,dict) else None
+    if (not isinstance(head,dict) or isinstance(head.get("height"),bool)
+            or not isinstance(head.get("height"),int) or head["height"]<1
+            or not isinstance(anchor,dict) or set(anchor)!={"anchor_height",
+                "anchor_block_hash","anchor_state_root","classification","inspection",
+                "inspection_sha256"}
+            or anchor.get("anchor_height")!=137145
+            or anchor.get("anchor_block_hash")
+                !="8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90"
+            or anchor.get("anchor_state_root")
+                !="d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d"
+            or anchor.get("inspection_sha256")!=digest(canonical(inspection))):
+        raise SystemExit(f"maintenance evidence bundle trusted anchor differs: {node}")
+    if head["height"]<anchor["anchor_height"]:
+        if anchor.get("classification")!="below_trusted_anchor" or inspection is not None:
+            raise SystemExit(f"maintenance evidence bundle below-anchor proof differs: {node}")
+        return
+    if (not isinstance(inspection,dict) or set(inspection)!={"schema","height",
+            "block_hash","state_root","input_roots"}
+            or inspection.get("schema")!="arc.recovery.legacy-block-inspection.v1"
+            or inspection.get("height")!=anchor["anchor_height"]
+            or hash_re.fullmatch(str(inspection.get("block_hash"))) is None
+            or hash_re.fullmatch(str(inspection.get("state_root"))) is None):
+        raise SystemExit(f"maintenance evidence bundle anchor inspection differs: {node}")
+    roots=inspection.get("input_roots")
+    if not isinstance(roots,dict) or set(roots)!={"data_dir","state_wal","snapshot",
+                                                 "genesis","legacy_validator_set"}:
+        raise SystemExit(f"maintenance evidence bundle anchor input roots differ: {node}")
+    if persisted.get("source_pair_role")=="post-quarantine-final-export":
+        expected_roots={"state_wal":persisted.get("state_wal_sha256"),
+            "snapshot":persisted.get("snapshot_sha256"),
+            "genesis":persisted.get("genesis_sha256"),
+            "legacy_validator_set":persisted.get("legacy_validator_set_sha256")}
+    else:
+        source=persisted.get("source_inputs",{});staged=persisted.get("staged_inputs",{})
+        expected_roots={"state_wal":source.get("fixed_state_wal",{}).get("sha256"),
+            "snapshot":source.get("fixed_snapshot",{}).get("sha256"),
+            "genesis":staged.get("genesis",{}).get("sha256"),
+            "legacy_validator_set":staged.get("legacy_validator_set",{}).get("sha256")}
+    if any(roots.get(label,{}).get("sha256")!=expected
+           for label,expected in expected_roots.items()):
+        raise SystemExit(f"maintenance evidence bundle anchor source binding differs: {node}")
+    matches=(inspection["block_hash"]==anchor["anchor_block_hash"]
+             and inspection["state_root"]==anchor["anchor_state_root"])
+    expected="valid_anchor_descendant" if matches else "conflicting_anchor"
+    if anchor.get("classification")!=expected:
+        raise SystemExit(f"maintenance evidence bundle anchor classification differs: {node}")
 authenticated_sealed=sealed(authenticated,authenticated_bytes,"fleet","authenticated-prefence-height-cross-proof")
 observation_selection_sealed=sealed(
     observation_selection,observation_selection_bytes,"fleet","live-observation-selection")
@@ -6175,6 +6230,9 @@ for node,host in fleet:
                     !=persisted.get("source_inputs",{}).get("live_source_capture_sha256")
                 or persisted.get("head")!=projection["stable_head"]):
             raise SystemExit(f"maintenance evidence stopped-round persisted head differs: {node}")
+        if persisted.get("schema")!="arc.recovery.persisted-legacy-head-stopped-precommit.v2":
+            raise SystemExit(f"maintenance evidence stopped persisted schema differs: {node}")
+        validate_dag_and_anchor(persisted,node)
         transition_sealed=sealed(
             transition,transition_bytes,node,"persistently-stopped-transition"
         )
@@ -6248,8 +6306,8 @@ for node,host in fleet:
             or cross.get("challenge")!=challenge
             or cross.get("quarantine_status_sha256")!=digest(canonical(cross.get("quarantine_status")))):
         raise SystemExit(f"maintenance evidence bundle public cross proof differs: {node}")
-    if (persisted.get("schema") not in {"arc.recovery.persisted-legacy-head.v1",
-                                        "arc.recovery.persisted-legacy-head.v2"}
+    if (persisted.get("schema") not in {"arc.recovery.persisted-legacy-head.v3",
+                                        "arc.recovery.persisted-legacy-head.v4"}
             or (persisted.get("capture_id"),persisted.get("node"),persisted.get("freeze_plan_sha256"))!=identity
             or persisted.get("source_main_commit")!=source_commit
             or persisted.get("writer_stopped") is not True
@@ -6257,6 +6315,7 @@ for node,host in fleet:
             or persisted.get("network_quarantine_active") is not True
             or persisted.get("global_absence_claimed") is not False):
         raise SystemExit(f"maintenance evidence bundle persisted head differs: {node}")
+    validate_dag_and_anchor(persisted,node)
     nodes.append({"node":node,"host":host,
         "stopped_status":sealed(stopped,stopped_bytes,node,"stopped-status"),
         "network_quarantine_receipt":sealed(network,network_bytes,node,"network-quarantine-receipt"),
@@ -6554,6 +6613,62 @@ def exact_tuple(value,label):
         raise SystemExit(f"maintenance-boundary {label} tuple is malformed")
     return {key:value[key] for key in ("height","block_hash","state_root")}
 
+def validate_dag_and_anchor(persisted,node):
+    dag=persisted.get("legacy_dag_round")
+    try:rounds.validate_legacy_dag_round(dag,f"maintenance-boundary {node}")
+    except rounds.QuarantineRoundError as error:
+        raise SystemExit(
+            f"maintenance-boundary persisted DAG round differs: {node}: {error}"
+        ) from error
+    head=persisted.get("head",{});anchor=persisted.get("trusted_anchor_ancestry")
+    inspection=anchor.get("inspection") if isinstance(anchor,dict) else None
+    if (not isinstance(head,dict) or isinstance(head.get("height"),bool)
+            or not isinstance(head.get("height"),int) or head["height"]<1
+            or not isinstance(anchor,dict) or set(anchor)!={"anchor_height",
+                "anchor_block_hash","anchor_state_root","classification","inspection",
+                "inspection_sha256"}
+            or anchor.get("anchor_height")!=137145
+            or anchor.get("anchor_block_hash")
+                !="8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90"
+            or anchor.get("anchor_state_root")
+                !="d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d"
+            or anchor.get("inspection_sha256")!=digest(canonical(inspection))):
+        raise SystemExit(f"maintenance-boundary trusted anchor differs: {node}")
+    if head["height"]<anchor["anchor_height"]:
+        if anchor.get("classification")!="below_trusted_anchor" or inspection is not None:
+            raise SystemExit(f"maintenance-boundary below-anchor proof differs: {node}")
+        return
+    if (not isinstance(inspection,dict) or set(inspection)!={"schema","height",
+            "block_hash","state_root","input_roots"}
+            or inspection.get("schema")!="arc.recovery.legacy-block-inspection.v1"
+            or inspection.get("height")!=anchor["anchor_height"]
+            or hash_re.fullmatch(str(inspection.get("block_hash"))) is None
+            or hash_re.fullmatch(str(inspection.get("state_root"))) is None):
+        raise SystemExit(f"maintenance-boundary anchor inspection differs: {node}")
+    roots=inspection.get("input_roots")
+    if not isinstance(roots,dict) or set(roots)!={"data_dir","state_wal","snapshot",
+                                                 "genesis","legacy_validator_set"}:
+        raise SystemExit(f"maintenance-boundary anchor input roots differ: {node}")
+    if persisted.get("source_pair_role")=="post-quarantine-final-export":
+        expected_roots={"state_wal":persisted.get("state_wal_sha256"),
+            "snapshot":persisted.get("snapshot_sha256"),
+            "genesis":persisted.get("genesis_sha256"),
+            "legacy_validator_set":persisted.get("legacy_validator_set_sha256")}
+    else:
+        source=persisted.get("source_inputs",{});staged=persisted.get("staged_inputs",{})
+        expected_roots={"state_wal":source.get("fixed_state_wal",{}).get("sha256"),
+            "snapshot":source.get("fixed_snapshot",{}).get("sha256"),
+            "genesis":staged.get("genesis",{}).get("sha256"),
+            "legacy_validator_set":staged.get("legacy_validator_set",{}).get("sha256")}
+    if any(roots.get(label,{}).get("sha256")!=expected
+           for label,expected in expected_roots.items()):
+        raise SystemExit(f"maintenance-boundary anchor source binding differs: {node}")
+    matches=(inspection["block_hash"]==anchor["anchor_block_hash"]
+             and inspection["state_root"]==anchor["anchor_state_root"])
+    expected="valid_anchor_descendant" if matches else "conflicting_anchor"
+    if anchor.get("classification")!=expected:
+        raise SystemExit(f"maintenance-boundary anchor classification differs: {node}")
+
 rows=[];evidence_heights=[];challenge=stability.get("challenge")
 if hash_re.fullmatch(str(challenge)) is None:
     raise SystemExit("maintenance-boundary quarantine challenge is malformed")
@@ -6576,6 +6691,9 @@ for (node,host),origin,authenticated_row in zip(fleet,origins,authenticated_rows
                 or persisted.get("source_pair_role")!="preauthorization-boundary"
                 or persisted.get("head")!=projection["stable_head"]):
             raise SystemExit(f"maintenance-boundary stopped transition binding differs: {node}")
+        if persisted.get("schema")!="arc.recovery.persisted-legacy-head-stopped-precommit.v2":
+            raise SystemExit(f"maintenance-boundary stopped persisted schema differs: {node}")
+        validate_dag_and_anchor(persisted,node)
         current=bundle_row.get("current_status",{})
         if (not isinstance(current,dict) or set(current)!={"value","sha256"}
                 or digest(canonical(current.get("value")))!=current.get("sha256")
@@ -6697,8 +6815,8 @@ for (node,host),origin,authenticated_row in zip(fleet,origins,authenticated_rows
             or public_latest["block_hash"]!=origin.get("latest_block_hash")
             or fenced_tuple["height"]<public_tuple["height"]):
         raise SystemExit(f"maintenance-boundary public/post-quarantine tuple differs: {node}")
-    if (persisted.get("schema") not in {"arc.recovery.persisted-legacy-head.v1",
-                                        "arc.recovery.persisted-legacy-head.v2"}
+    if (persisted.get("schema") not in {"arc.recovery.persisted-legacy-head.v3",
+                                        "arc.recovery.persisted-legacy-head.v4"}
             or (persisted.get("capture_id"),persisted.get("node"),persisted.get("freeze_plan_sha256"))!=identity
             or persisted.get("source_main_commit")!=source_commit
             or persisted.get("boot_id")!=next(row["boot_id"] for row in plan["nodes"] if row["name"]==node)
@@ -6712,6 +6830,7 @@ for (node,host),origin,authenticated_row in zip(fleet,origins,authenticated_rows
             or hash_re.fullmatch(str(persisted.get("final_source_capture_sha256"))) is None
             or persisted.get("export_status")!="EXPORTED_UNSIGNED"):
         raise SystemExit(f"maintenance-boundary persisted head identity differs: {node}")
+    validate_dag_and_anchor(persisted,node)
     persisted_tuple=exact_tuple(persisted.get("head"),f"{node} persisted")
     if persisted_tuple["height"]<fenced_tuple["height"]:
         raise SystemExit(f"maintenance-boundary persisted head precedes post-quarantine head: {node}")

--- a/scripts/recovery/archive-node.sh
+++ b/scripts/recovery/archive-node.sh
@@ -5261,7 +5261,7 @@ BINDING_SCHEMA = "arc.recovery.quarantine-nft-table-binding.v1"
 APPLIED_COMMIT_SCHEMA = "arc.recovery.quarantine-nft-applied-commit.v1"
 NODE_APPLIED_SCHEMA = "arc.recovery.quarantine-node-nft-applied.v1"
 NODE_STOPPED_SCHEMA = "arc.recovery.quarantine-node-persistently-stopped-precommit.v1"
-PERSISTED_STOPPED_SCHEMA = "arc.recovery.persisted-legacy-head-stopped-precommit.v1"
+PERSISTED_STOPPED_SCHEMA = "arc.recovery.persisted-legacy-head-stopped-precommit.v2"
 STOPPED_STATUS_SCHEMA = "arc.recovery.quarantine-prior-persistently-stopped-status.v1"
 ANCESTRY_SCHEMA = "arc.recovery.quarantine-post-fence-ancestry.v1"
 STATUS_SCHEMA = "arc.recovery.quarantine-prior-fenced-status.v1"
@@ -6882,6 +6882,13 @@ WantedBy=multi-user.target
                     or data_identity["inode"] <= 0):
                 fail("stopped-precommit data directory device differs")
             held["original_data_dir"] = (data_dir, data_fd, data_identity, True)
+            dag_wal_dir = data_dir / "dag-wal"
+            dag_wal_dir_fd, dag_wal_dir_identity = open_held(
+                dag_wal_dir, directory=True
+            )
+            held["legacy_dag_wal_dir"] = (
+                dag_wal_dir, dag_wal_dir_fd, dag_wal_dir_identity, True,
+            )
             final_wal_path = data_dir / "state.wal"
             final_wal_fd, final_wal_identity = open_held(final_wal_path)
             if final_wal_identity["size"] <= 0:
@@ -7060,6 +7067,7 @@ WantedBy=multi-user.target
                 }
             source_inputs = {
                 "original_data_dir": data_identity,
+                "legacy_dag_wal_dir": dag_wal_dir_identity,
                 "final_state_wal": final_wal_identity,
                 "fixed_data_dir": fixed_dir_identity,
                 "fixed_state_wal": wal_identity,
@@ -7088,6 +7096,89 @@ WantedBy=multi-user.target
             ) as work_raw:
                 work = pathlib.Path(work_raw)
                 candidate = work / "candidate.arcchkpt"
+                dag_result = subprocess.run(
+                    [str(staged_paths["inspector"][0]), "recovery",
+                     "inspect-legacy-dag-round", "--dag-wal-dir", str(dag_wal_dir)],
+                    env=command_env, stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE, check=False,
+                )
+                if dag_result.returncode != 0:
+                    fail("stopped-precommit exact legacy DAG round inspection failed")
+                try:
+                    dag_inspection = json.loads(dag_result.stdout)
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    fail("stopped-precommit legacy DAG round inspection is invalid JSON")
+                dag_fields = {
+                    "schema", "status", "source_consensus_round", "first_segment",
+                    "last_segment", "segment_count", "inspected_first_segment",
+                    "inspected_segment_count", "inspected_entry_count",
+                    "namespace_sha256", "namespace", "read_only",
+                }
+                namespace_fields = {"schema", "segment_names", "inspected_tail"}
+                namespace = dag_inspection.get("namespace", {}) \
+                    if isinstance(dag_inspection, dict) else {}
+                segment_names = namespace.get("segment_names") \
+                    if isinstance(namespace, dict) else None
+                tail = namespace.get("inspected_tail") \
+                    if isinstance(namespace, dict) else None
+                if (
+                    not isinstance(dag_inspection, dict)
+                    or set(dag_inspection) != dag_fields
+                    or dag_inspection.get("schema")
+                        != "arc.recovery.legacy-dag-round-inspection.v1"
+                    or dag_inspection.get("status") != "VERIFIED_STOPPED_DAG_CURSOR"
+                    or dag_inspection.get("read_only") is not True
+                    or any(
+                        isinstance(dag_inspection.get(field), bool)
+                        or not isinstance(dag_inspection.get(field), int)
+                        or dag_inspection[field] < 1
+                        for field in (
+                            "source_consensus_round", "segment_count",
+                            "inspected_segment_count", "inspected_entry_count",
+                        )
+                    )
+                    or any(
+                        isinstance(dag_inspection.get(field), bool)
+                        or not isinstance(dag_inspection.get(field), int)
+                        or dag_inspection[field] < 0
+                        for field in (
+                            "first_segment", "last_segment", "inspected_first_segment",
+                        )
+                    )
+                    or dag_inspection["first_segment"]
+                        > dag_inspection["inspected_first_segment"]
+                    or dag_inspection["inspected_first_segment"]
+                        > dag_inspection["last_segment"]
+                    or not 1 <= dag_inspection["inspected_segment_count"] <= 3
+                    or not isinstance(namespace, dict)
+                    or set(namespace) != namespace_fields
+                    or namespace.get("schema")
+                        != "arc.recovery.legacy-dag-wal-namespace.v1"
+                    or not isinstance(segment_names, list)
+                    or len(segment_names) != dag_inspection["segment_count"]
+                    or segment_names != sorted(segment_names)
+                    or len(set(segment_names)) != len(segment_names)
+                    or not isinstance(tail, list)
+                    or len(tail) != dag_inspection["inspected_segment_count"]
+                    or [row.get("name") for row in tail if isinstance(row, dict)]
+                        != segment_names[-dag_inspection["inspected_segment_count"]:]
+                    or any(
+                        not isinstance(row, dict)
+                        or set(row) != {"name", "sha256", "size"}
+                        or re.fullmatch(r"wal-[0-9]{8}\.bin", str(row.get("name"))) is None
+                        or HASH_RE.fullmatch(str(row.get("sha256"))) is None
+                        or isinstance(row.get("size"), bool)
+                        or not isinstance(row.get("size"), int)
+                        or row["size"] < 0
+                        for row in tail
+                    )
+                    or HASH_RE.fullmatch(str(dag_inspection.get("namespace_sha256")))
+                        is None
+                    or sha(json.dumps(
+                        namespace, sort_keys=True, separators=(",", ":")
+                    ).encode()) != dag_inspection["namespace_sha256"]
+                ):
+                    fail("stopped-precommit legacy DAG round inspection differs")
                 export_command = [
                     str(staged_paths["inspector"][0]), "recovery", "export",
                     "--data-dir", str(fixed_dir), "--snapshot", str(snapshot_path),
@@ -7210,6 +7301,71 @@ WantedBy=multi-user.target
                         )
                     },
                 }
+                trusted_anchor = {
+                    "height": 137145,
+                    "block_hash":
+                        "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90",
+                    "state_root":
+                        "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d",
+                }
+                anchor_inspection = None
+                if head_height >= trusted_anchor["height"]:
+                    anchor_command = [
+                        str(staged_paths["inspector"][0]), "recovery",
+                        "inspect-legacy-block", "--data-dir", str(fixed_dir),
+                        "--snapshot", str(snapshot_path), "--genesis",
+                        str(staged_paths["genesis"][0]), "--legacy-validator-set",
+                        str(staged_paths["legacy_validator_set"][0]), "--height",
+                        str(trusted_anchor["height"]),
+                        "--expected-state-wal-sha256", wal_identity["sha256"],
+                        "--expected-snapshot-sha256", snapshot_identity["sha256"],
+                        "--expected-genesis-sha256", genesis_sha,
+                        "--expected-legacy-validator-set-sha256",
+                        legacy_validators_sha,
+                    ]
+                    anchor_result = subprocess.run(
+                        anchor_command, env=command_env, stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE, check=False,
+                    )
+                    if anchor_result.returncode != 0:
+                        fail("stopped-precommit trusted anchor inspection failed")
+                    try:
+                        anchor_inspection = json.loads(anchor_result.stdout)
+                    except (UnicodeDecodeError, json.JSONDecodeError):
+                        fail("stopped-precommit trusted anchor inspection returned invalid JSON")
+                    if (
+                        not isinstance(anchor_inspection, dict)
+                        or set(anchor_inspection) != {
+                            "schema", "height", "block_hash", "state_root", "input_roots",
+                        }
+                        or anchor_inspection.get("schema")
+                            != "arc.recovery.legacy-block-inspection.v1"
+                        or anchor_inspection.get("height") != trusted_anchor["height"]
+                        or HASH_RE.fullmatch(str(anchor_inspection.get("block_hash"))) is None
+                        or HASH_RE.fullmatch(str(anchor_inspection.get("state_root"))) is None
+                        or anchor_inspection.get("input_roots") != expected_cli_inputs
+                    ):
+                        fail("stopped-precommit trusted anchor inspection differs")
+                    anchor_classification = (
+                        "valid_anchor_descendant"
+                        if (
+                            anchor_inspection["block_hash"]
+                                == trusted_anchor["block_hash"]
+                            and anchor_inspection["state_root"]
+                                == trusted_anchor["state_root"]
+                        )
+                        else "conflicting_anchor"
+                    )
+                else:
+                    anchor_classification = "below_trusted_anchor"
+                trusted_anchor_ancestry = {
+                    "anchor_height": trusted_anchor["height"],
+                    "anchor_block_hash": trusted_anchor["block_hash"],
+                    "anchor_state_root": trusted_anchor["state_root"],
+                    "classification": anchor_classification,
+                    "inspection": anchor_inspection,
+                    "inspection_sha256": sha(canonical(anchor_inspection)),
+                }
                 checks = []
                 for label, height, expected_hash in (
                     ("public-latest", public_row["latest_block_height"],
@@ -7287,7 +7443,7 @@ WantedBy=multi-user.target
                     completed_at = format_utc(now_value())
                 parse_utc(completed_at, "stopped persisted-head completion")
                 persisted = {
-                    "schema": "arc.recovery.persisted-legacy-head-stopped-precommit.v1",
+                    "schema": "arc.recovery.persisted-legacy-head-stopped-precommit.v2",
                     "source_main_commit": auth["source_main_commit"],
                     "capture_id": capture_id, "node": node, "host": FLEET_MAP[node],
                     "freeze_plan_sha256": freeze_sha, "round_number": round_number,
@@ -7311,6 +7467,13 @@ WantedBy=multi-user.target
                     "final_absence_sample": final_absence_sample,
                     "export_summary_sha256": sha(export_result.stdout),
                     "inspect_summary_sha256": sha(inspect_result.stdout),
+                    "legacy_dag_round": {
+                        "source_consensus_round": dag_inspection["source_consensus_round"],
+                        "namespace_sha256": dag_inspection["namespace_sha256"],
+                        "inspection": dag_inspection,
+                        "inspection_sha256": sha(canonical(dag_inspection)),
+                    },
+                    "trusted_anchor_ancestry": trusted_anchor_ancestry,
                     "candidate_checkpoint_sha256": candidate_sha,
                     "candidate_checkpoint_size": candidate_details.st_size,
                     "authorization_ancestry_proof_sha256": sha(ancestry_raw),
@@ -7467,7 +7630,8 @@ WantedBy=multi-user.target
             "source_inputs", "staged_inputs", "source_pair_role",
             "live_source_capture_sha256",
             "final_absence_sample", "export_summary_sha256",
-            "inspect_summary_sha256", "candidate_checkpoint_sha256",
+            "inspect_summary_sha256", "legacy_dag_round",
+            "trusted_anchor_ancestry", "candidate_checkpoint_sha256",
             "candidate_checkpoint_size", "authorization_ancestry_proof_sha256",
             "head", "allow_unbound_legacy_wal", "completed_at", "writer_stopped",
             "restart_barrier_active", "network_quarantine_active",
@@ -7504,6 +7668,107 @@ WantedBy=multi-user.target
                 or HASH_RE.fullmatch(str(head.get("block_hash"))) is None
                 or HASH_RE.fullmatch(str(head.get("state_root"))) is None):
             fail("persistently-stopped stable head differs")
+        dag_round = persisted.get("legacy_dag_round")
+        if (not isinstance(dag_round, dict) or set(dag_round) != {
+                "source_consensus_round", "namespace_sha256", "inspection",
+                "inspection_sha256"
+            } or isinstance(dag_round.get("source_consensus_round"), bool)
+                or not isinstance(dag_round.get("source_consensus_round"), int)
+                or dag_round["source_consensus_round"] < 1
+                or HASH_RE.fullmatch(str(dag_round.get("namespace_sha256"))) is None
+                or HASH_RE.fullmatch(str(dag_round.get("inspection_sha256"))) is None
+                or dag_round.get("inspection_sha256")
+                    != sha(canonical(dag_round.get("inspection")))):
+            fail("persistently-stopped durable DAG round differs")
+        dag_inspection = dag_round["inspection"]
+        dag_namespace = dag_inspection.get("namespace") \
+            if isinstance(dag_inspection, dict) else None
+        dag_segment_names = dag_namespace.get("segment_names") \
+            if isinstance(dag_namespace, dict) else None
+        dag_tail = dag_namespace.get("inspected_tail") \
+            if isinstance(dag_namespace, dict) else None
+        if (not isinstance(dag_inspection, dict) or set(dag_inspection) != {
+                "schema", "status", "source_consensus_round", "first_segment",
+                "last_segment", "segment_count", "inspected_first_segment",
+                "inspected_segment_count", "inspected_entry_count",
+                "namespace_sha256", "namespace", "read_only"
+            } or dag_inspection.get("schema")
+                != "arc.recovery.legacy-dag-round-inspection.v1"
+                or dag_inspection.get("status") != "VERIFIED_STOPPED_DAG_CURSOR"
+                or dag_inspection.get("read_only") is not True
+                or dag_round["source_consensus_round"]
+                    != dag_inspection.get("source_consensus_round")
+                or dag_round["namespace_sha256"]
+                    != dag_inspection.get("namespace_sha256")
+                or not isinstance(dag_namespace, dict)
+                or set(dag_namespace) != {"schema", "segment_names", "inspected_tail"}
+                or dag_namespace.get("schema")
+                    != "arc.recovery.legacy-dag-wal-namespace.v1"
+                or not isinstance(dag_segment_names, list)
+                or dag_segment_names != [
+                    f"wal-{index:08d}.bin"
+                    for index in range(
+                        dag_inspection.get("first_segment", -1),
+                        dag_inspection.get("last_segment", -2) + 1,
+                    )
+                ]
+                or dag_inspection.get("segment_count") != len(dag_segment_names)
+                or dag_inspection.get("inspected_segment_count")
+                    != min(3, len(dag_segment_names))
+                or dag_inspection.get("inspected_first_segment")
+                    != dag_inspection.get("last_segment")
+                        - dag_inspection.get("inspected_segment_count", 0) + 1
+                or isinstance(dag_inspection.get("inspected_entry_count"), bool)
+                or not isinstance(dag_inspection.get("inspected_entry_count"), int)
+                or dag_inspection["inspected_entry_count"] < 1
+                or not isinstance(dag_tail, list)
+                or [row.get("name") for row in dag_tail if isinstance(row, dict)]
+                    != dag_segment_names[-dag_inspection["inspected_segment_count"]:]
+                or any(not isinstance(row, dict) or set(row) != {
+                        "name", "sha256", "size"
+                    } or HASH_RE.fullmatch(str(row.get("sha256"))) is None
+                        or isinstance(row.get("size"), bool)
+                        or not isinstance(row.get("size"), int) or row["size"] < 0
+                    for row in dag_tail)
+                or sha(json.dumps(
+                    dag_namespace, sort_keys=True, separators=(",", ":")
+                ).encode()) != dag_round["namespace_sha256"]):
+            fail("persistently-stopped durable DAG inspection differs")
+        anchor = persisted.get("trusted_anchor_ancestry")
+        anchor_inspection = anchor.get("inspection") if isinstance(anchor, dict) else None
+        if (not isinstance(anchor, dict) or set(anchor) != {
+                "anchor_height", "anchor_block_hash", "anchor_state_root",
+                "classification", "inspection", "inspection_sha256"
+            } or anchor.get("anchor_height") != 137145
+                or anchor.get("anchor_block_hash")
+                    != "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90"
+                or anchor.get("anchor_state_root")
+                    != "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d"
+                or anchor.get("inspection_sha256") != sha(canonical(anchor_inspection))
+                or (head["height"] < 137145 and (
+                    anchor.get("classification") != "below_trusted_anchor"
+                    or anchor_inspection is not None))
+                or (head["height"] >= 137145 and (
+                    anchor.get("classification") not in {
+                        "valid_anchor_descendant", "conflicting_anchor"
+                    } or not isinstance(anchor_inspection, dict)
+                    or set(anchor_inspection) != {
+                        "schema", "height", "block_hash", "state_root", "input_roots"
+                    } or anchor_inspection.get("schema")
+                        != "arc.recovery.legacy-block-inspection.v1"
+                    or anchor_inspection.get("height") != 137145
+                    or HASH_RE.fullmatch(str(anchor_inspection.get("block_hash"))) is None
+                    or HASH_RE.fullmatch(str(anchor_inspection.get("state_root"))) is None
+                ))):
+            fail("persistently-stopped trusted-anchor ancestry differs")
+        anchor_matches = isinstance(anchor_inspection, dict) and (
+            anchor_inspection.get("block_hash") == anchor["anchor_block_hash"]
+            and anchor_inspection.get("state_root") == anchor["anchor_state_root"]
+        )
+        if head["height"] >= 137145 and (
+                (anchor.get("classification") == "valid_anchor_descendant")
+                is not anchor_matches):
+            fail("persistently-stopped trusted-anchor classification differs")
         if (wrappers["nft_apply_intent"][1]
                 != persisted.get("nft_apply_intent_sha256")
                 or wrappers["persistence_plan"][1]
@@ -18877,6 +19142,16 @@ PY
     local staged_wal_identity staged_snapshot_identity
     staged_wal_identity="$(stat -Lc %d:%i:%s:%f:%u:%g:%h "$temporary/export-source/state.wal")"
     staged_snapshot_identity="$(stat -Lc %d:%i:%s:%f:%u:%g:%h "$temporary/export-source/state.snapshot.lz4")"
+    local legacy_dag_wal_dir="$archive_data_dir/dag-wal"
+    require_safe_absolute_path "$legacy_dag_wal_dir" "persisted-head legacy DAG WAL directory"
+    [ -d "$legacy_dag_wal_dir" ] && [ ! -L "$legacy_dag_wal_dir" ] || \
+        die "persisted-head captured legacy DAG WAL directory is missing or a symlink"
+    /usr/bin/env -i HOME=/root PATH=/usr/bin:/bin LANG=C LC_ALL=C \
+        /proc/self/fd/8 recovery inspect-legacy-dag-round \
+        --dag-wal-dir "$legacy_dag_wal_dir" \
+        > "$temporary/legacy-dag-round-inspection.json" \
+        2> "$temporary/legacy-dag-round-inspection.stderr" || \
+        die "persisted-head exact legacy DAG round inspection failed"
     if /usr/bin/env -i HOME=/root PATH=/usr/bin:/bin LANG=C LC_ALL=C \
         /proc/self/fd/8 recovery export \
         --data-dir "$temporary/export-source" \
@@ -18891,6 +19166,36 @@ PY
         export_exit="$?"
     fi
     [ "$export_exit" -eq 0 ] || die "persisted-head exact recovery export failed: exit=$export_exit"
+    local anchor_source_height
+    anchor_source_height="$(python3 - "$temporary/export-summary.json" <<'PY'
+import json,sys
+value=json.load(open(sys.argv[1],encoding="utf-8"))
+height=value.get("source_height")
+if isinstance(height,bool) or not isinstance(height,int) or height<0:
+    raise SystemExit("persisted-head source height is malformed")
+print(height)
+PY
+    )" || die "cannot read persisted-head source height for trusted-anchor proof"
+    if [ "$anchor_source_height" -ge 137145 ]; then
+        /usr/bin/env -i HOME=/root PATH=/usr/bin:/bin LANG=C LC_ALL=C \
+            /proc/self/fd/8 recovery inspect-legacy-block \
+            --data-dir "$temporary/export-source" \
+            --snapshot "$temporary/export-source/state.snapshot.lz4" \
+            --genesis "$genesis" --legacy-validator-set "$legacy_validators" \
+            --height 137145 --expected-state-wal-sha256 "$wal_before" \
+            --expected-snapshot-sha256 "$snapshot_before" \
+            --expected-genesis-sha256 "$genesis_sha" \
+            --expected-legacy-validator-set-sha256 "$legacy_validators_sha" \
+            --allow-unbound-legacy-wal \
+            > "$temporary/trusted-anchor-inspection.json" \
+            2> "$temporary/trusted-anchor-inspection.stderr" || \
+            die "persisted-head trusted anchor inspection failed"
+    else
+        python3 - "$temporary/trusted-anchor-inspection.json" <<'PY'
+import pathlib,sys
+pathlib.Path(sys.argv[1]).write_bytes(b"null\n")
+PY
+    fi
     python3 - "$temporary" <<'PY'
 import pathlib,stat,sys
 root=pathlib.Path(sys.argv[1]); candidate=root/"candidate.arcchkpt"
@@ -18923,6 +19228,8 @@ PY
     verify_legacy_network_quarantine "$stop_root" "$capture_id" "$node" "$freeze_sha"
     pgrep -x arc-node >/dev/null 2>&1 && die "legacy writer appeared during persisted-head export"
     python3 - "$temporary/export-summary.json" "$temporary/candidate.inspect.json" \
+        "$temporary/legacy-dag-round-inspection.json" \
+        "$temporary/trusted-anchor-inspection.json" \
         "$temporary/offline-wal-boundary.json" "$temporary/candidate.arcchkpt" "$output" \
         "$capture_id" "$node" "$freeze_sha" "$boot_id" "$binary_sha" "$genesis_sha" \
         "$validators_sha" "$legacy_validators_sha" "$snapshot" "$snapshot_before" \
@@ -18936,7 +19243,7 @@ PY
         "$archive_wal_suffix_sha" "$archive_wal_suffix_classification" \
         "$selected_source_schema" "$selected_normalization_receipt_sha" <<'PY'
 import datetime,hashlib,json,os,pathlib,re,stat,sys
-(summary_raw,inspect_raw,boundary_raw,candidate_raw,output_raw,capture,node,freeze,boot,binary_sha,genesis_sha,
+(summary_raw,inspect_raw,dag_raw,anchor_raw,boundary_raw,candidate_raw,output_raw,capture,node,freeze,boot,binary_sha,genesis_sha,
  validators_sha,legacy_sha,snapshot_raw,snapshot_sha,snapshot_size_raw,wal_raw,wal_sha,
  wal_size_raw,capture_raw,stop_raw,wal_identity_raw,snapshot_identity_raw,
  staged_wal_identity_raw,staged_snapshot_identity_raw,final_capture_sha,
@@ -18944,7 +19251,8 @@ import datetime,hashlib,json,os,pathlib,re,stat,sys
  archive_wal_raw,archive_wal_sha,archive_wal_size_raw,archive_wal_identity_raw,
  archive_suffix_bytes_raw,archive_suffix_sha,archive_suffix_classification,
  selected_source_schema,selected_normalization_receipt_sha)=sys.argv[1:]
-summary_path=pathlib.Path(summary_raw); inspect_path=pathlib.Path(inspect_raw)
+summary_path=pathlib.Path(summary_raw); inspect_path=pathlib.Path(inspect_raw); dag_path=pathlib.Path(dag_raw)
+anchor_path=pathlib.Path(anchor_raw)
 boundary_path=pathlib.Path(boundary_raw); candidate=pathlib.Path(candidate_raw); output=pathlib.Path(output_raw)
 capture_root=pathlib.Path(capture_raw); stop_root=pathlib.Path(stop_raw)
 canonical=lambda value:(json.dumps(value,sort_keys=True,separators=(",",":"))+"\n").encode()
@@ -18959,6 +19267,8 @@ def staged_identity(raw):
             "uid":int(uid),"gid":int(gid),"nlink":int(nlink)}
 summary_bytes=summary_path.read_bytes(); summary=json.loads(summary_bytes)
 inspect_bytes=inspect_path.read_bytes(); inspect=json.loads(inspect_bytes)
+dag_bytes=dag_path.read_bytes(); dag=json.loads(dag_bytes)
+anchor_bytes=anchor_path.read_bytes(); anchor_inspection=json.loads(anchor_bytes)
 boundary_bytes=boundary_path.read_bytes(); boundary=json.loads(boundary_bytes)
 source_wal_identity=source_identity(wal_identity_raw)
 source_snapshot_identity=source_identity(snapshot_identity_raw)
@@ -19041,6 +19351,77 @@ if (inspect.get("status")!="UNTRUSTED_INSPECTION"
             "manifest_hash","payload_hash","source_consensus_round","created_at_unix_ms",
             "recovery_epoch","validator_set_id","transition_height","transition_block_hash"))):
     raise SystemExit("persisted-head inspect/export candidate cross-check differs")
+dag_fields={"schema","status","source_consensus_round","first_segment","last_segment",
+            "segment_count","inspected_first_segment","inspected_segment_count",
+            "inspected_entry_count","namespace_sha256","namespace","read_only"}
+namespace_fields={"schema","segment_names","inspected_tail"}
+namespace=dag.get("namespace",{}) if isinstance(dag,dict) else {}
+segment_names=namespace.get("segment_names") if isinstance(namespace,dict) else None
+tail=namespace.get("inspected_tail") if isinstance(namespace,dict) else None
+if (not isinstance(dag,dict) or set(dag)!=dag_fields
+        or dag.get("schema")!="arc.recovery.legacy-dag-round-inspection.v1"
+        or dag.get("status")!="VERIFIED_STOPPED_DAG_CURSOR" or dag.get("read_only") is not True
+        or any(isinstance(dag.get(field),bool) or not isinstance(dag.get(field),int)
+               or dag[field]<1 for field in ("source_consensus_round","segment_count",
+                    "inspected_segment_count","inspected_entry_count"))
+        or any(isinstance(dag.get(field),bool) or not isinstance(dag.get(field),int)
+               or dag[field]<0 for field in ("first_segment","last_segment","inspected_first_segment"))
+        or dag["first_segment"]>dag["inspected_first_segment"]>dag["last_segment"]
+        or dag["inspected_segment_count"]>3
+        or not isinstance(namespace,dict) or set(namespace)!=namespace_fields
+        or namespace.get("schema")!="arc.recovery.legacy-dag-wal-namespace.v1"
+        or not isinstance(segment_names,list) or len(segment_names)!=dag["segment_count"]
+        or segment_names!=sorted(segment_names) or len(set(segment_names))!=len(segment_names)
+        or not isinstance(tail,list) or len(tail)!=dag["inspected_segment_count"]
+        or [row.get("name") for row in tail if isinstance(row,dict)]
+            !=segment_names[-dag["inspected_segment_count"]:]
+        or any(not isinstance(row,dict) or set(row)!={"name","sha256","size"}
+               or re.fullmatch(r"wal-[0-9]{8}\.bin",str(row.get("name"))) is None
+               or re.fullmatch(r"[0-9a-f]{64}",str(row.get("sha256"))) is None
+               or isinstance(row.get("size"),bool) or not isinstance(row.get("size"),int)
+               or row["size"]<0 for row in tail)
+        or re.fullmatch(r"[0-9a-f]{64}",str(dag.get("namespace_sha256"))) is None
+        or hashlib.sha256(json.dumps(namespace,sort_keys=True,
+                separators=(",",":")).encode()).hexdigest()
+            !=dag["namespace_sha256"]):
+    raise SystemExit("persisted-head legacy DAG round inspection differs")
+trusted_anchor={
+    "height":137145,
+    "block_hash":"8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90",
+    "state_root":"d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d",
+}
+if height<trusted_anchor["height"]:
+    if anchor_inspection is not None or anchor_bytes!=b"null\n":
+        raise SystemExit("below-anchor persisted head unexpectedly has an inspection")
+    anchor_classification="below_trusted_anchor"
+else:
+    if (not isinstance(anchor_inspection,dict) or set(anchor_inspection)!={
+            "schema","height","block_hash","state_root","input_roots"}
+            or anchor_inspection.get("schema")!="arc.recovery.legacy-block-inspection.v1"
+            or anchor_inspection.get("height")!=trusted_anchor["height"]
+            or not re.fullmatch(r"[0-9a-f]{64}",str(anchor_inspection.get("block_hash")))
+            or not re.fullmatch(r"[0-9a-f]{64}",str(anchor_inspection.get("state_root")))):
+        raise SystemExit("persisted-head trusted anchor inspection differs")
+    roots=anchor_inspection.get("input_roots")
+    if (not isinstance(roots,dict) or set(roots)!={
+            "data_dir","state_wal","snapshot","genesis","legacy_validator_set"}
+            or roots.get("state_wal",{}).get("sha256")!=wal_sha
+            or roots.get("snapshot",{}).get("sha256")!=snapshot_sha
+            or roots.get("genesis",{}).get("sha256")!=genesis_sha
+            or roots.get("legacy_validator_set",{}).get("sha256")!=legacy_sha):
+        raise SystemExit("persisted-head trusted anchor inputs differ")
+    anchor_classification=("valid_anchor_descendant"
+        if (anchor_inspection["block_hash"]==trusted_anchor["block_hash"]
+            and anchor_inspection["state_root"]==trusted_anchor["state_root"])
+        else "conflicting_anchor")
+trusted_anchor_ancestry={
+    "anchor_height":trusted_anchor["height"],
+    "anchor_block_hash":trusted_anchor["block_hash"],
+    "anchor_state_root":trusted_anchor["state_root"],
+    "classification":anchor_classification,
+    "inspection":anchor_inspection,
+    "inspection_sha256":hashlib.sha256(canonical(anchor_inspection)).hexdigest(),
+}
 boundary_keys={"schema","capture_wal_sha256","capture_wal_bytes","accepted_prefix_bytes",
                "accepted_prefix_sha256","quarantined_tail_bytes","quarantined_tail_sha256",
                "tail_reason","prefix_plus_tail_sha256","prefix_plus_tail_reconstructs_capture"}
@@ -19173,8 +19554,8 @@ elif partial.exists() and not partial.is_symlink():
     try:
         parsed=json.loads(partial.read_text(encoding="utf-8"))
         if (isinstance(parsed,dict) and parsed.get("schema") in {
-                "arc.recovery.persisted-legacy-head.v1",
-                "arc.recovery.persisted-legacy-head.v2"}):
+                "arc.recovery.persisted-legacy-head.v3",
+                "arc.recovery.persisted-legacy-head.v4"}):
             prior_source=partial
     except (UnicodeError,json.JSONDecodeError): pass
 if prior_source is not None:
@@ -19183,8 +19564,8 @@ else: completed_at=datetime.datetime.now(datetime.timezone.utc).replace(microsec
 if not isinstance(completed_at,str) or not re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z",completed_at):
     raise SystemExit("persisted-head completion timestamp is malformed")
 receipt={
- "schema":("arc.recovery.persisted-legacy-head.v2" if normalization_wrapper is not None
-           else "arc.recovery.persisted-legacy-head.v1"),
+ "schema":("arc.recovery.persisted-legacy-head.v4" if normalization_wrapper is not None
+           else "arc.recovery.persisted-legacy-head.v3"),
  "source_main_commit":plan["source_commit"],
  "capture_id":capture,"node":node,"freeze_plan_sha256":freeze,"boot_id":boot,
  "inspector_binary_sha256":binary_sha,"genesis_sha256":genesis_sha,
@@ -19213,6 +19594,11 @@ receipt={
  },
  "export_summary_sha256":hashlib.sha256(summary_bytes).hexdigest(),
  "inspect_summary_sha256":hashlib.sha256(inspect_bytes).hexdigest(),
+ "legacy_dag_round":{"source_consensus_round":dag["source_consensus_round"],
+                     "namespace_sha256":dag["namespace_sha256"],
+                     "inspection":dag,
+                     "inspection_sha256":hashlib.sha256(canonical(dag)).hexdigest()},
+ "trusted_anchor_ancestry":trusted_anchor_ancestry,
  "wal_boundary_sha256":hashlib.sha256(boundary_bytes).hexdigest(),
  "export_status":"EXPORTED_UNSIGNED",
  "head":{"height":height,"block_hash":block_hash,"state_root":state_root},

--- a/scripts/recovery/build-production-manifest.py
+++ b/scripts/recovery/build-production-manifest.py
@@ -114,6 +114,13 @@ MAX_MACOS_CANARY_ACCEPTANCE_AGE_SECONDS = 6 * 60 * 60
 # same bound from the immutable receipt/cross-proof timeline; the six official
 # HTTP origins no longer exist to resample at that point.
 MAX_LEGACY_HEIGHT_TO_AUTHENTICATED_CROSS_SECONDS = 300
+TRUSTED_CHECKPOINT_MIN_HEIGHT = 137_145
+TRUSTED_CHECKPOINT_ANCHOR_BLOCK_HASH = (
+    "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90"
+)
+TRUSTED_CHECKPOINT_ANCHOR_STATE_ROOT = (
+    "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d"
+)
 ZERO_HASH = "0" * 64
 MAX_JSON_BYTES = 16 * 1024 * 1024
 MAX_METADATA_BYTES = 64 * 1024
@@ -706,6 +713,7 @@ def stage_prearchive_inputs(args: argparse.Namespace) -> tuple[argparse.Namespac
     for path, label in (
         (args.freeze_plan, "freeze plan"),
         (args.legacy_maintenance_evidence_bundle, "legacy maintenance evidence bundle"),
+        (args.canonical_source_preselection, "canonical-source preselection"),
         (args.legacy_maintenance_boundary, "legacy maintenance boundary"),
         (args.legacy_late_fork_source_set, "legacy late-fork source set"),
         (args.offline_stop_evidence, "offline-stop evidence"),
@@ -798,6 +806,26 @@ def stage_prearchive_inputs(args: argparse.Namespace) -> tuple[argparse.Namespac
                     args.legacy_maintenance_evidence_bundle.name + ".sha256"
                 ),
                 "legacy-maintenance-evidence-bundle.json.sha256",
+                512,
+                0o400,
+                False,
+                "root",
+            ),
+            (
+                "canonical_source_preselection",
+                args.canonical_source_preselection,
+                "canonical-source-preselection.json",
+                4 * 1024 * 1024,
+                0o400,
+                False,
+                "root",
+            ),
+            (
+                "canonical_source_preselection_sidecar",
+                args.canonical_source_preselection.with_name(
+                    args.canonical_source_preselection.name + ".sha256"
+                ),
+                "canonical-source-preselection.json.sha256",
                 512,
                 0o400,
                 False,
@@ -2608,6 +2636,8 @@ def validate_legacy_maintenance_evidence_bundle(
         "snapshot_path",
         "state_wal_path",
         "export_contract",
+        "legacy_dag_round",
+        "trusted_anchor_ancestry",
         "completed_at",
         "rerun_reexecutes_export",
         "writer_stopped",
@@ -3236,15 +3266,15 @@ def validate_legacy_maintenance_evidence_bundle(
 
         persisted_schema = persisted_value.get("schema") if isinstance(persisted_value, dict) else None
         expected_persisted_fields = set(persisted_fields)
-        if persisted_schema == "arc.recovery.persisted-legacy-head.v2":
+        if persisted_schema == "arc.recovery.persisted-legacy-head.v4":
             expected_persisted_fields.add("wal_normalization")
         persisted_value = require_exact_object(
             persisted_value, expected_persisted_fields, f"{name} persisted-head value"
         )
         if (
             persisted_value.get("schema") not in {
-                "arc.recovery.persisted-legacy-head.v1",
-                "arc.recovery.persisted-legacy-head.v2",
+                "arc.recovery.persisted-legacy-head.v3",
+                "arc.recovery.persisted-legacy-head.v4",
             }
             or persisted_value.get("source_main_commit") != args.source_main_sha
             or (
@@ -3356,6 +3386,10 @@ def validate_legacy_maintenance_evidence_bundle(
             "read_only": True,
         }:
             fail(f"maintenance evidence persisted export contract differs at {name}")
+        validate_embedded_legacy_dag_round(
+            persisted_value.get("legacy_dag_round"),
+            f"{name} persisted legacy DAG round",
+        )
         _parse_utc_seconds(
             persisted_value.get("completed_at"), f"{name} persisted-head completed_at"
         )
@@ -3366,7 +3400,7 @@ def validate_legacy_maintenance_evidence_bundle(
         )
         if selected_source_head != persisted_head:
             fail(f"maintenance evidence selected final source head differs at {name}")
-        normalized_persisted = persisted_value["schema"] == "arc.recovery.persisted-legacy-head.v2"
+        normalized_persisted = persisted_value["schema"] == "arc.recovery.persisted-legacy-head.v4"
         archived_fields = {
             "path", "sha256", "size", "file_identity", "preserved_by",
         }
@@ -5359,6 +5393,7 @@ CHECKPOINT_COMPARE_FIELDS = (
     "source_validator_stake",
     "source_validator_set_hash",
     "community_reward_issuance_policy_hash",
+    "community_rewards_v1_activation_height",
 )
 
 
@@ -5390,6 +5425,7 @@ def validate_checkpoint_summary(value: dict[str, Any], label: str) -> None:
         "signature_count",
         "source_validator_count",
         "source_validator_stake",
+        "community_rewards_v1_activation_height",
     ):
         require_uint(value.get(field), f"{label}.{field}")
     if not isinstance(value.get("chain_id"), str) or not value["chain_id"]:
@@ -5404,6 +5440,8 @@ def validate_checkpoint_summary(value: dict[str, Any], label: str) -> None:
         fail(f"{label} does not bind the canonical eight-validator/40M source set")
     if value["transition_height"] != value["source_height"] + 1:
         fail(f"{label} transition height is not exactly source H+1")
+    if value["community_rewards_v1_activation_height"] > value["transition_height"]:
+        fail(f"{label} community reward activation height is after H+1")
 
 
 def inspect_signed_checkpoint(args: argparse.Namespace) -> dict[str, Any]:
@@ -5416,6 +5454,756 @@ def inspect_signed_checkpoint(args: argparse.Namespace) -> dict[str, Any]:
     if inspected.get("status") != "UNTRUSTED_INSPECTION":
         fail("signed checkpoint inspect returned an unexpected status")
     return inspected
+
+
+def validate_embedded_legacy_dag_round(raw: Any, label: str) -> dict[str, Any]:
+    value = require_exact_object(
+        raw,
+        {"source_consensus_round", "namespace_sha256", "inspection", "inspection_sha256"},
+        label,
+    )
+    source_round = require_uint(
+        value.get("source_consensus_round"), f"{label} source consensus round", positive=True
+    )
+    namespace_sha = require_hash(value.get("namespace_sha256"), f"{label} namespace root")
+    inspection = require_exact_object(
+        value.get("inspection"),
+        {
+            "schema", "status", "source_consensus_round", "first_segment",
+            "last_segment", "segment_count", "inspected_first_segment",
+            "inspected_segment_count", "inspected_entry_count", "namespace_sha256",
+            "namespace", "read_only",
+        },
+        f"{label} inspection",
+    )
+    if (
+        inspection.get("schema") != "arc.recovery.legacy-dag-round-inspection.v1"
+        or inspection.get("status") != "VERIFIED_STOPPED_DAG_CURSOR"
+        or inspection.get("read_only") is not True
+        or inspection.get("source_consensus_round") != source_round
+        or inspection.get("namespace_sha256") != namespace_sha
+    ):
+        fail(f"{label} inspection identity differs")
+    for field in (
+        "source_consensus_round", "segment_count", "inspected_segment_count",
+        "inspected_entry_count",
+    ):
+        require_uint(inspection.get(field), f"{label} inspection {field}", positive=True)
+    for field in ("first_segment", "last_segment", "inspected_first_segment"):
+        require_uint(inspection.get(field), f"{label} inspection {field}")
+    if (
+        inspection["last_segment"] < inspection["first_segment"]
+        or inspection["segment_count"]
+        != inspection["last_segment"] - inspection["first_segment"] + 1
+        or inspection["inspected_segment_count"]
+        != min(3, inspection["segment_count"])
+        or inspection["inspected_first_segment"]
+        != inspection["last_segment"] - inspection["inspected_segment_count"] + 1
+    ):
+        fail(f"{label} inspection segment bounds differ")
+    namespace = require_exact_object(
+        inspection.get("namespace"),
+        {"schema", "segment_names", "inspected_tail"},
+        f"{label} namespace",
+    )
+    names = namespace.get("segment_names")
+    tail = namespace.get("inspected_tail")
+    if (
+        namespace.get("schema") != "arc.recovery.legacy-dag-wal-namespace.v1"
+        or names
+        != [
+            f"wal-{index:08d}.bin"
+            for index in range(inspection["first_segment"], inspection["last_segment"] + 1)
+        ]
+        or not isinstance(tail, list)
+        or len(tail) != inspection["inspected_segment_count"]
+    ):
+        fail(f"{label} namespace inventory differs")
+    normalized_tail: list[dict[str, Any]] = []
+    for index, raw_row in enumerate(tail):
+        row = require_exact_object(
+            raw_row, {"name", "sha256", "size"}, f"{label} inspected tail {index}"
+        )
+        require_hash(row.get("sha256"), f"{label} inspected tail {index} hash")
+        require_uint(row.get("size"), f"{label} inspected tail {index} size")
+        normalized_tail.append(row)
+    if [row["name"] for row in normalized_tail] != names[-len(normalized_tail):]:
+        fail(f"{label} inspected tail does not match the namespace suffix")
+    namespace_preimage = {
+        "schema": namespace["schema"],
+        "segment_names": names,
+        "inspected_tail": normalized_tail,
+    }
+    encoded_namespace = json.dumps(
+        namespace_preimage, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    if sha256_bytes(encoded_namespace) != namespace_sha:
+        fail(f"{label} namespace root is not reproducible")
+    inspection_sha = require_hash(
+        value.get("inspection_sha256"), f"{label} inspection root"
+    )
+    if inspection_sha != sha256_bytes(canonical_bytes(inspection)):
+        fail(f"{label} inspection root is not reproducible")
+    return value
+
+
+def persisted_source_pair(value: Mapping[str, Any], label: str) -> dict[str, Any]:
+    """Project the replay pair identically from active v3/v4 or stopped v2 receipts."""
+
+    if value.get("schema") in {
+        "arc.recovery.persisted-legacy-head.v3",
+        "arc.recovery.persisted-legacy-head.v4",
+    }:
+        raw = {
+            "wal_sha256": value.get("state_wal_sha256"),
+            "wal_size": value.get("state_wal_size"),
+            "snapshot_sha256": value.get("snapshot_sha256"),
+            "snapshot_size": value.get("snapshot_size"),
+        }
+    else:
+        source_inputs = value.get("source_inputs")
+        fixed_wal = (
+            source_inputs.get("fixed_state_wal")
+            if isinstance(source_inputs, dict)
+            else None
+        )
+        fixed_snapshot = (
+            source_inputs.get("fixed_snapshot")
+            if isinstance(source_inputs, dict)
+            else None
+        )
+        raw = {
+            "wal_sha256": fixed_wal.get("sha256") if isinstance(fixed_wal, dict) else None,
+            "wal_size": fixed_wal.get("size") if isinstance(fixed_wal, dict) else None,
+            "snapshot_sha256": (
+                fixed_snapshot.get("sha256") if isinstance(fixed_snapshot, dict) else None
+            ),
+            "snapshot_size": (
+                fixed_snapshot.get("size") if isinstance(fixed_snapshot, dict) else None
+            ),
+        }
+    return {
+        "state_wal": {
+            "sha256": require_hash(raw["wal_sha256"], f"{label} WAL hash"),
+            "size": require_uint(raw["wal_size"], f"{label} WAL size", positive=True),
+        },
+        "snapshot": {
+            "sha256": require_hash(raw["snapshot_sha256"], f"{label} snapshot hash"),
+            "size": require_uint(
+                raw["snapshot_size"], f"{label} snapshot size", positive=True
+            ),
+        },
+    }
+
+
+def select_canonical_source(
+    args: argparse.Namespace | None,
+    evidence_bundle: Mapping[str, Any],
+    inspected: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Select the unique highest captured descendant and bind its replay pair."""
+
+    snapshot_sha: str | None = None
+    snapshot_size: int | None = None
+    wal_sha: str | None = None
+    wal_size: int | None = None
+    if args is not None:
+        snapshot_sha, snapshot_size = hash_secure(
+            args.source_snapshot, "canonical source snapshot"
+        )
+        wal_sha, wal_size = hash_secure(args.source_wal, "canonical source WAL")
+    candidates: list[dict[str, Any]] = []
+    valid_descendants: list[
+        tuple[
+            dict[str, Any], Mapping[str, Any], Mapping[str, Any],
+            tuple[str, int, str, int],
+        ]
+    ] = []
+    raw_nodes = evidence_bundle.get("nodes")
+    if not isinstance(raw_nodes, list) or len(raw_nodes) != len(FLEET):
+        fail("canonical-source selection requires exactly six captured node receipts")
+    for (expected_node, expected_host), row in zip(FLEET, raw_nodes, strict=True):
+        if (
+            not isinstance(row, dict)
+            or row.get("node") != expected_node
+            or row.get("host") != expected_host
+        ):
+            fail("canonical-source captured node receipts are missing or out of order")
+        persisted = require_exact_object(
+            row.get("persisted_head"),
+            {"value", "sha256"},
+            f"{expected_node} canonical-source persisted-head wrapper",
+        )
+        value = persisted.get("value")
+        if not isinstance(value, dict):
+            fail(f"{expected_node} canonical-source persisted-head value is missing")
+        persisted_sha = require_hash(
+            persisted.get("sha256"),
+            f"{expected_node} canonical-source persisted-head root",
+        )
+        if persisted_sha != sha256_bytes(canonical_bytes(value)):
+            fail(f"{expected_node} canonical-source persisted-head wrapper is not sealed")
+        if value.get("schema") not in {
+            "arc.recovery.persisted-legacy-head.v3",
+            "arc.recovery.persisted-legacy-head.v4",
+            quarantine_rounds.PERSISTED_STOPPED_SCHEMA,
+        }:
+            fail(f"{expected_node} canonical-source persisted-head schema is stale")
+        if value.get("node") != expected_node:
+            fail(f"{expected_node} canonical-source persisted-head node differs")
+        source_head = require_exact_object(
+            value.get("head"),
+            {"height", "block_hash", "state_root"},
+            f"{row['node']} canonical-source candidate head",
+        )
+        candidate_height = require_uint(
+            source_head.get("height"), f"{row['node']} candidate height"
+        )
+        candidate_block_hash = require_hash(
+            str(source_head.get("block_hash", "")).removeprefix("0x"),
+            f"{row['node']} candidate block hash",
+        )
+        candidate_state_root = require_hash(
+            str(source_head.get("state_root", "")).removeprefix("0x"),
+            f"{row['node']} candidate state root",
+        )
+        ancestry = require_exact_object(
+            value.get("trusted_anchor_ancestry"),
+            {
+                "anchor_height",
+                "anchor_block_hash",
+                "anchor_state_root",
+                "classification",
+                "inspection",
+                "inspection_sha256",
+            },
+            f"{row['node']} trusted-anchor ancestry",
+        )
+        if (
+            ancestry.get("anchor_height") != TRUSTED_CHECKPOINT_MIN_HEIGHT
+            or ancestry.get("anchor_block_hash")
+            != TRUSTED_CHECKPOINT_ANCHOR_BLOCK_HASH
+            or ancestry.get("anchor_state_root")
+            != TRUSTED_CHECKPOINT_ANCHOR_STATE_ROOT
+        ):
+            fail(f"{row['node']} ancestry proof targets another trusted anchor")
+        ancestry_inspection = ancestry.get("inspection")
+        ancestry_inspection_sha = require_hash(
+            ancestry.get("inspection_sha256"),
+            f"{row['node']} ancestry inspection root",
+        )
+        if ancestry_inspection_sha != sha256_bytes(canonical_bytes(ancestry_inspection)):
+            fail(f"{row['node']} ancestry inspection root differs from its value")
+        classification = ancestry.get("classification")
+        if candidate_height < TRUSTED_CHECKPOINT_MIN_HEIGHT:
+            if classification != "below_trusted_anchor" or ancestry_inspection is not None:
+                fail(f"{row['node']} below-anchor candidate is misclassified")
+        else:
+            if classification not in {"valid_anchor_descendant", "conflicting_anchor"}:
+                fail(
+                    f"{row['node']} captured candidate lacks a conclusive anchor "
+                    "classification"
+                )
+            inspection = require_exact_object(
+                ancestry_inspection,
+                {"schema", "height", "block_hash", "state_root", "input_roots"},
+                f"{row['node']} trusted-anchor inspection",
+            )
+            if (
+                inspection.get("schema")
+                != "arc.recovery.legacy-block-inspection.v1"
+                or inspection.get("height") != TRUSTED_CHECKPOINT_MIN_HEIGHT
+            ):
+                fail(f"{row['node']} trusted-anchor inspection identity differs")
+            inspection_block_hash = require_hash(
+                str(inspection.get("block_hash", "")).removeprefix("0x"),
+                f"{row['node']} inspected anchor block hash",
+            )
+            inspection_state_root = require_hash(
+                str(inspection.get("state_root", "")).removeprefix("0x"),
+                f"{row['node']} inspected anchor state root",
+            )
+            input_roots = require_exact_object(
+                inspection.get("input_roots"),
+                {"data_dir", "state_wal", "snapshot", "genesis", "legacy_validator_set"},
+                f"{row['node']} trusted-anchor inspection input roots",
+            )
+            directory_root = require_exact_object(
+                input_roots.get("data_dir"),
+                {"device", "inode", "mode", "uid", "gid", "nlink", "mtime_ns", "ctime_ns"},
+                f"{row['node']} trusted-anchor data-directory identity",
+            )
+            for field in directory_root:
+                require_uint(
+                    directory_root.get(field),
+                    f"{row['node']} trusted-anchor data-directory {field}",
+                )
+            file_roots: dict[str, Mapping[str, Any]] = {}
+            for root_name in ("state_wal", "snapshot", "genesis", "legacy_validator_set"):
+                file_root = require_exact_object(
+                    input_roots.get(root_name),
+                    {
+                        "device", "inode", "mode", "uid", "gid", "nlink",
+                        "sha256", "size", "mtime_ns", "ctime_ns",
+                    },
+                    f"{row['node']} trusted-anchor {root_name} identity",
+                )
+                for field in (
+                    "device", "inode", "mode", "uid", "gid", "nlink", "size",
+                    "mtime_ns", "ctime_ns",
+                ):
+                    require_uint(
+                        file_root.get(field),
+                        f"{row['node']} trusted-anchor {root_name} {field}",
+                    )
+                require_hash(
+                    file_root.get("sha256"),
+                    f"{row['node']} trusted-anchor {root_name} hash",
+                )
+                file_roots[root_name] = file_root
+
+            if value.get("schema") in {
+                "arc.recovery.persisted-legacy-head.v3",
+                "arc.recovery.persisted-legacy-head.v4",
+            }:
+                staged_contract = value["staged_file_contract"]
+                expected_hashes = {
+                    "state_wal": value["state_wal_sha256"],
+                    "snapshot": value["snapshot_sha256"],
+                    "genesis": value["genesis_sha256"],
+                    "legacy_validator_set": value["legacy_validator_set_sha256"],
+                }
+                for root_name, expected_hash in expected_hashes.items():
+                    if file_roots[root_name]["sha256"] != expected_hash:
+                        fail(
+                            f"{row['node']} trusted-anchor {root_name} input is not "
+                            "the persisted source pair"
+                        )
+                for root_name in ("state_wal", "snapshot"):
+                    staged = staged_contract[root_name]
+                    if any(
+                        file_roots[root_name][field] != staged[field]
+                        for field in ("sha256", "size", "mode", "uid", "gid", "nlink")
+                    ):
+                        fail(
+                            f"{row['node']} trusted-anchor {root_name} identity differs "
+                            "from the staged persisted source pair"
+                        )
+            else:
+                source_inputs = value.get("source_inputs")
+                staged_inputs = value.get("staged_inputs")
+                if not isinstance(source_inputs, dict) or not isinstance(staged_inputs, dict):
+                    fail(f"{row['node']} stopped persisted source inputs are missing")
+                expected_inputs = {
+                    "data_dir": source_inputs.get("fixed_data_dir"),
+                    "state_wal": source_inputs.get("fixed_state_wal"),
+                    "snapshot": source_inputs.get("fixed_snapshot"),
+                    "genesis": staged_inputs.get("genesis"),
+                    "legacy_validator_set": staged_inputs.get("legacy_validator_set"),
+                }
+                if any(
+                    not isinstance(expected, dict) or input_roots[name] != expected
+                    for name, expected in expected_inputs.items()
+                ):
+                    fail(
+                        f"{row['node']} trusted-anchor inputs differ from the "
+                        "stopped persisted source pair"
+                    )
+            anchor_matches = (
+                inspection_block_hash == TRUSTED_CHECKPOINT_ANCHOR_BLOCK_HASH
+                and inspection_state_root == TRUSTED_CHECKPOINT_ANCHOR_STATE_ROOT
+            )
+            if (classification == "valid_anchor_descendant") is not anchor_matches:
+                fail(f"{row['node']} trusted-anchor classification differs")
+        candidate = {
+            "node": row["node"],
+            "persisted_head_schema": value.get("schema"),
+            "persisted_head_sha256": persisted["sha256"],
+            "source_height": candidate_height,
+            "source_block_hash": candidate_block_hash,
+            "source_state_root": candidate_state_root,
+            "classification": classification,
+            "anchor_inspection_sha256": ancestry_inspection_sha,
+        }
+        candidates.append(candidate)
+        pair_projection = persisted_source_pair(
+            value, f"{row['node']} selected-pair"
+        )
+        pair = (
+            pair_projection["state_wal"]["sha256"],
+            pair_projection["state_wal"]["size"],
+            pair_projection["snapshot"]["sha256"],
+            pair_projection["snapshot"]["size"],
+        )
+        legacy_dag_round = validate_embedded_legacy_dag_round(
+            value.get("legacy_dag_round"),
+            f"{row['node']} canonical-source legacy DAG round",
+        )
+        if classification == "valid_anchor_descendant":
+            valid_descendants.append((candidate, persisted, value, pair))
+    if not valid_descendants:
+        fail("captured fleet has no valid descendant of the trusted recovery anchor")
+    maximum_height = max(candidate[0]["source_height"] for candidate in valid_descendants)
+    maximal = [
+        candidate
+        for candidate in valid_descendants
+        if candidate[0]["source_height"] == maximum_height
+    ]
+    maximal_tuples = {
+        (
+            candidate[0]["source_height"],
+            candidate[0]["source_block_hash"],
+            candidate[0]["source_state_root"],
+        )
+        for candidate in maximal
+    }
+    if len(maximal_tuples) != 1:
+        fail("highest valid anchor descendants disagree on their canonical tuple")
+    selected_candidate, persisted, value, selected_pair = maximal[0]
+    selected_wal_sha, selected_wal_size, selected_snapshot_sha, selected_snapshot_size = (
+        selected_pair
+    )
+    if args is not None and (
+        wal_sha != selected_wal_sha
+        or wal_size != selected_wal_size
+        or snapshot_sha != selected_snapshot_sha
+        or snapshot_size != selected_snapshot_size
+    ):
+        fail("supplied replay pair is not the deterministic highest valid anchor descendant")
+    head = value["head"]
+    legacy_dag_round = value["legacy_dag_round"]
+    if inspected is not None:
+        if (
+            head["height"] != inspected["source_height"]
+            or head["block_hash"].removeprefix("0x")
+            != str(inspected["source_block_hash"]).removeprefix("0x")
+            or head["state_root"].removeprefix("0x")
+            != str(inspected["source_state_root"]).removeprefix("0x")
+            or legacy_dag_round["source_consensus_round"]
+            != inspected["source_consensus_round"]
+        ):
+            fail(
+                "signed checkpoint source tuple/round differs from its captured "
+                "persisted head"
+            )
+    elif args is not None:
+        fail("canonical-source selection received source bytes without a checkpoint")
+    canonical_source = {
+        "node": selected_candidate["node"],
+        "source_height": selected_candidate["source_height"],
+        "source_block_hash": selected_candidate["source_block_hash"],
+        "source_state_root": selected_candidate["source_state_root"],
+        "source_consensus_round": legacy_dag_round["source_consensus_round"],
+        "snapshot_sha256": selected_snapshot_sha,
+        "wal_sha256": selected_wal_sha,
+        "persisted_head_sha256": persisted["sha256"],
+        "legacy_dag_round_inspection_sha256": legacy_dag_round[
+            "inspection_sha256"
+        ],
+        "legacy_dag_wal_namespace_sha256": legacy_dag_round["namespace_sha256"],
+    }
+    selection = {
+        "schema": "arc.recovery.canonical-source-selection.v1",
+        "selection_rule": "highest-valid-anchor-descendant-tuple",
+        "equivalent_maximal_pair_rule": (
+            "first-production-fleet-node-with-matching-source-pair"
+        ),
+        "trusted_anchor": {
+            "height": TRUSTED_CHECKPOINT_MIN_HEIGHT,
+            "block_hash": TRUSTED_CHECKPOINT_ANCHOR_BLOCK_HASH,
+            "state_root": TRUSTED_CHECKPOINT_ANCHOR_STATE_ROOT,
+        },
+        "candidates": candidates,
+        "selected": {
+            "node": selected_candidate["node"],
+            "source_height": selected_candidate["source_height"],
+            "source_block_hash": selected_candidate["source_block_hash"],
+            "source_state_root": selected_candidate["source_state_root"],
+            "persisted_head_sha256": selected_candidate["persisted_head_sha256"],
+        },
+    }
+    return canonical_source, {
+        "value": selection,
+        "sha256": sha256_bytes(canonical_bytes(selection)),
+    }
+
+
+def select_source(args: argparse.Namespace) -> str:
+    """Seal the pre-sign canonical source decision from full maintenance evidence."""
+
+    validate_protected_main_commit(args.source_main_sha)
+    freeze, _freeze_payload, freeze_sha, _freeze_sidecar_sha, _freeze_sidecar = (
+        validate_freeze_inputs(args)
+    )
+    (
+        height_receipt,
+        _prequarantine_public_max_height,
+        height_receipt_sha,
+        _height_receipt_payload,
+    ) = load_intrinsic_legacy_public_height_receipt(args, freeze_sha=freeze_sha)
+    (
+        evidence_bundle_sha,
+        _evidence_bundle_size,
+        evidence_bundle,
+        _evidence_bundle_payload,
+        _evidence_bundle_sidecar,
+    ) = validate_legacy_maintenance_evidence_bundle(
+        args,
+        freeze,
+        freeze_sha,
+        height_receipt,
+        height_receipt_sha,
+    )
+    (
+        boundary_sha,
+        _boundary_size,
+        boundary,
+        _boundary_payload,
+        _boundary_sidecar,
+    ) = validate_legacy_maintenance_boundary(
+        args,
+        freeze,
+        freeze_sha,
+        height_receipt,
+        height_receipt_sha,
+        evidence_bundle,
+        evidence_bundle_sha,
+    )
+    canonical_source, selection = select_canonical_source(None, evidence_bundle, None)
+    source_height = canonical_source["source_height"]
+    observed_cutoff_height = boundary["observed_cutoff_height"]
+    reopening_floor_height = boundary["legacy_public_max_height"]
+    if (
+        source_height < TRUSTED_CHECKPOINT_MIN_HEIGHT
+        or observed_cutoff_height < source_height
+        or reopening_floor_height
+        != observed_cutoff_height + rollout.LEGACY_CONTINUITY_SAFETY_MARGIN
+    ):
+        fail("pre-sign source selection violates H<=C and F=C+128")
+    selected_rows = [
+        row
+        for row in evidence_bundle["nodes"]
+        if row.get("node") == canonical_source["node"]
+    ]
+    if len(selected_rows) != 1:
+        fail("pre-sign source selection does not identify one captured node")
+    persisted_wrapper = selected_rows[0]["persisted_head"]
+    pair = persisted_source_pair(
+        persisted_wrapper["value"], "pre-sign selected source pair"
+    )
+    receipt = {
+        "schema": "arc.recovery.canonical-source-preselection.v1",
+        "source_main_commit": args.source_main_sha,
+        "freeze_plan_sha256": freeze_sha,
+        "legacy_maintenance_evidence_bundle_sha256": evidence_bundle_sha,
+        "legacy_maintenance_boundary_sha256": boundary_sha,
+        "source_height": source_height,
+        "transition_height": source_height + 1,
+        "source_block_hash": canonical_source["source_block_hash"],
+        "source_state_root": canonical_source["source_state_root"],
+        "source_consensus_round": canonical_source["source_consensus_round"],
+        "observed_cutoff_height": observed_cutoff_height,
+        "reopening_floor_height": reopening_floor_height,
+        "selected_source_pair": {
+            "node": canonical_source["node"],
+            "persisted_head_schema": persisted_wrapper["value"]["schema"],
+            "persisted_head_sha256": persisted_wrapper["sha256"],
+            "state_wal": pair["state_wal"],
+            "snapshot": pair["snapshot"],
+        },
+        "canonical_source": canonical_source,
+        "canonical_source_selection": selection,
+    }
+    return create_private_seal(args.output, receipt)
+
+
+def validate_source_preselection(
+    path: Path,
+    *,
+    source_main_sha: str,
+    freeze_sha: str,
+    evidence_bundle_sha: str,
+    boundary_sha: str,
+    evidence_bundle: Mapping[str, Any],
+    canonical_source: Mapping[str, Any],
+    canonical_source_selection: Mapping[str, Any],
+) -> tuple[dict[str, Any], str]:
+    value, _payload, digest = load_canonical_json(
+        path,
+        label="canonical-source preselection",
+        maximum_bytes=4 * 1024 * 1024,
+        exact_mode=0o400,
+        require_read_only=True,
+    )
+    sidecar, _details = read_secure(
+        path.with_name(path.name + ".sha256"),
+        label="canonical-source preselection checksum",
+        maximum_bytes=512,
+        exact_mode=0o400,
+        require_read_only=True,
+    )
+    if sidecar != f"{digest}  {path.name}\n".encode("ascii"):
+        fail("canonical-source preselection checksum differs")
+    value = require_exact_object(
+        value,
+        {
+            "schema", "source_main_commit", "freeze_plan_sha256",
+            "legacy_maintenance_evidence_bundle_sha256",
+            "legacy_maintenance_boundary_sha256", "source_height",
+            "transition_height", "source_block_hash", "source_state_root",
+            "source_consensus_round", "observed_cutoff_height",
+            "reopening_floor_height", "selected_source_pair",
+            "canonical_source", "canonical_source_selection",
+        },
+        "canonical-source preselection",
+    )
+    expected_scalars = {
+        "schema": "arc.recovery.canonical-source-preselection.v1",
+        "source_main_commit": source_main_sha,
+        "freeze_plan_sha256": freeze_sha,
+        "legacy_maintenance_evidence_bundle_sha256": evidence_bundle_sha,
+        "legacy_maintenance_boundary_sha256": boundary_sha,
+        "source_height": canonical_source["source_height"],
+        "transition_height": canonical_source["source_height"] + 1,
+        "source_block_hash": canonical_source["source_block_hash"],
+        "source_state_root": canonical_source["source_state_root"],
+        "source_consensus_round": canonical_source["source_consensus_round"],
+    }
+    if any(value.get(field) != expected for field, expected in expected_scalars.items()):
+        fail("canonical-source preselection differs from the revalidated capture")
+    if (
+        value.get("canonical_source") != canonical_source
+        or value.get("canonical_source_selection") != canonical_source_selection
+    ):
+        fail("canonical-source preselection proof differs from fresh selection")
+    pair = require_exact_object(
+        value.get("selected_source_pair"),
+        {"node", "persisted_head_schema", "persisted_head_sha256", "state_wal", "snapshot"},
+        "canonical-source preselection selected pair",
+    )
+    if (
+        pair.get("node") != canonical_source["node"]
+        or pair.get("persisted_head_sha256")
+        != canonical_source["persisted_head_sha256"]
+    ):
+        fail("canonical-source preselection selected pair differs")
+    selected_evidence = [
+        row
+        for row in evidence_bundle.get("nodes", [])
+        if isinstance(row, dict) and row.get("node") == canonical_source["node"]
+    ]
+    if len(selected_evidence) != 1:
+        fail("canonical-source preselection selected receipt is ambiguous")
+    persisted_wrapper = selected_evidence[0].get("persisted_head")
+    if not isinstance(persisted_wrapper, dict) or not isinstance(
+        persisted_wrapper.get("value"), dict
+    ):
+        fail("canonical-source preselection selected receipt is missing")
+    expected_pair = persisted_source_pair(
+        persisted_wrapper["value"], "canonical-source preselection fresh selected pair"
+    )
+    if (
+        pair.get("persisted_head_schema") != persisted_wrapper["value"].get("schema")
+        or pair.get("persisted_head_sha256") != persisted_wrapper.get("sha256")
+    ):
+        fail("canonical-source preselection selected receipt identity differs")
+    for field in ("state_wal", "snapshot"):
+        item = require_exact_object(
+            pair.get(field), {"sha256", "size"}, f"canonical-source {field}"
+        )
+        require_hash(item.get("sha256"), f"canonical-source {field} hash")
+        require_uint(item.get("size"), f"canonical-source {field} size", positive=True)
+    if (
+        pair["state_wal"] != expected_pair["state_wal"]
+        or pair["snapshot"] != expected_pair["snapshot"]
+        or pair["state_wal"]["sha256"] != canonical_source["wal_sha256"]
+        or pair["snapshot"]["sha256"] != canonical_source["snapshot_sha256"]
+    ):
+        fail("canonical-source preselection pair roots differ")
+    return value, digest
+
+
+def inspect_trusted_anchor(
+    args: argparse.Namespace,
+    canonical_source: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Replay and seal the historical anchor independently of selected H."""
+
+    binary_sha, _binary_size = hash_secure(
+        args.binary, "trusted-anchor inspector binary", executable=True
+    )
+    genesis_sha, _genesis_size = hash_secure(args.genesis, "trusted-anchor genesis")
+    legacy_sha, _legacy_size = hash_secure(
+        args.legacy_validator_set, "trusted-anchor legacy validator set"
+    )
+    observed = run_exact_binary(
+        args.binary,
+        [
+            "recovery",
+            "inspect-legacy-block",
+            "--data-dir",
+            os.fspath(args.source_wal.parent),
+            "--snapshot",
+            os.fspath(args.source_snapshot),
+            "--genesis",
+            os.fspath(args.genesis),
+            "--legacy-validator-set",
+            os.fspath(args.legacy_validator_set),
+            "--height",
+            str(TRUSTED_CHECKPOINT_MIN_HEIGHT),
+            "--expected-state-wal-sha256",
+            canonical_source["wal_sha256"],
+            "--expected-snapshot-sha256",
+            canonical_source["snapshot_sha256"],
+            "--expected-genesis-sha256",
+            genesis_sha,
+            "--expected-legacy-validator-set-sha256",
+            legacy_sha,
+            "--allow-unbound-legacy-wal",
+        ],
+        "trusted-anchor legacy block inspection",
+        timeout=3600,
+    )
+    expected_fields = {"schema", "height", "block_hash", "state_root", "input_roots"}
+    if set(observed) != expected_fields:
+        fail("trusted-anchor inspection fields differ")
+    roots = require_exact_object(
+        observed["input_roots"],
+        {"data_dir", "state_wal", "snapshot", "genesis", "legacy_validator_set"},
+        "trusted-anchor inspection input roots",
+    )
+    expected_roots = {
+        "state_wal": canonical_source["wal_sha256"],
+        "snapshot": canonical_source["snapshot_sha256"],
+        "genesis": genesis_sha,
+        "legacy_validator_set": legacy_sha,
+    }
+    if any(
+        not isinstance(roots[name], dict) or roots[name].get("sha256") != expected
+        for name, expected in expected_roots.items()
+    ):
+        fail("trusted-anchor inspection input hashes differ from the selected pair")
+    if (
+        observed["schema"] != "arc.recovery.legacy-block-inspection.v1"
+        or observed["height"] != TRUSTED_CHECKPOINT_MIN_HEIGHT
+        or observed["block_hash"].removeprefix("0x")
+        != TRUSTED_CHECKPOINT_ANCHOR_BLOCK_HASH
+        or observed["state_root"].removeprefix("0x")
+        != TRUSTED_CHECKPOINT_ANCHOR_STATE_ROOT
+    ):
+        fail("trusted-anchor inspection does not reproduce block 137145")
+    return {
+        "schema": "arc.recovery.trusted-anchor-proof.v1",
+        "height": TRUSTED_CHECKPOINT_MIN_HEIGHT,
+        "block_hash": TRUSTED_CHECKPOINT_ANCHOR_BLOCK_HASH,
+        "state_root": TRUSTED_CHECKPOINT_ANCHOR_STATE_ROOT,
+        "inspection_sha256": sha256_bytes(canonical_bytes(observed)),
+        "inspector_binary_sha256": binary_sha,
+        "source_snapshot_sha256": canonical_source["snapshot_sha256"],
+        "source_wal_sha256": canonical_source["wal_sha256"],
+        "genesis_sha256": genesis_sha,
+        "legacy_validator_set_sha256": legacy_sha,
+    }
 
 
 def reproduce_checkpoint(args: argparse.Namespace, inspected: dict[str, Any]) -> None:
@@ -5472,6 +6260,9 @@ def chain_from_checkpoint(
     boundary_sha: str,
     evidence_bundle_sha: str,
     late_fork_source_set_sha: str,
+    canonical_source: Mapping[str, Any],
+    canonical_source_selection: Mapping[str, Any],
+    trusted_anchor: Mapping[str, Any],
 ) -> dict[str, Any]:
     return {
         "chain_id": inspected["chain_id"],
@@ -5480,6 +6271,9 @@ def chain_from_checkpoint(
         "recovery_epoch": inspected["recovery_epoch"],
         "validator_set_id": inspected["validator_set_id"],
         "source_height": inspected["source_height"],
+        "canonical_source": copy.deepcopy(canonical_source),
+        "canonical_source_selection": copy.deepcopy(canonical_source_selection),
+        "trusted_anchor": copy.deepcopy(trusted_anchor),
         "legacy_maintenance_evidence_bundle_sha256": evidence_bundle_sha,
         "legacy_maintenance_boundary_sha256": boundary_sha,
         "legacy_late_fork_source_set_sha256": late_fork_source_set_sha,
@@ -5766,12 +6560,51 @@ def prearchive(args: argparse.Namespace) -> str:
     if metadata_sha != hash_secure(args.build_metadata, "pre-tag build metadata")[0]:
         fail("pre-tag build metadata changed after validation")
     inspected = inspect_signed_checkpoint(args)
-    if prequarantine_public_max_height < inspected["source_height"]:
-        fail("legacy public-height receipt is below the selected checkpoint height")
-    if maintenance_boundary["observed_cutoff_height"] < prequarantine_public_max_height:
-        fail("legacy maintenance cutoff is below a pre-quarantine public observation")
-    if genesis_info["activation_height"] != inspected["transition_height"]:
-        fail("genesis community reward activation is not the checkpoint H+1 transition")
+    source_height = inspected["source_height"]
+    transition_height = inspected["transition_height"]
+    if source_height < TRUSTED_CHECKPOINT_MIN_HEIGHT:
+        fail("signed checkpoint source height is below trusted anchor 137145")
+    if transition_height != source_height + 1:
+        fail("signed checkpoint transition height is not capture-derived H+1")
+    if (
+        maintenance_boundary["observed_cutoff_height"]
+        < source_height
+        or maintenance_boundary["legacy_public_max_height"]
+        != maintenance_boundary["observed_cutoff_height"]
+        + rollout.LEGACY_CONTINUITY_SAFETY_MARGIN
+    ):
+        fail(
+            "legacy maintenance boundary is below capture-derived checkpoint H "
+            "or does not bind reopening floor F=cutoff+128"
+        )
+    if (
+        genesis_info["activation_height"]
+        != inspected["community_rewards_v1_activation_height"]
+        or genesis_info["activation_height"] > transition_height
+    ):
+        fail("genesis community reward activation differs from or follows after H+1")
+
+    canonical_source, canonical_source_selection = select_canonical_source(
+        args, maintenance_evidence_bundle, inspected
+    )
+    source_preselection, source_preselection_sha = validate_source_preselection(
+        args.canonical_source_preselection,
+        source_main_sha=args.source_main_sha,
+        freeze_sha=freeze_sha,
+        evidence_bundle_sha=evidence_bundle_sha,
+        boundary_sha=boundary_sha,
+        evidence_bundle=maintenance_evidence_bundle,
+        canonical_source=canonical_source,
+        canonical_source_selection=canonical_source_selection,
+    )
+    if (
+        source_preselection["observed_cutoff_height"]
+        != maintenance_boundary["observed_cutoff_height"]
+        or source_preselection["reopening_floor_height"]
+        != maintenance_boundary["legacy_public_max_height"]
+    ):
+        fail("canonical-source preselection differs from the maintenance boundary")
+    trusted_anchor = inspect_trusted_anchor(args, canonical_source)
     reproduce_checkpoint(args, inspected)
 
     artifacts = {
@@ -5809,6 +6642,16 @@ def prearchive(args: argparse.Namespace) -> str:
                 args.legacy_maintenance_evidence_bundle.name + ".sha256"
             ),
             "legacy maintenance evidence bundle sidecar",
+        ),
+        "canonical_source_preselection": {
+            "path": os.fspath(args.canonical_source_preselection),
+            "sha256": source_preselection_sha,
+        },
+        "canonical_source_preselection_sidecar": artifact(
+            args.canonical_source_preselection.with_name(
+                args.canonical_source_preselection.name + ".sha256"
+            ),
+            "canonical-source preselection sidecar",
         ),
         "legacy_maintenance_boundary": {
             "path": os.fspath(args.legacy_maintenance_boundary),
@@ -5949,6 +6792,9 @@ def prearchive(args: argparse.Namespace) -> str:
             boundary_sha,
             evidence_bundle_sha,
             late_fork_source_set_sha,
+            canonical_source,
+            canonical_source_selection,
+            trusted_anchor,
         ),
         "artifacts": artifacts,
         "checks": {
@@ -6751,6 +7597,16 @@ def validate_archive_evidence(
             "legacy_maintenance_evidence_bundle_sidecar",
             "legacy-maintenance-evidence-bundle.json.sha256",
         ),
+        "canonical-source-preselection.json": _expected_artifact_object(
+            prearchive,
+            "canonical_source_preselection",
+            "canonical-source-preselection.json",
+        ),
+        "canonical-source-preselection.json.sha256": _expected_artifact_object(
+            prearchive,
+            "canonical_source_preselection_sidecar",
+            "canonical-source-preselection.json.sha256",
+        ),
         "legacy-maintenance-boundary.json": _expected_artifact_object(
             prearchive,
             "legacy_maintenance_boundary",
@@ -7153,6 +8009,24 @@ def absolute_path(value: str) -> Path:
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     commands = result.add_subparsers(dest="command", required=True)
+    select = commands.add_parser(
+        "select-source",
+        help="validate stopped fleet evidence and seal the canonical source before signing",
+    )
+    select.add_argument("--source-main-sha", required=True)
+    select.add_argument("--freeze-plan", required=True, type=absolute_path)
+    select.add_argument("--freeze-plan-sha256", required=True)
+    select.add_argument("--legacy-public-height-receipt", required=True, type=absolute_path)
+    select.add_argument(
+        "--legacy-maintenance-evidence-bundle", required=True, type=absolute_path
+    )
+    select.add_argument("--legacy-maintenance-boundary", required=True, type=absolute_path)
+    select.add_argument("--binary", required=True, type=absolute_path)
+    select.add_argument("--genesis", required=True, type=absolute_path)
+    select.add_argument("--validator-public-keys", required=True, type=absolute_path)
+    select.add_argument("--legacy-validator-set", required=True, type=absolute_path)
+    select.add_argument("--output", required=True, type=absolute_path)
+
     prepare = commands.add_parser("prearchive", help="derive and seal the prearchive rollout")
     prepare.add_argument("--source-main-sha", required=True)
     prepare.add_argument("--pretag-run-id", required=True, type=int)
@@ -7166,6 +8040,7 @@ def parser() -> argparse.ArgumentParser:
     prepare.add_argument("--freeze-plan-sha256", required=True)
     prepare.add_argument("--legacy-public-height-receipt", required=True, type=absolute_path)
     prepare.add_argument("--legacy-maintenance-evidence-bundle", required=True, type=absolute_path)
+    prepare.add_argument("--canonical-source-preselection", required=True, type=absolute_path)
     prepare.add_argument("--legacy-maintenance-boundary", required=True, type=absolute_path)
     prepare.add_argument("--legacy-late-fork-source-set", required=True, type=absolute_path)
     prepare.add_argument("--offline-stop-evidence", required=True, type=absolute_path)
@@ -7229,7 +8104,21 @@ def parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = parser().parse_args(argv)
     try:
-        if args.command == "prearchive":
+        if args.command == "select-source":
+            digest = select_source(args)
+            print(
+                json.dumps(
+                    {
+                        "schema": "arc.recovery.production-manifest-build.v1",
+                        "phase": "select-source",
+                        "selection_sha256": digest,
+                        "output": os.fspath(args.output),
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            )
+        elif args.command == "prearchive":
             digest = prearchive(args)
             print(
                 json.dumps(

--- a/scripts/recovery/owner-emergency-recovery.py
+++ b/scripts/recovery/owner-emergency-recovery.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Any, NoReturn, Sequence
 
 
-RECEIPT_SCHEMA = "arc.recovery.owner-emergency-recovery.v2"
+RECEIPT_SCHEMA = "arc.recovery.owner-emergency-recovery.v3"
 REPOSITORY = "FerrumVir/arc-chain"
 PROTECTED_BRANCH = "main"
 WORKFLOW_PATH = ".github/workflows/owner-emergency-recovery-approval.yml"
@@ -44,19 +44,21 @@ REASON = (
 )
 RISK_ACKNOWLEDGEMENT = (
     "I authorize five reviewed ARC validator identities to sign the recovery "
-    "checkpoint rooted at preserved source block 137145 and transition block "
-    "137146. I understand that the six legacy forks remain preserved read-only, "
-    "that rollback cannot rewrite signed history, and that this receipt does not "
-    "represent approval by six independent humans."
+    "checkpoint rooted at the capture-derived preserved source block and its "
+    "immediate successor transition. I understand that the six legacy forks "
+    "remain preserved read-only, that rollback cannot rewrite signed history, "
+    "and that this receipt does not represent approval by six independent humans."
 )
-SOURCE_HEIGHT = 137_145
-TRANSITION_HEIGHT = 137_146
+TRUSTED_ANCHOR_HEIGHT = 137_145
+COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT = 137_146
+CONTINUITY_SAFETY_MARGIN = 128
 RECOVERY_EPOCH = 1
 VALIDATOR_SET_ID = 1
 SIGNATURES_REQUIRED = 5
 TOTAL_STAKE = 40_000_000
 MINIMUM_SIGNED_STAKE = TOTAL_STAKE * 2 // 3 + 1
 MAX_JSON_BYTES = 256 * 1024
+MAX_SAFE_JSON_INTEGER = 9_007_199_254_740_991
 DEFAULT_MAX_AGE_SECONDS = 900
 FUTURE_TOLERANCE_SECONDS = 30
 HASH_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -171,6 +173,13 @@ def require_commit(value: object, label: str) -> str:
 def require_positive_int(value: object, label: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         fail(f"{label} must be a positive integer")
+    return value
+
+
+def require_safe_positive_int(value: object, label: str) -> int:
+    value = require_positive_int(value, label)
+    if value > MAX_SAFE_JSON_INTEGER:
+        fail(f"{label} exceeds the exact JSON integer bound")
     return value
 
 
@@ -486,6 +495,14 @@ def scope_value(
     source_main_sha: str,
     checkpoint_manifest_hash: str,
     validator_public_keys_sha256: str,
+    source_height: int,
+    transition_height: int,
+    source_block_hash: str,
+    source_state_root: str,
+    source_consensus_round: int,
+    observed_cutoff_height: int,
+    reopening_floor_height: int,
+    legacy_maintenance_boundary_sha256: str,
 ) -> dict[str, Any]:
     return {
         "checkpoint_manifest_hash": require_checkpoint_hash(
@@ -494,9 +511,26 @@ def scope_value(
         "protected_branch": PROTECTED_BRANCH,
         "recovery_epoch": RECOVERY_EPOCH,
         "repository": REPOSITORY,
-        "source_height": SOURCE_HEIGHT,
+        "source_block_hash": require_hash(source_block_hash, "source block hash"),
+        "source_consensus_round": require_safe_positive_int(
+            source_consensus_round, "source consensus round"
+        ),
+        "source_height": require_safe_positive_int(source_height, "source height"),
         "source_main_sha": require_commit(source_main_sha, "protected-main commit"),
-        "transition_height": TRANSITION_HEIGHT,
+        "source_state_root": require_hash(source_state_root, "source state root"),
+        "transition_height": require_safe_positive_int(
+            transition_height, "transition height"
+        ),
+        "observed_cutoff_height": require_safe_positive_int(
+            observed_cutoff_height, "observed cutoff height"
+        ),
+        "reopening_floor_height": require_safe_positive_int(
+            reopening_floor_height, "reopening floor height"
+        ),
+        "legacy_maintenance_boundary_sha256": require_hash(
+            legacy_maintenance_boundary_sha256,
+            "legacy maintenance boundary SHA-256",
+        ),
         "validator_public_keys_sha256": require_hash(
             validator_public_keys_sha256, "validator public-key manifest SHA-256"
         ),
@@ -512,9 +546,15 @@ def validate_scope(value: object) -> dict[str, Any]:
             "protected_branch",
             "recovery_epoch",
             "repository",
+            "source_block_hash",
+            "source_consensus_round",
             "source_height",
             "source_main_sha",
+            "source_state_root",
             "transition_height",
+            "observed_cutoff_height",
+            "reopening_floor_height",
+            "legacy_maintenance_boundary_sha256",
             "validator_public_keys_sha256",
             "validator_set_id",
         },
@@ -523,12 +563,41 @@ def validate_scope(value: object) -> dict[str, Any]:
     if (
         scope["repository"] != REPOSITORY
         or scope["protected_branch"] != PROTECTED_BRANCH
-        or scope["source_height"] != SOURCE_HEIGHT
-        or scope["transition_height"] != TRANSITION_HEIGHT
         or scope["recovery_epoch"] != RECOVERY_EPOCH
         or scope["validator_set_id"] != VALIDATOR_SET_ID
     ):
         fail("authorization scope differs from the reviewed ARC v0.8 recovery boundary")
+    source_height = require_safe_positive_int(
+        scope["source_height"], "authorization source height"
+    )
+    transition_height = require_safe_positive_int(
+        scope["transition_height"], "authorization transition height"
+    )
+    observed_cutoff_height = require_safe_positive_int(
+        scope["observed_cutoff_height"], "authorization observed cutoff height"
+    )
+    reopening_floor_height = require_safe_positive_int(
+        scope["reopening_floor_height"], "authorization reopening floor height"
+    )
+    if source_height < TRUSTED_ANCHOR_HEIGHT:
+        fail("authorization source height is below the reviewed history anchor")
+    if transition_height != source_height + 1:
+        fail("authorization transition height must equal source height plus one")
+    if source_height > observed_cutoff_height:
+        fail("authorization source height exceeds the maximum observed legacy cutoff")
+    if reopening_floor_height != observed_cutoff_height + CONTINUITY_SAFETY_MARGIN:
+        fail("authorization reopening floor must equal observed cutoff plus 128")
+    if COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT > transition_height:
+        fail("community rewards activation cannot follow the recovery transition")
+    require_hash(scope["source_block_hash"], "authorization source block hash")
+    require_hash(scope["source_state_root"], "authorization source state root")
+    require_safe_positive_int(
+        scope["source_consensus_round"], "authorization source consensus round"
+    )
+    require_hash(
+        scope["legacy_maintenance_boundary_sha256"],
+        "authorization legacy maintenance boundary SHA-256",
+    )
     require_commit(scope["source_main_sha"], "authorization protected-main commit")
     normalized_checkpoint = require_checkpoint_hash(
         scope["checkpoint_manifest_hash"], "authorization checkpoint hash"
@@ -768,6 +837,14 @@ def verify_github_artifact(args: argparse.Namespace) -> str:
         args.source_main_sha,
         args.checkpoint_manifest_hash,
         args.validator_public_keys_sha256,
+        args.source_height,
+        args.transition_height,
+        args.source_block_hash,
+        args.source_state_root,
+        args.source_consensus_round,
+        args.observed_cutoff_height,
+        args.reopening_floor_height,
+        args.legacy_maintenance_boundary_sha256,
     )
     if receipt["scope"] != expected_scope:
         fail("owner emergency-recovery receipt does not authorize these exact signing inputs")
@@ -838,6 +915,14 @@ def parser() -> argparse.ArgumentParser:
     verifier.add_argument("--artifact-digest", required=True)
     verifier.add_argument("--source-main-sha", required=True)
     verifier.add_argument("--checkpoint-manifest-hash", required=True)
+    verifier.add_argument("--source-height", required=True, type=int)
+    verifier.add_argument("--transition-height", required=True, type=int)
+    verifier.add_argument("--source-block-hash", required=True)
+    verifier.add_argument("--source-state-root", required=True)
+    verifier.add_argument("--source-consensus-round", required=True, type=int)
+    verifier.add_argument("--observed-cutoff-height", required=True, type=int)
+    verifier.add_argument("--reopening-floor-height", required=True, type=int)
+    verifier.add_argument("--legacy-maintenance-boundary-sha256", required=True)
     verifier.add_argument("--validator-public-keys", required=True, type=Path)
     verifier.add_argument("--validator-public-keys-sha256", required=True)
     verifier.add_argument("--output", required=True, type=Path)

--- a/scripts/recovery/owner-emergency-recovery.schema.json
+++ b/scripts/recovery/owner-emergency-recovery.schema.json
@@ -13,7 +13,7 @@
   ],
   "properties": {
     "schema": {
-      "const": "arc.recovery.owner-emergency-recovery.v2"
+      "const": "arc.recovery.owner-emergency-recovery.v3"
     },
     "decision": {
       "type": "object",
@@ -64,7 +64,7 @@
           "const": "legacy_fleet_divergence_history_preserving_v080_cutover"
         },
         "risk_acknowledgement": {
-          "const": "I authorize five reviewed ARC validator identities to sign the recovery checkpoint rooted at preserved source block 137145 and transition block 137146. I understand that the six legacy forks remain preserved read-only, that rollback cannot rewrite signed history, and that this receipt does not represent approval by six independent humans."
+          "const": "I authorize five reviewed ARC validator identities to sign the recovery checkpoint rooted at the capture-derived preserved source block and its immediate successor transition. I understand that the six legacy forks remain preserved read-only, that rollback cannot rewrite signed history, and that this receipt does not represent approval by six independent humans."
         }
       }
     },
@@ -122,9 +122,15 @@
         "protected_branch",
         "recovery_epoch",
         "repository",
+        "source_block_hash",
+        "source_consensus_round",
         "source_height",
         "source_main_sha",
+        "source_state_root",
         "transition_height",
+        "observed_cutoff_height",
+        "reopening_floor_height",
+        "legacy_maintenance_boundary_sha256",
         "validator_public_keys_sha256",
         "validator_set_id"
       ],
@@ -143,10 +149,38 @@
           "pattern": "^0x[0-9a-f]{64}$"
         },
         "source_height": {
-          "const": 137145
+          "type": "integer",
+          "minimum": 137145,
+          "maximum": 9007199254740991
         },
         "transition_height": {
-          "const": 137146
+          "type": "integer",
+          "minimum": 137146,
+          "maximum": 9007199254740991
+        },
+        "source_block_hash": {
+          "$ref": "#/$defs/hash"
+        },
+        "source_state_root": {
+          "$ref": "#/$defs/hash"
+        },
+        "source_consensus_round": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991
+        },
+        "observed_cutoff_height": {
+          "type": "integer",
+          "minimum": 137145,
+          "maximum": 9007199254740991
+        },
+        "reopening_floor_height": {
+          "type": "integer",
+          "minimum": 137273,
+          "maximum": 9007199254740991
+        },
+        "legacy_maintenance_boundary_sha256": {
+          "$ref": "#/$defs/hash"
         },
         "recovery_epoch": {
           "const": 1

--- a/scripts/recovery/quarantine_rounds.py
+++ b/scripts/recovery/quarantine_rounds.py
@@ -52,7 +52,7 @@ NFT_GATE_SCHEMA = "arc.recovery.quarantine-nft-deadline-gate.v1"
 NFT_INTENT_SCHEMA = "arc.recovery.quarantine-nft-apply-intent.v1"
 ANCESTRY_SCHEMA = "arc.recovery.quarantine-post-fence-ancestry.v1"
 STOPPED_ANCESTRY_SCHEMA = "arc.recovery.quarantine-stopped-precommit-ancestry.v1"
-PERSISTED_STOPPED_SCHEMA = "arc.recovery.persisted-legacy-head-stopped-precommit.v1"
+PERSISTED_STOPPED_SCHEMA = "arc.recovery.persisted-legacy-head-stopped-precommit.v2"
 PERSISTENCE_PLAN_SCHEMA = "arc.recovery.quarantine-persistence-plan.v1"
 PERSISTENT_FENCE_SCHEMA = "arc.recovery.quarantine-persistent-restart-fence.v1"
 PRECOMMIT_STATUS_SCHEMA = "arc.recovery.quarantine-precommit-stopped-status.v1"
@@ -96,6 +96,108 @@ def require_commit(value: Any, label: str) -> str:
 def require_uint(value: Any, label: str, *, positive: bool = False) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < (1 if positive else 0):
         fail(f"{label} must be a {'positive' if positive else 'non-negative'} integer")
+    return value
+
+
+def validate_legacy_dag_round(value: Any, label: str) -> Mapping[str, Any]:
+    """Validate the self-contained, read-only durable DAG cursor proof.
+
+    The outer scalar projection is intentionally redundant.  Consumers must
+    recompute both roots from the embedded inspector output so a release can be
+    selected without trusting a live node or reopening archived WAL bytes.
+    """
+
+    fields = {
+        "source_consensus_round", "namespace_sha256", "inspection",
+        "inspection_sha256",
+    }
+    if not isinstance(value, dict) or set(value) != fields:
+        fail(f"{label} durable DAG round fields differ")
+    source_round = require_uint(
+        value.get("source_consensus_round"), f"{label} source consensus round",
+        positive=True,
+    )
+    namespace_sha = require_hash(
+        value.get("namespace_sha256"), f"{label} DAG namespace"
+    )
+    inspection_sha = require_hash(
+        value.get("inspection_sha256"), f"{label} DAG inspection"
+    )
+    inspection = value.get("inspection")
+    inspection_fields = {
+        "schema", "status", "source_consensus_round", "first_segment",
+        "last_segment", "segment_count", "inspected_first_segment",
+        "inspected_segment_count", "inspected_entry_count", "namespace_sha256",
+        "namespace", "read_only",
+    }
+    if not isinstance(inspection, dict) or set(inspection) != inspection_fields:
+        fail(f"{label} embedded DAG inspection fields differ")
+    if (
+        inspection.get("schema")
+        != "arc.recovery.legacy-dag-round-inspection.v1"
+        or inspection.get("status") != "VERIFIED_STOPPED_DAG_CURSOR"
+        or inspection.get("read_only") is not True
+        or inspection_sha != digest(inspection)
+        or inspection.get("source_consensus_round") != source_round
+        or inspection.get("namespace_sha256") != namespace_sha
+    ):
+        fail(f"{label} embedded DAG inspection identity differs")
+    first = require_uint(
+        inspection.get("first_segment"), f"{label} first DAG WAL segment"
+    )
+    last = require_uint(
+        inspection.get("last_segment"), f"{label} last DAG WAL segment"
+    )
+    segment_count = require_uint(
+        inspection.get("segment_count"), f"{label} DAG WAL segment count",
+        positive=True,
+    )
+    inspected_first = require_uint(
+        inspection.get("inspected_first_segment"),
+        f"{label} first inspected DAG WAL segment",
+    )
+    inspected_count = require_uint(
+        inspection.get("inspected_segment_count"),
+        f"{label} inspected DAG WAL segment count", positive=True,
+    )
+    require_uint(
+        inspection.get("inspected_entry_count"),
+        f"{label} inspected DAG WAL entry count", positive=True,
+    )
+    if (
+        last < first
+        or segment_count != last - first + 1
+        or inspected_count != min(3, segment_count)
+        or inspected_first != last - inspected_count + 1
+    ):
+        fail(f"{label} DAG WAL segment arithmetic differs")
+    namespace = inspection.get("namespace")
+    if not isinstance(namespace, dict) or set(namespace) != {
+        "schema", "segment_names", "inspected_tail"
+    }:
+        fail(f"{label} DAG WAL namespace fields differ")
+    segment_names = namespace.get("segment_names")
+    expected_names = [f"wal-{index:08d}.bin" for index in range(first, last + 1)]
+    tail = namespace.get("inspected_tail")
+    if (
+        namespace.get("schema") != "arc.recovery.legacy-dag-wal-namespace.v1"
+        or segment_names != expected_names
+        or not isinstance(tail, list)
+        or len(tail) != inspected_count
+    ):
+        fail(f"{label} DAG WAL namespace differs")
+    for index, row in enumerate(tail):
+        if not isinstance(row, dict) or set(row) != {"name", "sha256", "size"}:
+            fail(f"{label} inspected DAG WAL tail fields differ")
+        if row.get("name") != expected_names[-inspected_count + index]:
+            fail(f"{label} inspected DAG WAL tail order differs")
+        require_hash(row.get("sha256"), f"{label} inspected DAG WAL tail root")
+        require_uint(row.get("size"), f"{label} inspected DAG WAL tail size")
+    namespace_bytes = json.dumps(
+        namespace, sort_keys=True, separators=(",", ":")
+    ).encode()
+    if hashlib.sha256(namespace_bytes).hexdigest() != namespace_sha:
+        fail(f"{label} DAG WAL namespace root is not reproducible")
     return value
 
 
@@ -1570,6 +1672,7 @@ def validate_node_stopped_precommit(
         "source_pair_role",
         "live_source_capture_sha256", "final_absence_sample",
         "export_summary_sha256", "inspect_summary_sha256",
+        "legacy_dag_round", "trusted_anchor_ancestry",
         "candidate_checkpoint_sha256", "candidate_checkpoint_size",
         "authorization_ancestry_proof_sha256", "head", "allow_unbound_legacy_wal",
         "completed_at", "writer_stopped", "restart_barrier_active",
@@ -1617,15 +1720,26 @@ def validate_node_stopped_precommit(
         "persistently-stopped candidate checkpoint size", positive=True,
     )
     source_inputs = persisted.get("source_inputs")
-    if not isinstance(source_inputs, dict) or set(source_inputs) != {
-        "original_data_dir", "final_state_wal", "fixed_data_dir",
+    source_input_fields = {
+        "original_data_dir", "legacy_dag_wal_dir", "final_state_wal", "fixed_data_dir",
         "fixed_state_wal", "fixed_snapshot", "fixed_genesis_binding",
         "live_source_capture_sha256", "rust_live_source_capture_sha256",
         "source_pair_role",
-    }:
+    }
+    if (
+        not isinstance(source_inputs, dict)
+        or set(source_inputs) not in (
+            source_input_fields, source_input_fields | {"wal_normalization"}
+        )
+    ):
         fail("persistently-stopped source-input inventory differs")
     validate_file_identity(
         source_inputs["original_data_dir"], "persistently-stopped original data dir",
+        directory=True,
+    )
+    validate_file_identity(
+        source_inputs["legacy_dag_wal_dir"],
+        "persistently-stopped legacy DAG WAL dir",
         directory=True,
     )
     validate_file_identity(
@@ -1649,6 +1763,49 @@ def validate_node_stopped_precommit(
         require_hash(source_inputs.get(label), f"persistently-stopped {label}")
     if source_inputs.get("source_pair_role") != "preauthorization-boundary":
         fail("persistently-stopped source-pair role differs")
+    normalization = source_inputs.get("wal_normalization")
+    if normalization is not None:
+        normalization_fields = {
+            "normalizer_sha256", "plan_sha256", "receipt_sha256",
+            "normalized_data_dir", "normalized_state_wal", "source_snapshot",
+            "semantic_stream_sha256",
+        }
+        if not isinstance(normalization, dict) or set(normalization) != normalization_fields:
+            fail("persistently-stopped WAL normalization evidence differs")
+        for label in (
+            "normalizer_sha256", "plan_sha256", "receipt_sha256",
+            "semantic_stream_sha256",
+        ):
+            require_hash(
+                normalization.get(label),
+                f"persistently-stopped normalization {label}",
+            )
+        validate_file_identity(
+            normalization["normalized_data_dir"],
+            "persistently-stopped normalized source directory",
+            directory=True,
+        )
+        normalized_wal = validate_file_identity(
+            normalization["normalized_state_wal"],
+            "persistently-stopped normalized source WAL",
+        )
+        normalization_snapshot = validate_file_identity(
+            normalization["source_snapshot"],
+            "persistently-stopped normalization source snapshot",
+        )
+        if (
+            (normalized_wal["sha256"], normalized_wal["size"])
+            != (
+                source_inputs["fixed_state_wal"]["sha256"],
+                source_inputs["fixed_state_wal"]["size"],
+            )
+            or (normalization_snapshot["sha256"], normalization_snapshot["size"])
+            != (
+                source_inputs["fixed_snapshot"]["sha256"],
+                source_inputs["fixed_snapshot"]["size"],
+            )
+        ):
+            fail("persistently-stopped normalized/fixed pair content differs")
     if (
         persisted.get("live_source_capture_sha256")
         != source_inputs["live_source_capture_sha256"]
@@ -1675,11 +1832,103 @@ def validate_node_stopped_precommit(
         row = validate_file_identity(staged_inputs[label], f"persistently-stopped staged {label}")
         if row["sha256"] != persisted[root_field]:
             fail(f"persistently-stopped staged {label} root differs")
+    expected_input_roots = {
+        "data_dir": {
+            key: source_inputs["fixed_data_dir"][key]
+            for key in (
+                "device", "inode", "mode", "uid", "gid", "nlink", "mtime_ns", "ctime_ns",
+            )
+        },
+        "state_wal": {
+            key: source_inputs["fixed_state_wal"][key]
+            for key in (
+                "device", "inode", "mode", "uid", "gid", "nlink", "sha256",
+                "size", "mtime_ns", "ctime_ns",
+            )
+        },
+        "snapshot": {
+            key: source_inputs["fixed_snapshot"][key]
+            for key in (
+                "device", "inode", "mode", "uid", "gid", "nlink", "sha256",
+                "size", "mtime_ns", "ctime_ns",
+            )
+        },
+        "genesis": {
+            key: staged_inputs["genesis"][key]
+            for key in (
+                "device", "inode", "mode", "uid", "gid", "nlink", "sha256",
+                "size", "mtime_ns", "ctime_ns",
+            )
+        },
+        "legacy_validator_set": {
+            key: staged_inputs["legacy_validator_set"][key]
+            for key in (
+                "device", "inode", "mode", "uid", "gid", "nlink", "sha256",
+                "size", "mtime_ns", "ctime_ns",
+            )
+        },
+    }
     head, height = validate_stable_head(
         persisted.get("head"), "persistently-stopped persisted head"
     )
     if value.get("stable_head") != head:
         fail("persistently-stopped stable-head projection differs")
+    validate_legacy_dag_round(
+        persisted.get("legacy_dag_round"), "persistently-stopped"
+    )
+    anchor = persisted.get("trusted_anchor_ancestry")
+    anchor_fields = {
+        "anchor_height", "anchor_block_hash", "anchor_state_root",
+        "classification", "inspection", "inspection_sha256",
+    }
+    anchor_inspection = anchor.get("inspection") if isinstance(anchor, dict) else None
+    if (
+        not isinstance(anchor, dict)
+        or set(anchor) != anchor_fields
+        or anchor.get("anchor_height") != 137145
+        or anchor.get("anchor_block_hash")
+            != "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90"
+        or anchor.get("anchor_state_root")
+            != "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d"
+        or anchor.get("inspection_sha256") != digest(anchor_inspection)
+    ):
+        fail("persistently-stopped trusted anchor binding differs")
+    if height < anchor["anchor_height"]:
+        if (
+            anchor.get("classification") != "below_trusted_anchor"
+            or anchor_inspection is not None
+        ):
+            fail("persistently-stopped below-anchor classification differs")
+    else:
+        inspection_fields = {
+            "schema", "height", "block_hash", "state_root", "input_roots",
+        }
+        if (
+            not isinstance(anchor_inspection, dict)
+            or set(anchor_inspection) != inspection_fields
+            or anchor_inspection.get("schema")
+                != "arc.recovery.legacy-block-inspection.v1"
+            or anchor_inspection.get("height") != anchor["anchor_height"]
+            or anchor_inspection.get("input_roots") != expected_input_roots
+        ):
+            fail("persistently-stopped trusted anchor inspection differs")
+        observed_hash = require_hash(
+            anchor_inspection.get("block_hash"),
+            "persistently-stopped observed anchor block",
+        )
+        observed_state = require_hash(
+            anchor_inspection.get("state_root"),
+            "persistently-stopped observed anchor state",
+        )
+        matches = (
+            observed_hash == anchor["anchor_block_hash"]
+            and observed_state == anchor["anchor_state_root"]
+        )
+        expected_classification = (
+            "valid_anchor_descendant" if matches else "conflicting_anchor"
+        )
+        if anchor.get("classification") != expected_classification:
+            fail("persistently-stopped trusted anchor classification differs")
     completed = parse_utc(
         persisted.get("completed_at"), "persistently-stopped persisted-head completion"
     )
@@ -1719,42 +1968,6 @@ def validate_node_stopped_precommit(
         item.get("label") if isinstance(item, dict) else None for item in checks
     ] != ["public-latest", "authenticated-loopback-latest"]:
         fail("persistently-stopped authorization ancestry checks differ")
-    expected_input_roots = {
-        "data_dir": {
-            key: source_inputs["fixed_data_dir"][key]
-            for key in (
-                "device", "inode", "mode", "uid", "gid", "nlink", "mtime_ns", "ctime_ns",
-            )
-        },
-        "state_wal": {
-            key: source_inputs["fixed_state_wal"][key]
-            for key in (
-                "device", "inode", "mode", "uid", "gid", "nlink", "sha256",
-                "size", "mtime_ns", "ctime_ns",
-            )
-        },
-        "snapshot": {
-            key: source_inputs["fixed_snapshot"][key]
-            for key in (
-                "device", "inode", "mode", "uid", "gid", "nlink", "sha256",
-                "size", "mtime_ns", "ctime_ns",
-            )
-        },
-        "genesis": {
-            key: staged_inputs["genesis"][key]
-            for key in (
-                "device", "inode", "mode", "uid", "gid", "nlink", "sha256",
-                "size", "mtime_ns", "ctime_ns",
-            )
-        },
-        "legacy_validator_set": {
-            key: staged_inputs["legacy_validator_set"][key]
-            for key in (
-                "device", "inode", "mode", "uid", "gid", "nlink", "sha256",
-                "size", "mtime_ns", "ctime_ns",
-            )
-        },
-    }
     for check in checks:
         if set(check) != {
             "label", "height", "expected_block_hash", "observed_block_hash",

--- a/scripts/recovery/recovery-manifest.schema.json
+++ b/scripts/recovery/recovery-manifest.schema.json
@@ -23,6 +23,9 @@
           "chain": {
             "required": [
               "legacy_maintenance_evidence_bundle_sha256",
+              "canonical_source",
+              "canonical_source_selection",
+              "trusted_anchor",
               "legacy_maintenance_boundary_sha256",
               "legacy_late_fork_source_set_sha256",
               "legacy_observed_cutoff_height",
@@ -46,6 +49,7 @@
               "pretag_raw_desktop_windows_x86_64", "genesis",
               "validator_public_keys", "legacy_public_height_receipt",
               "legacy_maintenance_evidence_bundle", "legacy_maintenance_evidence_bundle_sidecar",
+              "canonical_source_preselection", "canonical_source_preselection_sidecar",
               "legacy_maintenance_boundary", "legacy_maintenance_boundary_sidecar",
               "legacy_late_fork_source_set", "legacy_late_fork_source_set_sidecar",
               "legacy_late_fork_interlock_tool",
@@ -252,6 +256,146 @@
         "recovery_epoch": { "type": "integer", "minimum": 1 },
         "validator_set_id": { "type": "integer", "minimum": 1 },
         "source_height": { "type": "integer", "minimum": 0 },
+        "canonical_source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "node",
+            "source_height",
+            "source_block_hash",
+            "source_state_root",
+            "source_consensus_round",
+            "snapshot_sha256",
+            "wal_sha256",
+            "persisted_head_sha256",
+            "legacy_dag_round_inspection_sha256",
+            "legacy_dag_wal_namespace_sha256"
+          ],
+          "properties": {
+            "node": { "enum": ["nyc", "lax", "ams", "lhr", "nrt", "sgp"] },
+            "source_height": { "type": "integer", "minimum": 137145 },
+            "source_block_hash": { "$ref": "#/$defs/hash" },
+            "source_state_root": { "$ref": "#/$defs/hash" },
+            "source_consensus_round": { "type": "integer", "minimum": 1 },
+            "snapshot_sha256": { "$ref": "#/$defs/hash" },
+            "wal_sha256": { "$ref": "#/$defs/hash" },
+            "persisted_head_sha256": { "$ref": "#/$defs/hash" },
+            "legacy_dag_round_inspection_sha256": { "$ref": "#/$defs/hash" },
+            "legacy_dag_wal_namespace_sha256": { "$ref": "#/$defs/hash" }
+          }
+        },
+        "canonical_source_selection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["value", "sha256"],
+          "properties": {
+            "sha256": { "$ref": "#/$defs/bareHash" },
+            "value": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "schema", "selection_rule", "equivalent_maximal_pair_rule",
+                "trusted_anchor", "candidates", "selected"
+              ],
+              "properties": {
+                "schema": { "const": "arc.recovery.canonical-source-selection.v1" },
+                "selection_rule": { "const": "highest-valid-anchor-descendant-tuple" },
+                "equivalent_maximal_pair_rule": {
+                  "const": "first-production-fleet-node-with-matching-source-pair"
+                },
+                "trusted_anchor": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["height", "block_hash", "state_root"],
+                  "properties": {
+                    "height": { "const": 137145 },
+                    "block_hash": {
+                      "const": "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90"
+                    },
+                    "state_root": {
+                      "const": "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d"
+                    }
+                  }
+                },
+                "candidates": {
+                  "type": "array",
+                  "minItems": 6,
+                  "maxItems": 6,
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "node", "persisted_head_schema", "persisted_head_sha256",
+                      "source_height", "source_block_hash", "source_state_root",
+                      "classification", "anchor_inspection_sha256"
+                    ],
+                    "properties": {
+                      "node": { "enum": ["nyc", "lax", "ams", "lhr", "nrt", "sgp"] },
+                      "persisted_head_schema": { "type": "string", "minLength": 1 },
+                      "persisted_head_sha256": { "$ref": "#/$defs/bareHash" },
+                      "source_height": { "type": "integer", "minimum": 0 },
+                      "source_block_hash": { "$ref": "#/$defs/bareHash" },
+                      "source_state_root": { "$ref": "#/$defs/bareHash" },
+                      "classification": {
+                        "enum": [
+                          "below_trusted_anchor", "valid_anchor_descendant", "conflicting_anchor"
+                        ]
+                      },
+                      "anchor_inspection_sha256": { "$ref": "#/$defs/bareHash" }
+                    }
+                  }
+                },
+                "selected": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "node", "source_height", "source_block_hash", "source_state_root",
+                    "persisted_head_sha256"
+                  ],
+                  "properties": {
+                    "node": { "enum": ["nyc", "lax", "ams", "lhr", "nrt", "sgp"] },
+                    "source_height": { "type": "integer", "minimum": 137145 },
+                    "source_block_hash": { "$ref": "#/$defs/bareHash" },
+                    "source_state_root": { "$ref": "#/$defs/bareHash" },
+                    "persisted_head_sha256": { "$ref": "#/$defs/bareHash" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "trusted_anchor": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "schema",
+            "height",
+            "block_hash",
+            "state_root",
+            "inspection_sha256",
+            "inspector_binary_sha256",
+            "source_snapshot_sha256",
+            "source_wal_sha256",
+            "genesis_sha256",
+            "legacy_validator_set_sha256"
+          ],
+          "properties": {
+            "schema": { "const": "arc.recovery.trusted-anchor-proof.v1" },
+            "height": { "const": 137145 },
+            "block_hash": {
+              "const": "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90"
+            },
+            "state_root": {
+              "const": "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d"
+            },
+            "inspection_sha256": { "$ref": "#/$defs/hash" },
+            "inspector_binary_sha256": { "$ref": "#/$defs/hash" },
+            "source_snapshot_sha256": { "$ref": "#/$defs/hash" },
+            "source_wal_sha256": { "$ref": "#/$defs/hash" },
+            "genesis_sha256": { "$ref": "#/$defs/hash" },
+            "legacy_validator_set_sha256": { "$ref": "#/$defs/hash" }
+          }
+        },
         "legacy_maintenance_evidence_bundle_sha256": { "$ref": "#/$defs/hash" },
         "legacy_maintenance_boundary_sha256": { "$ref": "#/$defs/hash" },
         "legacy_late_fork_source_set_sha256": { "$ref": "#/$defs/hash" },
@@ -330,6 +474,8 @@
         "legacy_public_height_receipt": { "$ref": "#/$defs/artifact" },
         "legacy_maintenance_evidence_bundle": { "$ref": "#/$defs/artifact" },
         "legacy_maintenance_evidence_bundle_sidecar": { "$ref": "#/$defs/artifact" },
+        "canonical_source_preselection": { "$ref": "#/$defs/artifact" },
+        "canonical_source_preselection_sidecar": { "$ref": "#/$defs/artifact" },
         "legacy_maintenance_boundary": { "$ref": "#/$defs/artifact" },
         "legacy_maintenance_boundary_sidecar": { "$ref": "#/$defs/artifact" },
         "legacy_late_fork_source_set": { "$ref": "#/$defs/artifact" },
@@ -467,6 +613,7 @@
   },
   "$defs": {
     "hash": { "type": "string", "pattern": "^(0x)?[0-9a-f]{64}$" },
+    "bareHash": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
     "protectedPretagResponse": {
       "type": "object",
       "additionalProperties": false,

--- a/scripts/recovery/recovery_rollout.py
+++ b/scripts/recovery/recovery_rollout.py
@@ -3060,8 +3060,8 @@ def verify_legacy_maintenance_stage_payloads(
             or cross_value.get("schema")
             != "arc.recovery.legacy-network-quarantine-public-cross-proof.v1"
             or persisted_value.get("schema") not in {
-                "arc.recovery.persisted-legacy-head.v1",
-                "arc.recovery.persisted-legacy-head.v2",
+                "arc.recovery.persisted-legacy-head.v3",
+                "arc.recovery.persisted-legacy-head.v4",
             }
             or persisted_value.get("source_main_commit") != source_commit
             or persisted_value.get("source_pair_role")
@@ -3072,6 +3072,13 @@ def verify_legacy_maintenance_stage_payloads(
             or persisted_value.get("global_absence_claimed") is not False
         ):
             fail(f"legacy maintenance {node} retained object policy differs")
+        try:
+            quarantine_rounds.validate_legacy_dag_round(
+                persisted_value.get("legacy_dag_round"),
+                f"legacy maintenance {node}",
+            )
+        except quarantine_rounds.QuarantineRoundError as error:
+            fail(f"legacy maintenance {node} durable DAG proof differs: {error}")
         exact_hash(
             persisted_value.get("final_source_capture_sha256"),
             f"legacy maintenance {node} final source capture root",
@@ -3110,7 +3117,7 @@ def verify_legacy_maintenance_stage_payloads(
         if selected_source_head != persisted_head:
             fail(f"legacy maintenance {node} selected final source head differs")
         normalized_persisted = persisted_value.get("schema") \
-            == "arc.recovery.persisted-legacy-head.v2"
+            == "arc.recovery.persisted-legacy-head.v4"
         archived_required = ["path", "sha256", "size", "file_identity", "preserved_by"]
         if normalized_persisted:
             archived_required += ["source_relation", "normalization_receipt_sha256",

--- a/scripts/recovery/recovery_rollout.py
+++ b/scripts/recovery/recovery_rollout.py
@@ -393,6 +393,89 @@ def require_keys(value: Any, field: str, required: Iterable[str], optional: Iter
     return value
 
 
+def validate_embedded_legacy_dag_round(value: Any, label: str) -> dict[str, Any]:
+    """Validate the self-contained durable DAG cursor proof."""
+
+    proof = require_keys(
+        value,
+        label,
+        ("source_consensus_round", "namespace_sha256", "inspection", "inspection_sha256"),
+    )
+    source_round = required_int(
+        proof["source_consensus_round"], f"{label} source consensus round", minimum=1
+    )
+    namespace_sha = bare_hash(proof["namespace_sha256"], f"{label} namespace root")
+    inspection_sha = bare_hash(proof["inspection_sha256"], f"{label} inspection root")
+    inspection = require_keys(
+        proof["inspection"],
+        f"{label} inspection",
+        (
+            "schema", "status", "source_consensus_round", "first_segment",
+            "last_segment", "segment_count", "inspected_first_segment",
+            "inspected_segment_count", "inspected_entry_count", "namespace_sha256",
+            "namespace", "read_only",
+        ),
+    )
+    if (
+        inspection["schema"] != "arc.recovery.legacy-dag-round-inspection.v1"
+        or inspection["status"] != "VERIFIED_STOPPED_DAG_CURSOR"
+        or inspection["read_only"] is not True
+        or inspection["source_consensus_round"] != source_round
+        or inspection["namespace_sha256"] != namespace_sha
+        or sha256_bytes(canonical_bytes(inspection)) != inspection_sha
+    ):
+        fail(f"{label} inspection identity differs")
+    first = required_int(inspection["first_segment"], f"{label} first segment")
+    last = required_int(inspection["last_segment"], f"{label} last segment")
+    segment_count = required_int(
+        inspection["segment_count"], f"{label} segment count", minimum=1
+    )
+    inspected_first = required_int(
+        inspection["inspected_first_segment"], f"{label} inspected first segment"
+    )
+    inspected_count = required_int(
+        inspection["inspected_segment_count"], f"{label} inspected segment count", minimum=1
+    )
+    required_int(
+        inspection["inspected_entry_count"], f"{label} inspected entry count", minimum=1
+    )
+    if (
+        last < first
+        or segment_count != last - first + 1
+        or inspected_count != min(3, segment_count)
+        or inspected_first != last - inspected_count + 1
+    ):
+        fail(f"{label} segment arithmetic differs")
+    namespace = require_keys(
+        inspection["namespace"],
+        f"{label} namespace",
+        ("schema", "segment_names", "inspected_tail"),
+    )
+    expected_names = [f"wal-{index:08d}.bin" for index in range(first, last + 1)]
+    tail = namespace["inspected_tail"]
+    if (
+        namespace["schema"] != "arc.recovery.legacy-dag-wal-namespace.v1"
+        or namespace["segment_names"] != expected_names
+        or not isinstance(tail, list)
+        or len(tail) != inspected_count
+    ):
+        fail(f"{label} namespace differs")
+    for index, row in enumerate(tail):
+        tail_row = require_keys(
+            row, f"{label} inspected tail {index}", ("name", "sha256", "size")
+        )
+        if tail_row["name"] != expected_names[-inspected_count + index]:
+            fail(f"{label} inspected tail order differs")
+        bare_hash(tail_row["sha256"], f"{label} inspected tail {index} root")
+        required_int(tail_row["size"], f"{label} inspected tail {index} size")
+    namespace_bytes = json.dumps(
+        namespace, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    if sha256_bytes(namespace_bytes) != namespace_sha:
+        fail(f"{label} namespace root is not reproducible")
+    return proof
+
+
 def validate_live_observation_selection(
     value: Any,
     *,
@@ -1327,6 +1410,9 @@ def validate_manifest(
         "approved_checkpoint_manifest_hash",
     )
     production_legacy_fields = (
+        "canonical_source",
+        "canonical_source_selection",
+        "trusted_anchor",
         "legacy_maintenance_evidence_bundle_sha256",
         "legacy_maintenance_boundary_sha256",
         "legacy_late_fork_source_set_sha256",
@@ -1357,6 +1443,252 @@ def validate_manifest(
     if legacy_public_max_height < source_height:
         fail("manifest.chain.legacy_public_max_height must be at least source_height")
     if mode == "production":
+        if source_height < 137_145:
+            fail("manifest.chain.source_height predates trusted anchor 137145")
+        canonical_source = require_keys(
+            chain["canonical_source"],
+            "manifest.chain.canonical_source",
+            (
+                "node",
+                "source_height",
+                "source_block_hash",
+                "source_state_root",
+                "source_consensus_round",
+                "snapshot_sha256",
+                "wal_sha256",
+                "persisted_head_sha256",
+                "legacy_dag_round_inspection_sha256",
+                "legacy_dag_wal_namespace_sha256",
+            ),
+        )
+        if canonical_source["node"] not in {name for name, _host in PRODUCTION_FLEET}:
+            fail("manifest.chain.canonical_source.node is not a production validator")
+        for field in (
+            "source_height",
+            "source_consensus_round",
+        ):
+            required_int(
+                canonical_source[field], f"manifest.chain.canonical_source.{field}"
+            )
+        for field in (
+            "source_block_hash",
+            "source_state_root",
+            "snapshot_sha256",
+            "wal_sha256",
+            "persisted_head_sha256",
+            "legacy_dag_round_inspection_sha256",
+            "legacy_dag_wal_namespace_sha256",
+        ):
+            bare_hash(
+                canonical_source[field], f"manifest.chain.canonical_source.{field}"
+            )
+        if (
+            canonical_source["source_height"] != chain["source_height"]
+            or canonical_source["source_consensus_round"]
+            != chain["source_consensus_round"]
+            or bare_hash(
+                canonical_source["source_block_hash"],
+                "manifest.chain.canonical_source.source_block_hash",
+            )
+            != bare_hash(chain["source_block_hash"], "manifest.chain.source_block_hash")
+            or bare_hash(
+                canonical_source["source_state_root"],
+                "manifest.chain.canonical_source.source_state_root",
+            )
+            != bare_hash(chain["source_state_root"], "manifest.chain.source_state_root")
+        ):
+            fail("manifest.chain.canonical_source differs from checkpoint source identity")
+
+        selection_wrapper = require_keys(
+            chain["canonical_source_selection"],
+            "manifest.chain.canonical_source_selection",
+            ("value", "sha256"),
+        )
+        selection_sha = bare_hash(
+            selection_wrapper["sha256"],
+            "manifest.chain.canonical_source_selection.sha256",
+        )
+        selection = require_keys(
+            selection_wrapper["value"],
+            "manifest.chain.canonical_source_selection.value",
+            (
+                "schema",
+                "selection_rule",
+                "equivalent_maximal_pair_rule",
+                "trusted_anchor",
+                "candidates",
+                "selected",
+            ),
+        )
+        if sha256_bytes(canonical_bytes(selection)) != selection_sha:
+            fail("manifest canonical-source selection wrapper is not reproducible")
+        selection_anchor = require_keys(
+            selection["trusted_anchor"],
+            "manifest canonical-source selection trusted anchor",
+            ("height", "block_hash", "state_root"),
+        )
+        if (
+            selection["schema"] != "arc.recovery.canonical-source-selection.v1"
+            or selection["selection_rule"]
+            != "highest-valid-anchor-descendant-tuple"
+            or selection["equivalent_maximal_pair_rule"]
+            != "first-production-fleet-node-with-matching-source-pair"
+            or selection_anchor
+            != {
+                "height": 137_145,
+                "block_hash": "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90",
+                "state_root": "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d",
+            }
+        ):
+            fail("manifest canonical-source selection targets another trust policy")
+        candidates = selection["candidates"]
+        if not isinstance(candidates, list) or len(candidates) != len(PRODUCTION_FLEET):
+            fail("manifest canonical-source selection does not classify all six captures")
+        valid_candidates: list[dict[str, Any]] = []
+        for (expected_node, _host), raw_candidate in zip(
+            PRODUCTION_FLEET, candidates, strict=True
+        ):
+            candidate = require_keys(
+                raw_candidate,
+                f"manifest canonical-source candidate {expected_node}",
+                (
+                    "node",
+                    "persisted_head_schema",
+                    "persisted_head_sha256",
+                    "source_height",
+                    "source_block_hash",
+                    "source_state_root",
+                    "classification",
+                    "anchor_inspection_sha256",
+                ),
+            )
+            candidate_height = required_int(
+                candidate["source_height"],
+                f"manifest canonical-source candidate {expected_node} height",
+            )
+            if candidate["node"] != expected_node or not isinstance(
+                candidate["persisted_head_schema"], str
+            ):
+                fail("manifest canonical-source candidate identity/order differs")
+            for field in (
+                "persisted_head_sha256",
+                "source_block_hash",
+                "source_state_root",
+                "anchor_inspection_sha256",
+            ):
+                bare_hash(
+                    candidate[field],
+                    f"manifest canonical-source candidate {expected_node}.{field}",
+                )
+            classification = candidate["classification"]
+            if candidate_height < 137_145:
+                if classification != "below_trusted_anchor":
+                    fail("manifest below-anchor canonical-source candidate is misclassified")
+            elif classification not in {"valid_anchor_descendant", "conflicting_anchor"}:
+                fail("manifest canonical-source candidate lacks conclusive ancestry")
+            if classification == "valid_anchor_descendant":
+                valid_candidates.append(candidate)
+        if not valid_candidates:
+            fail("manifest canonical-source selection has no valid anchor descendant")
+        highest = max(candidate["source_height"] for candidate in valid_candidates)
+        maximal = [
+            candidate for candidate in valid_candidates
+            if candidate["source_height"] == highest
+        ]
+        maximal_tuples = {
+            (
+                bare_hash(
+                    candidate["source_block_hash"],
+                    "manifest maximal canonical-source candidate block hash",
+                ),
+                bare_hash(
+                    candidate["source_state_root"],
+                    "manifest maximal canonical-source candidate state root",
+                ),
+            )
+            for candidate in maximal
+        }
+        if len(maximal_tuples) != 1:
+            fail("manifest highest valid anchor descendants disagree on their tuple")
+        selected = require_keys(
+            selection["selected"],
+            "manifest canonical-source selection selected candidate",
+            (
+                "node",
+                "source_height",
+                "source_block_hash",
+                "source_state_root",
+                "persisted_head_sha256",
+            ),
+        )
+        canonical_selected = {
+            "node": canonical_source["node"],
+            "source_height": canonical_source["source_height"],
+            "source_block_hash": bare_hash(
+                canonical_source["source_block_hash"],
+                "manifest canonical source selected block hash",
+            ),
+            "source_state_root": bare_hash(
+                canonical_source["source_state_root"],
+                "manifest canonical source selected state root",
+            ),
+            "persisted_head_sha256": canonical_source["persisted_head_sha256"],
+        }
+        maximal_selected = [
+            {
+                field: candidate[field]
+                for field in (
+                    "node",
+                    "source_height",
+                    "source_block_hash",
+                    "source_state_root",
+                    "persisted_head_sha256",
+                )
+            }
+            for candidate in maximal
+        ]
+        if selected not in maximal_selected or selected != canonical_selected:
+            fail("manifest canonical source is not a highest valid descendant pair")
+
+        trusted_anchor = require_keys(
+            chain["trusted_anchor"],
+            "manifest.chain.trusted_anchor",
+            (
+                "schema",
+                "height",
+                "block_hash",
+                "state_root",
+                "inspection_sha256",
+                "inspector_binary_sha256",
+                "source_snapshot_sha256",
+                "source_wal_sha256",
+                "genesis_sha256",
+                "legacy_validator_set_sha256",
+            ),
+        )
+        if (
+            trusted_anchor["schema"] != "arc.recovery.trusted-anchor-proof.v1"
+            or trusted_anchor["height"] != 137_145
+            or trusted_anchor["block_hash"]
+            != "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90"
+            or trusted_anchor["state_root"]
+            != "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d"
+        ):
+            fail("manifest.chain.trusted_anchor differs from block 137145")
+        for field in (
+            "inspection_sha256",
+            "inspector_binary_sha256",
+            "source_snapshot_sha256",
+            "source_wal_sha256",
+            "genesis_sha256",
+            "legacy_validator_set_sha256",
+        ):
+            bare_hash(trusted_anchor[field], f"manifest.chain.trusted_anchor.{field}")
+        if (
+            trusted_anchor["source_snapshot_sha256"] != canonical_source["snapshot_sha256"]
+            or trusted_anchor["source_wal_sha256"] != canonical_source["wal_sha256"]
+        ):
+            fail("manifest.chain.trusted_anchor is not bound to canonical source inputs")
         bare_hash(
             chain["legacy_maintenance_evidence_bundle_sha256"],
             "manifest.chain.legacy_maintenance_evidence_bundle_sha256",
@@ -1373,6 +1705,8 @@ def validate_manifest(
             chain["legacy_observed_cutoff_height"],
             "manifest.chain.legacy_observed_cutoff_height",
         )
+        if observed_cutoff < source_height:
+            fail("manifest.chain legacy observed cutoff is below checkpoint source H")
         if chain["legacy_continuity_safety_margin"] != LEGACY_CONTINUITY_SAFETY_MARGIN:
             fail(
                 "manifest.chain.legacy_continuity_safety_margin must be exactly "
@@ -1429,6 +1763,8 @@ def validate_manifest(
                 "legacy_public_height_receipt",
                 "legacy_maintenance_evidence_bundle",
                 "legacy_maintenance_evidence_bundle_sidecar",
+                "canonical_source_preselection",
+                "canonical_source_preselection_sidecar",
                 "legacy_maintenance_boundary",
                 "legacy_maintenance_boundary_sidecar",
                 "legacy_late_fork_source_set",
@@ -1460,6 +1796,18 @@ def validate_manifest(
     for key in artifacts:
         validate_artifact(artifacts[key], f"manifest.artifacts.{key}")
     if mode == "production":
+        if (
+            canonical_source["snapshot_sha256"] != artifacts["source_snapshot"]["sha256"]
+            or canonical_source["wal_sha256"] != artifacts["source_wal"]["sha256"]
+            or trusted_anchor["inspector_binary_sha256"] != artifacts["binary"]["sha256"]
+            or trusted_anchor["source_snapshot_sha256"]
+            != artifacts["source_snapshot"]["sha256"]
+            or trusted_anchor["source_wal_sha256"] != artifacts["source_wal"]["sha256"]
+            or trusted_anchor["genesis_sha256"] != artifacts["genesis"]["sha256"]
+            or trusted_anchor["legacy_validator_set_sha256"]
+            != artifacts["legacy_validator_set"]["sha256"]
+        ):
+            fail("canonical source or trusted anchor differs from manifest artifacts")
         validate_protected_pretag_window_set(
             provenance["protected_pretag_artifact"], provenance, artifacts
         )
@@ -3116,6 +3464,10 @@ def verify_legacy_maintenance_stage_payloads(
             )
         if selected_source_head != persisted_head:
             fail(f"legacy maintenance {node} selected final source head differs")
+        validate_embedded_legacy_dag_round(
+            persisted_value.get("legacy_dag_round"),
+            f"legacy maintenance {node} DAG round proof",
+        )
         normalized_persisted = persisted_value.get("schema") \
             == "arc.recovery.persisted-legacy-head.v4"
         archived_required = ["path", "sha256", "size", "file_identity", "preserved_by"]
@@ -6541,8 +6893,21 @@ class RecoveryRollout:
             for node in self.validators
         ]
         sources.extend(self._legacy_archive_sources(archived_forks))
-        primary = sources[0]["id"]
         chain = self.chain
+        canonical_source = chain.get("canonical_source")
+        canonical_node = (
+            canonical_source.get("node") if isinstance(canonical_source, dict) else None
+        )
+        primary_matches = [
+            source
+            for source in sources
+            if source.get("id") == f"v3-{canonical_node}"
+            and source.get("kind") == "v3"
+            and source.get("enabled") is True
+        ]
+        if len(primary_matches) != 1:
+            fail("captured canonical source does not identify exactly one enabled v3 source")
+        primary = primary_matches[0]["id"]
         return {
             "schema": "arc.frontend.network.v1",
             "state": "recovered",

--- a/scripts/recovery/recovery_rollout.py
+++ b/scripts/recovery/recovery_rollout.py
@@ -13244,7 +13244,11 @@ else
   status=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' --connect-timeout 5 --max-time 15 --resolve "$hostname:443:127.0.0.1" "https://$hostname/health" || true)
   test "$status" = 503 || { printf 'maintenance edge health returned HTTP %s\n' "$status" >&2; exit 1; }
 fi
-receipt="$gate/${target}.json"
+# A maintenance reclose under the public-open intent and the subsequent
+# retirement-safe rollback use distinct, independently sealed intents. Keep
+# both create-only receipts instead of making those valid transitions contend
+# for one target-only filename.
+receipt="$gate/${target}.${intent_sha}.json"
 arc_semantic_python - "$receipt" "$rollout" "$target" "$source_sha" "$intent_sha" "$height" "$block_hash" "$state_root" "$node_name" "$hostname" <<'PY'
 import hashlib,json,os,pathlib,stat,sys
 path=pathlib.Path(sys.argv[1])

--- a/scripts/recovery/recovery_rollout.py
+++ b/scripts/recovery/recovery_rollout.py
@@ -5021,6 +5021,10 @@ def write_frontend_config(
         validate_distinct_receipt_evidence(reward_evidence)
     elif reward_evidence is not None:
         fail("--reward-evidence is permitted only for a receipt-mode frontend publication")
+    # Bind every published checkpoint identity to the exact sealed ARCCHKPT
+    # inspected in this process.  Artifact SHA verification alone cannot prove
+    # the inner payload root that the public recovery projection exposes.
+    rollout.verify_checkpoint()
     archive = rollout.manifest["archive"]
     finalized = all(archive[field] != "0" * 64 for field in ARCHIVE_FINALIZATION_FIELDS)
     if finalized:
@@ -5038,9 +5042,15 @@ def write_frontend_config(
             ]
         else:
             assert archive_complete_path is not None
-            legacy_archive_nodes = load_legacy_archive_fork_nodes(
+            local_fork_rows = load_legacy_archive_fork_nodes(
                 rollout, archive_manifest_path, archive_complete_path
             )
+            local_forks = rollout._enrich_legacy_archive_fork_rows(local_fork_rows)
+            legacy_archive_nodes = [
+                local_forks[node["name"]]
+                for node in rollout.validators
+                if node["name"] in local_forks
+            ]
     else:
         if archive_manifest_path is not None or archive_complete_path is not None:
             fail("prearchive frontend publication cannot accept finalized archive files")
@@ -5619,6 +5629,7 @@ class RecoveryRollout:
         self.production_public_listener_baseline: dict[str, dict[str, int]] = {}
         self.archive_metadata_loaded = False
         self.production_archive_verified_root: str | None = None
+        self.verified_checkpoint_identity: dict[str, str] | None = None
         self.archive_manifest_payload: bytes | None = None
         self.archive_complete_payload: bytes | None = None
         self.legacy_archive_forks: dict[str, dict[str, Any]] = {}
@@ -6715,7 +6726,7 @@ class RecoveryRollout:
         }
 
     def _legacy_archive_sources(
-        self, archived_forks: Sequence[Mapping[str, str]]
+        self, archived_forks: Sequence[Mapping[str, Any]]
     ) -> list[dict[str, Any]]:
         """Derive alternate-source config only from a live, pinned provenance proof.
 
@@ -6827,11 +6838,55 @@ class RecoveryRollout:
                 fail(f"legacy archive {index} bundle root differs from its sealed row")
             if normalized["inventory_sha256"] != archived_fork.get("inventory_sha256"):
                 fail(f"legacy archive {index} inventory root differs from its sealed row")
+            immutable_hash_fields = (
+                "binding_index_sha256",
+                "binding_sha256",
+                "checkpoint_sha256",
+                "checkpoint_manifest_hash",
+                "checkpoint_payload_hash",
+                "source_block_hash",
+                "source_state_root",
+            )
+            for field in immutable_hash_fields:
+                expected_value = archived_fork.get(field)
+                if expected_value is None:
+                    fail(
+                        f"legacy archive {index} has no immutable {field} expectation; "
+                        "fetch the verified binding metadata before publication"
+                    )
+                expected_hash = bare_hash(
+                    expected_value,
+                    f"legacy archive {index} immutable {field}",
+                )
+                if normalized[field] != expected_hash:
+                    fail(
+                        f"legacy archive {index} {field} differs from its immutable binding tree"
+                    )
+            immutable_integer_fields = (
+                "source_height",
+                "source_consensus_round",
+                "recovery_epoch",
+                "validator_set_id",
+            )
+            for field in immutable_integer_fields:
+                expected_value = archived_fork.get(field)
+                if (
+                    isinstance(expected_value, bool)
+                    or not isinstance(expected_value, int)
+                    or expected_value < 0
+                ):
+                    fail(
+                        f"legacy archive {index} has no immutable {field} expectation"
+                    )
+                if proof[field] != expected_value:
+                    fail(
+                        f"legacy archive {index} {field} differs from its immutable binding tree"
+                    )
             if proof["canonical_checkpoint_height"] != self.chain["source_height"]:
                 fail(f"legacy archive {index} canonical checkpoint height differs")
-            if proof["recovery_epoch"] != self.chain["recovery_epoch"]:
+            if archived_fork["recovery_epoch"] != self.chain["recovery_epoch"]:
                 fail(f"legacy archive {index} recovery epoch differs")
-            if proof["validator_set_id"] != self.chain["validator_set_id"]:
+            if archived_fork["validator_set_id"] != self.chain["validator_set_id"]:
                 fail(f"legacy archive {index} validator set differs")
             sources.append(
                 {
@@ -6880,6 +6935,34 @@ class RecoveryRollout:
         """
         if self.manifest["mode"] != "production":
             fail("recovered frontend config requires a production rollout manifest")
+        checkpoint_identity = self.verified_checkpoint_identity
+        if checkpoint_identity is None:
+            fail(
+                "recovered frontend config requires a same-process sealed checkpoint verification"
+            )
+        if set(checkpoint_identity) != {
+            "checkpoint_sha256",
+            "checkpoint_manifest_hash",
+            "checkpoint_payload_hash",
+        }:
+            fail("verified checkpoint identity has an unsupported field set")
+        expected_checkpoint_identity = {
+            "checkpoint_sha256": bare_hash(
+                self.manifest["artifacts"]["checkpoint"]["sha256"],
+                "manifest checkpoint artifact sha256",
+            ),
+            "checkpoint_manifest_hash": bare_hash(
+                self.chain["approved_checkpoint_manifest_hash"],
+                "manifest checkpoint manifest hash",
+            ),
+        }
+        for field, wanted in expected_checkpoint_identity.items():
+            if bare_hash(checkpoint_identity[field], f"verified {field}") != wanted:
+                fail(f"verified {field} differs from the sealed manifest")
+        checkpoint_payload_hash = bare_hash(
+            checkpoint_identity["checkpoint_payload_hash"],
+            "verified checkpoint payload hash",
+        )
         sources = [
             {
                 "id": f"v3-{node['name']}",
@@ -6921,6 +7004,10 @@ class RecoveryRollout:
                 "manifestHash": bare_hash(
                     chain["approved_checkpoint_manifest_hash"], "checkpoint manifest hash"
                 ),
+                "checkpointFileSha256": expected_checkpoint_identity[
+                    "checkpoint_sha256"
+                ],
+                "checkpointPayloadHash": checkpoint_payload_hash,
                 "boundaryBlockHash": bare_hash(
                     chain["transition_block_hash"], "transition block hash"
                 ),
@@ -7121,8 +7208,27 @@ class RecoveryRollout:
                         fail(f"recovery {output_name} {key} differs from the locked manifest")
                 elif got != wanted:
                     fail(f"recovery {output_name} {key} differs: expected {wanted!r}, got {got!r}")
+        inspected_payload = bare_hash(
+            inspected.get("payload_hash"), "recovery inspect.payload_hash"
+        )
+        verified_payload = bare_hash(
+            verified.get("payload_hash"), "recovery verify.payload_hash"
+        )
+        if inspected_payload != verified_payload:
+            fail("recovery inspect/verify payload hashes differ")
         if verified.get("status") != "VERIFIED_QUORUM" or verified.get("signature_count", 0) < REQUIRED_APPROVALS:
             fail("checkpoint does not carry a verified 5-of-6 signature quorum")
+        self.verified_checkpoint_identity = {
+            "checkpoint_sha256": bare_hash(
+                self.manifest["artifacts"]["checkpoint"]["sha256"],
+                "manifest checkpoint artifact sha256",
+            ),
+            "checkpoint_manifest_hash": bare_hash(
+                self.chain["approved_checkpoint_manifest_hash"],
+                "manifest checkpoint manifest hash",
+            ),
+            "checkpoint_payload_hash": inspected_payload,
+        }
         self.say("PASS checkpoint content, GO pin, v3 boundary, and 5-of-6 signature quorum")
 
     def verify_execution_provenance(self) -> None:
@@ -7284,6 +7390,228 @@ class RecoveryRollout:
             fail(f"archive object {name} changed after complete-archive verification")
         return payload
 
+    def _load_remote_legacy_binding_metadata(
+        self,
+        node: Mapping[str, Any],
+        *,
+        binding_index_sha256: str,
+    ) -> dict[str, Any]:
+        """Read the immutable fork identity from its stopped, hash-bound tree.
+
+        The public archive process independently validates these same objects,
+        but its ``/provenance`` response is not itself an out-of-band trust
+        root.  Capture an expected projection here so publication can compare
+        every live field with the exact binding index, binding, and ARCCHKPT
+        retained on the stopped validator.
+        """
+
+        archive = self.manifest["archive"]
+        expected_index = bare_hash(
+            binding_index_sha256,
+            f"legacy archive {node['name']} binding index sha256",
+        )
+        source_root = (
+            f"/root/arc-recovery-bindings/"
+            f"{archive['prearchive_rollout_sha256']}/{node['name']}"
+        )
+        output = self.ssh_read_only(
+            node,
+            "set -eu\n"
+            + self.remote_semantic_python_prelude(node)
+            + r'''root=$1 expected_index=$2 expected_capture=$3 expected_rollout=$4 expected_node=$5
+case "$root" in /root/arc-recovery-bindings/*/"$expected_node") ;; *) exit 1 ;; esac
+test -d "$root" && test ! -L "$root"
+for name in binding.files.sha256 binding.json candidate.arcchkpt; do
+  test -f "$root/$name" && test ! -L "$root/$name"
+  test -z "$(find "$root/$name" -maxdepth 0 -perm /0222 -print -quit)"
+done
+printf '%s  %s\n' "$expected_index" "$root/binding.files.sha256" | sha256sum --check --strict
+arc_semantic_python - "$root" "$expected_index" "$expected_capture" "$expected_rollout" "$expected_node" <<'PY'
+import hashlib,json,os,pathlib,re,stat,sys
+
+root=pathlib.Path(sys.argv[1])
+expected_index,expected_capture,expected_rollout,expected_node=sys.argv[2:]
+
+def digest(path):
+    value=hashlib.sha256()
+    with path.open('rb') as handle:
+        for chunk in iter(lambda:handle.read(1024*1024),b''):
+            value.update(chunk)
+    return value.hexdigest()
+
+def bare(value,label):
+    if not isinstance(value,str): raise SystemExit(f'{label} is not a hash')
+    normalized=value.removeprefix('0x')
+    if re.fullmatch(r'[0-9a-f]{64}',normalized) is None:
+        raise SystemExit(f'{label} is malformed')
+    return normalized
+
+index_path=root/'binding.files.sha256'
+if index_path.stat().st_size>65536 or (root/'binding.json').stat().st_size>4194304:
+    raise SystemExit('binding metadata exceeds its safety limit')
+index_payload=index_path.read_bytes()
+if digest(index_path)!=expected_index or not index_payload.endswith(b'\n') or b'\r' in index_payload or b'\0' in index_payload:
+    raise SystemExit('binding index bytes differ')
+rows={}
+for line in index_payload.decode('ascii').splitlines():
+    match=re.fullmatch(r'([0-9a-f]{64})  ([A-Za-z0-9_.@/+:-]+)',line)
+    if match is None or match.group(2) in rows:
+        raise SystemExit('unsafe or duplicate binding index row')
+    rows[match.group(2)]=match.group(1)
+if 'binding.json' not in rows or 'candidate.arcchkpt' not in rows:
+    raise SystemExit('binding index omits archive inputs')
+
+binding_path=root/'binding.json'
+checkpoint_path=root/'candidate.arcchkpt'
+if digest(binding_path)!=rows['binding.json'] or digest(checkpoint_path)!=rows['candidate.arcchkpt']:
+    raise SystemExit('binding index content hash differs')
+binding_payload=binding_path.read_bytes()
+try: binding=json.loads(binding_payload)
+except (UnicodeDecodeError,json.JSONDecodeError) as error:
+    raise SystemExit(f'binding is invalid JSON: {error}')
+binding_fields={
+    'schema','capture_id','node','rollout_manifest_sha256',
+    'source_consensus_round','created_at_unix_ms','allow_unbound_legacy_wal',
+    'legacy_validator_set_artifact_sha256','source_snapshot_artifact_sha256',
+    'reference_source_wal_artifact_sha256','export_exit_code','classification',
+    'classification_reason','canonical_match','expected','exported',
+}
+if not isinstance(binding,dict) or set(binding)!=binding_fields:
+    raise SystemExit('binding field set differs')
+canonical=(json.dumps(binding,sort_keys=True,separators=(',',':'))+'\n').encode()
+if binding_payload!=canonical:
+    raise SystemExit('binding is not canonical JSON')
+if (binding.get('schema')!='arc.recovery.capture-binding.v3'
+        or bare(binding.get('capture_id'),'binding capture id')!=expected_capture
+        or binding.get('node')!=expected_node
+        or bare(binding.get('rollout_manifest_sha256'),'binding rollout')!=expected_rollout
+        or binding.get('classification')!='valid_noncanonical_fork'
+        or binding.get('canonical_match') is not False
+        or binding.get('export_exit_code')!=0):
+    raise SystemExit('binding identity/classification differs')
+exported=binding.get('exported')
+exported_fields={
+    'source_height','source_block_hash','source_state_root','full_state_root',
+    'source_consensus_round','created_at_unix_ms','recovery_epoch',
+    'validator_set_id','manifest_hash','payload_hash','source_validator_count',
+    'source_validator_stake','source_validator_set_hash',
+}
+if not isinstance(exported,dict) or set(exported)!=exported_fields:
+    raise SystemExit('binding exported field set differs')
+for field in ('source_height','source_consensus_round','recovery_epoch','validator_set_id'):
+    if isinstance(exported.get(field),bool) or not isinstance(exported.get(field),int) or exported[field]<0:
+        raise SystemExit(f'binding exported {field} is malformed')
+value={
+    'schema':'arc.recovery.legacy-archive-binding-projection.v1',
+    'node':expected_node,
+    'binding_index_sha256':expected_index,
+    'binding_sha256':rows['binding.json'],
+    'checkpoint_sha256':rows['candidate.arcchkpt'],
+    'checkpoint_manifest_hash':bare(exported.get('manifest_hash'),'checkpoint manifest hash'),
+    'checkpoint_payload_hash':bare(exported.get('payload_hash'),'checkpoint payload hash'),
+    'source_height':exported['source_height'],
+    'source_block_hash':bare(exported.get('source_block_hash'),'source block hash'),
+    'source_state_root':bare(exported.get('source_state_root'),'source state root'),
+    'source_consensus_round':exported['source_consensus_round'],
+    'recovery_epoch':exported['recovery_epoch'],
+    'validator_set_id':exported['validator_set_id'],
+}
+sys.stdout.write(json.dumps(value,sort_keys=True,separators=(',',':'))+'\n')
+PY
+arc_semantic_python_revalidate
+''',
+            (
+                source_root,
+                expected_index,
+                archive["capture_id"],
+                archive["prearchive_rollout_sha256"],
+                node["name"],
+            ),
+            timeout=3600,
+        )
+        try:
+            metadata = require_keys(
+                json.loads(output),
+                f"legacy archive {node['name']} immutable binding projection",
+                (
+                    "schema", "node", "binding_index_sha256", "binding_sha256",
+                    "checkpoint_sha256", "checkpoint_manifest_hash",
+                    "checkpoint_payload_hash", "source_height", "source_block_hash",
+                    "source_state_root", "source_consensus_round", "recovery_epoch",
+                    "validator_set_id",
+                ),
+            )
+        except json.JSONDecodeError as error:
+            fail(f"legacy archive {node['name']} binding projection is invalid JSON: {error}")
+        if output.encode("utf-8") != canonical_bytes(metadata):
+            fail(f"legacy archive {node['name']} binding projection is noncanonical")
+        if metadata["schema"] != "arc.recovery.legacy-archive-binding-projection.v1":
+            fail(f"legacy archive {node['name']} binding projection schema differs")
+        if metadata["node"] != node["name"]:
+            fail(f"legacy archive {node['name']} binding projection node differs")
+        for field in (
+            "binding_index_sha256", "binding_sha256", "checkpoint_sha256",
+            "checkpoint_manifest_hash", "checkpoint_payload_hash",
+            "source_block_hash", "source_state_root",
+        ):
+            metadata[field] = bare_hash(
+                metadata[field], f"legacy archive {node['name']} {field}"
+            )
+        if metadata["binding_index_sha256"] != expected_index:
+            fail(f"legacy archive {node['name']} binding index projection differs")
+        for field in (
+            "source_height", "source_consensus_round", "recovery_epoch",
+            "validator_set_id",
+        ):
+            required_int(
+                metadata[field],
+                f"legacy archive {node['name']} {field}",
+            )
+        return metadata
+
+    def _enrich_legacy_archive_fork_rows(
+        self, fork_rows: Sequence[Mapping[str, str]]
+    ) -> dict[str, dict[str, Any]]:
+        """Resolve every fork row through its hash-pinned inventory and binding."""
+
+        archive = self.manifest["archive"]
+        validators_by_name = {node["name"]: node for node in self.validators}
+        deployments: dict[str, dict[str, Any]] = {}
+        for supplied in fork_rows:
+            row = dict(supplied)
+            node = row["node"]
+            if node not in validators_by_name or node in deployments:
+                fail("legacy archive metadata has an unknown or duplicate validator")
+            expected_inventory_name = f"legacy-{node}.inventory"
+            expected_bundle_name = f"legacy-{node}.tar.zst"
+            if (
+                row["inventory_name"] != expected_inventory_name
+                or row["bundle_name"] != expected_bundle_name
+            ):
+                fail(f"legacy archive row for {node} uses noncanonical object names")
+            inventory_payload = self._rclone_cat_pinned_archive_object(
+                expected_inventory_name,
+                row["inventory_sha256"],
+                max_bytes=64 * 1024,
+            )
+            inventory = parse_legacy_archive_inventory(
+                inventory_payload,
+                node=node,
+                capture_id=archive["capture_id"],
+                rollout_manifest_sha256=archive["prearchive_rollout_sha256"],
+            )
+            binding_metadata = self._load_remote_legacy_binding_metadata(
+                validators_by_name[node],
+                binding_index_sha256=inventory["binding_index_sha256"],
+            )
+            deployments[node] = {
+                **row,
+                "inventory_payload": inventory_payload,
+                "binding_index_sha256": inventory["binding_index_sha256"],
+                **binding_metadata,
+            }
+        return deployments
+
     def load_production_archive_metadata(self) -> None:
         """Fetch only hash-pinned small metadata needed to deploy fork readers.
 
@@ -7319,32 +7647,7 @@ class RecoveryRollout:
                 self, archive_manifest_path, complete_path
             )
 
-        deployments: dict[str, dict[str, Any]] = {}
-        for row in fork_rows:
-            node = row["node"]
-            expected_inventory_name = f"legacy-{node}.inventory"
-            expected_bundle_name = f"legacy-{node}.tar.zst"
-            if (
-                row["inventory_name"] != expected_inventory_name
-                or row["bundle_name"] != expected_bundle_name
-            ):
-                fail(f"legacy archive row for {node} uses noncanonical object names")
-            inventory_payload = self._rclone_cat_pinned_archive_object(
-                expected_inventory_name,
-                row["inventory_sha256"],
-                max_bytes=64 * 1024,
-            )
-            inventory = parse_legacy_archive_inventory(
-                inventory_payload,
-                node=node,
-                capture_id=archive["capture_id"],
-                rollout_manifest_sha256=archive["prearchive_rollout_sha256"],
-            )
-            deployments[node] = {
-                **row,
-                "inventory_payload": inventory_payload,
-                "binding_index_sha256": inventory["binding_index_sha256"],
-            }
+        deployments = self._enrich_legacy_archive_fork_rows(fork_rows)
         self.archive_manifest_payload = manifest_payload
         self.archive_complete_payload = complete_payload
         self.legacy_archive_forks = deployments
@@ -12869,6 +13172,7 @@ arc_semantic_python_revalidate
             + self.remote_semantic_python_prelude(node)
             + r'''root=$1 service=$2 rollout=$3 target=$4 maintenance_sha=$5 live_sha=$6 intent_sha=$7
 height=$8 block_hash=$9 state_root=${10} hostname=${11} node_name=${12} gateway_user=${13}
+validator_socket=${14}
 case "$target" in live) source_name=Caddyfile.live; source_sha=$live_sha ;; maintenance) source_name=Caddyfile.maintenance; source_sha=$maintenance_sha ;; *) exit 1 ;; esac
 case "$height" in ''|*[!0-9]*) exit 1 ;; esac
 for value in "$rollout" "$maintenance_sha" "$live_sha" "$intent_sha" "$block_hash" "$state_root"; do case "$value" in *[!0-9a-f]*|'') exit 1 ;; esac; test "${#value}" = 64; done
@@ -12886,6 +13190,32 @@ if test -e "$gate"; then
   test "$(stat -c %U:%G:%a "$gate")" = root:root:700
 else
   mkdir --mode=0700 "$gate"
+fi
+if [ "$target" = live ]; then
+  test -S "$validator_socket" && test ! -L "$validator_socket"
+  curl --silent --show-error --fail --connect-timeout 5 --max-time 30 \
+    --unix-socket "$validator_socket" "http://localhost/block/$height" | \
+    arc_semantic_python -c '
+import json,re,sys
+height=int(sys.argv[1]); block_hash=sys.argv[2]; state_root=sys.argv[3]
+payload=sys.stdin.buffer.read(16*1024*1024+1)
+if len(payload)>16*1024*1024: raise SystemExit("local final block response is oversized")
+value=json.loads(payload)
+block=value.get("block",value) if isinstance(value,dict) else None
+header=block.get("header") if isinstance(block,dict) else None
+if not isinstance(header,dict): raise SystemExit("local final block has no header")
+def bare(value,label):
+    if not isinstance(value,str): raise SystemExit(f"local final {label} is not a hash")
+    value=value.removeprefix("0x")
+    if re.fullmatch(r"[0-9a-f]{64}",value) is None: raise SystemExit(f"local final {label} is malformed")
+    return value
+observed_height=header.get("height",block.get("height"))
+observed_hash=header.get("hash",block.get("hash"))
+observed_root=header.get("state_root",header.get("stateRoot",block.get("state_root")))
+if observed_height!=height or bare(observed_hash,"block hash")!=block_hash or bare(observed_root,"state root")!=state_root:
+    raise SystemExit("local validator final commitment differs immediately before promotion")
+' "$height" "$block_hash" "$state_root"
+  arc_semantic_python_revalidate
 fi
 temporary=$(mktemp "$root/.Caddyfile.active.XXXXXX")
 trap 'rm -f -- "$temporary"' EXIT HUP INT TERM
@@ -12954,6 +13284,7 @@ arc_semantic_python_revalidate
                 node["host"],
                 node["name"],
                 CADDY_USER,
+                self.validator_rpc_socket(node),
             ),
             timeout=120,
         )
@@ -13007,11 +13338,14 @@ arc_semantic_python_revalidate
             fail("PUBLIC_GATE_MAINTENANCE_INCOMPLETE: " + "; ".join(failures))
         self.say("PASS every reachable production edge is durably maintenance-only")
 
-    def open_public_gate(
-        self,
-        initial: tuple[int, str, str],
-        final: tuple[int, str, str],
-    ) -> str:
+    def open_public_gate(self) -> str:
+        # Complete-archive verification belongs before this method.  Once the
+        # final advancing proof starts, no potentially long-running task may
+        # separate that proof from the host-local promotion checks below.
+        self.wait_nodes_ready()
+        self.prove_production_runtime_inventory()
+        self.prove_boundary()
+        initial, final = self.prove_advancing_convergence()
         legacy_max = self.chain["legacy_public_max_height"]
         if initial[0] <= legacy_max:
             fail("public gate opening proof is not strictly above the legacy maximum")
@@ -13059,32 +13393,48 @@ arc_semantic_python_revalidate
                     receipts[name] = future.result()
                 except BaseException as error:
                     failures.append(f"{name}:{type(error).__name__}:{error}")
-        if failures:
+        try:
+            if failures:
+                fail("PUBLIC_GATE_OPEN_INCOMPLETE: " + "; ".join(failures))
+            if set(receipts) != {node["name"] for node in self.validators}:
+                fail("public gate promotion receipt set is not the exact six")
+            # Keep semantic checks on authenticated SSH+loopback until every
+            # edge has switched. Any post-switch mismatch returns every
+            # reachable edge to maintenance before success is recorded.
+            self.wait_nodes_ready()
+            self.prove_boundary()
+            post_promotion = self.wait_convergence(minimum_height=final[0])
+            if post_promotion[0] < final[0]:
+                fail("post-promotion convergence fell below the promotion commitment")
+            # Host receipts contain identical commitment/config roots; preserve
+            # fleet order separately so a missing or duplicated result is visible.
+            receipt = {
+                "schema": "arc.recovery.public-gate-open-receipt.v2",
+                "rollout_manifest_sha256": self.digest,
+                "promotion_intent_sha256": intent_sha,
+                "final": self._commitment_receipt(final),
+                "post_promotion": self._commitment_receipt(post_promotion),
+                "nodes": [
+                    {
+                        "node": node["name"],
+                        "host": node["host"],
+                        "receipt_sha256": sha256_bytes(canonical_bytes(host_receipt)),
+                    }
+                    for node in self.validators
+                    for host_receipt in (receipts[node["name"]],)
+                ],
+            }
+            receipt_sha = self._rollback_journal_write(
+                "PUBLIC-GATE-OPEN-RECEIPT.json", receipt
+            )
+        except BaseException as original:
             try:
                 self.close_public_gate(intent_sha)
             except BaseException as close_error:
-                failures.append(f"maintenance-reclose:{type(close_error).__name__}:{close_error}")
-            fail("PUBLIC_GATE_OPEN_INCOMPLETE: " + "; ".join(failures))
-        if set(receipts) != {node["name"] for node in self.validators}:
-            fail("public gate promotion receipt set is not the exact six")
-        # Host receipts contain identical commitment/config roots; preserve
-        # fleet order separately so a missing or duplicated result is visible.
-        receipt = {
-            "schema": "arc.recovery.public-gate-open-receipt.v1",
-            "rollout_manifest_sha256": self.digest,
-            "promotion_intent_sha256": intent_sha,
-            "final": self._commitment_receipt(final),
-            "nodes": [
-                {
-                    "node": node["name"],
-                    "host": node["host"],
-                    "receipt_sha256": sha256_bytes(canonical_bytes(host_receipt)),
-                }
-                for node in self.validators
-                for host_receipt in (receipts[node["name"]],)
-            ],
-        }
-        receipt_sha = self._rollback_journal_write("PUBLIC-GATE-OPEN-RECEIPT.json", receipt)
+                raise RolloutError(
+                    f"{original}; public maintenance reclose failed: {close_error}"
+                ) from original
+            raise
         self.public_gate_receipt_sha256 = receipt_sha
         self.production_public_gate_open = True
         self.say(
@@ -14652,10 +15002,9 @@ printf 'legacy_start_barrier_active=1\nquarantine_retired=1\n'
                     restart_index, "RESTART", "COMPLETE", node=node
                 )
                 self.say(f"PASS {node['name']} production restart; fleet advanced #{before} -> #{after[0]}")
-            promotion_initial, promotion_final = self.prove_advancing_convergence()
             self.verify_production_archive(verify_live_captures=True)
             self._rollback_journal_event(30, "PUBLIC-OPEN", "STARTED")
-            self.open_public_gate(promotion_initial, promotion_final)
+            self.open_public_gate()
             self._rollback_journal_event(30, "PUBLIC-OPEN", "COMPLETE")
             for node in self.validators:
                 self._prove_production_listener(node, public_contract=True)

--- a/scripts/recovery/test_archive_node_quarantine_runtime.py
+++ b/scripts/recovery/test_archive_node_quarantine_runtime.py
@@ -249,7 +249,7 @@ class EmbeddedProgramTests(unittest.TestCase):
         ):
             self.assertIn(required, source)
 
-    def test_v1_and_v2_dispatch_are_additive(self) -> None:
+    def test_v3_and_v4_persisted_heads_bind_the_durable_dag_cursor(self) -> None:
         self.assertIn("capture-live-source)", self.shell)
         self.assertIn("capture-normalized-live-source)", self.shell)
         self.assertIn("wal-normalizer) filename=normalize-legacy-wal.py; mode=500", self.shell)
@@ -257,7 +257,19 @@ class EmbeddedProgramTests(unittest.TestCase):
             "wal-normalization-plan) filename=legacy-wal-normalization-plan.json; mode=400",
             self.shell,
         )
-        self.assertIn("arc.recovery.persisted-legacy-head.v2", self.shell)
+        self.assertIn("arc.recovery.persisted-legacy-head.v3", self.shell)
+        self.assertIn("arc.recovery.persisted-legacy-head.v4", self.shell)
+        self.assertIn("recovery inspect-legacy-dag-round", self.shell)
+        self.assertIn('"legacy_dag_round"', self.shell)
+        self.assertIn('"inspection": dag_inspection', self.shell)
+        self.assertIn('sha(canonical(dag_inspection))', self.shell)
+        self.assertIn('"trusted_anchor_ancestry"', self.shell)
+        self.assertIn('"valid_anchor_descendant"', self.shell)
+        self.assertIn('"below_trusted_anchor"', self.shell)
+        self.assertIn(
+            "arc.recovery.persisted-legacy-head-stopped-precommit.v2", self.shell
+        )
+        self.assertIn('"legacy_dag_wal_dir"', self.shell)
         self.assertIn("exact-content-pinned-normalization-source", self.shell)
 
     def test_fleet_stages_normalization_only_for_lax_and_ams(self) -> None:

--- a/scripts/recovery/test_build_production_manifest.py
+++ b/scripts/recovery/test_build_production_manifest.py
@@ -239,7 +239,7 @@ class Fixture:
         write(self.summary_path, canonical(self.summary), 0o444)
         self.binary = root / "arc-node-linux-x86_64"
         fake = f"""#!{sys.executable}
-import json,pathlib,sys
+import hashlib,json,pathlib,sys
 root=pathlib.Path({str(root)!r})
 value=json.loads((root/'checkpoint-summary.json').read_text())
 argv=sys.argv[1:]
@@ -254,6 +254,22 @@ elif action=='verify':
     value['status']='VERIFIED_QUORUM'; value['signature_count']=5
 elif action=='inspect':
     value['status']='UNTRUSTED_INSPECTION'; value['signature_count']=5
+elif action=='inspect-legacy-block':
+    def file_sha(flag):
+        return hashlib.sha256(pathlib.Path(argv[argv.index(flag)+1]).read_bytes()).hexdigest()
+    value={{
+        'schema':'arc.recovery.legacy-block-inspection.v1',
+        'height':137145,
+        'block_hash':'8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90',
+        'state_root':'d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d',
+        'input_roots':{{
+            'data_dir':{{'sha256':'f'*64}},
+            'state_wal':{{'sha256':argv[argv.index('--expected-state-wal-sha256')+1]}},
+            'snapshot':{{'sha256':file_sha('--snapshot')}},
+            'genesis':{{'sha256':file_sha('--genesis')}},
+            'legacy_validator_set':{{'sha256':file_sha('--legacy-validator-set')}},
+        }},
+    }}
 else:
     print('unsupported fake command',file=sys.stderr); raise SystemExit(8)
 print(json.dumps(value,sort_keys=True))
@@ -423,6 +439,8 @@ print(json.dumps(value,sort_keys=True))
         self.write_offline_stop()
         self.late_fork_source_set = root / "legacy-late-fork-source-set.json"
         self.rebuild_late_fork_source_set()
+        self.source_preselection = root / "canonical-source-preselection.json"
+        self.write_source_preselection()
         self.known_hosts = root / "known_hosts"
         known_lines = []
         for index, (_name, host) in enumerate(builder.FLEET):
@@ -449,12 +467,12 @@ print(json.dumps(value,sort_keys=True))
             "full_state_root": "0x" + "3" * 64,
             "chain_id": "0x415243",
             "genesis_hash": "0x" + "0" * 64,
-            "source_height": 137145,
-            "source_block_hash": "0x" + "1" * 64,
-            "source_state_root": "0x" + "5" * 64,
-            "source_consensus_round": 9_774_808,
+            "source_height": 141_062,
+            "source_block_hash": "0x" + f"{190:064x}",
+            "source_state_root": "0x" + f"{200:064x}",
+            "source_consensus_round": 10_000_001,
             "created_at_unix_ms": 1_787_857_623_000,
-            "transition_height": 137146,
+            "transition_height": 141_063,
             "transition_block_hash": "0x" + "2" * 64,
             "recovery_domain": "0x" + "6" * 64,
             "recovery_epoch": 1,
@@ -466,6 +484,7 @@ print(json.dumps(value,sort_keys=True))
             "source_validator_stake": 40_000_000,
             "source_validator_set_hash": "0x" + "8" * 64,
             "community_reward_issuance_policy_hash": "0x" + "9" * 64,
+            "community_rewards_v1_activation_height": 137_146,
         }
 
     def write_freeze(self, mutate=None) -> str:
@@ -517,7 +536,7 @@ print(json.dumps(value,sort_keys=True))
         timestamp = now.isoformat().replace("+00:00", "Z")
         rows = []
         for index, (name, _host, origin) in enumerate(builder.legacy_height.FLEET):
-            height = 137500 + index
+            height = 141_060 + index
             rows.append(
                 {
                     "name": name,
@@ -1322,8 +1341,98 @@ print(json.dumps(value,sort_keys=True))
             stability_heads.append(
                 {"node": name, "host": host, "head": copy.deepcopy(later_tuple)}
             )
+            wal_hash = (
+                sha(self.wal.read_bytes()) if index == 0 else f"{index + 248:064x}"
+            )
+            snapshot_hash = (
+                sha(self.snapshot.read_bytes()) if index == 0 else f"{index + 249:064x}"
+            )
+            def inspection_file_identity(
+                digest: str, size: int, identity_index: int
+            ) -> dict[str, int | str]:
+                return {
+                    "device": 10_000 + identity_index,
+                    "inode": 20_000 + identity_index,
+                    "mode": 0o100400,
+                    "uid": 0,
+                    "gid": 0,
+                    "nlink": 1,
+                    "sha256": digest,
+                    "size": size,
+                    "mtime_ns": 30_000 + identity_index,
+                    "ctime_ns": 40_000 + identity_index,
+                }
+
+            anchor_inspection = {
+                "schema": "arc.recovery.legacy-block-inspection.v1",
+                "height": 137_145,
+                "block_hash": (
+                    "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90"
+                    if index == 0
+                    else f"{index + 700:064x}"
+                ),
+                "state_root": (
+                    "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d"
+                    if index == 0
+                    else f"{index + 710:064x}"
+                ),
+                "input_roots": {
+                    "data_dir": {
+                        "device": 1_000 + index,
+                        "inode": 2_000 + index,
+                        "mode": 0o40700,
+                        "uid": 0,
+                        "gid": 0,
+                        "nlink": 2,
+                        "mtime_ns": 3_000 + index,
+                        "ctime_ns": 4_000 + index,
+                    },
+                    "state_wal": inspection_file_identity(wal_hash, 3, index * 10),
+                    "snapshot": inspection_file_identity(
+                        snapshot_hash, 8, index * 10 + 1
+                    ),
+                    "genesis": inspection_file_identity(
+                        sha(self.genesis.read_bytes()), len(self.genesis.read_bytes()),
+                        index * 10 + 2,
+                    ),
+                    "legacy_validator_set": inspection_file_identity(
+                        sha(self.legacy.read_bytes()), len(self.legacy.read_bytes()),
+                        index * 10 + 3,
+                    ),
+                },
+            }
+            dag_namespace = {
+                "schema": "arc.recovery.legacy-dag-wal-namespace.v1",
+                "segment_names": ["wal-00000001.bin"],
+                "inspected_tail": [
+                    {
+                        "name": "wal-00000001.bin",
+                        "sha256": f"{index + 720:064x}",
+                        "size": 64 + index,
+                    }
+                ],
+            }
+            dag_namespace_sha = sha(
+                json.dumps(
+                    dag_namespace, sort_keys=True, separators=(",", ":")
+                ).encode("utf-8")
+            )
+            dag_inspection = {
+                "schema": "arc.recovery.legacy-dag-round-inspection.v1",
+                "status": "VERIFIED_STOPPED_DAG_CURSOR",
+                "source_consensus_round": 10_000_001 + index,
+                "first_segment": 1,
+                "last_segment": 1,
+                "segment_count": 1,
+                "inspected_first_segment": 1,
+                "inspected_segment_count": 1,
+                "inspected_entry_count": 1,
+                "namespace_sha256": dag_namespace_sha,
+                "namespace": dag_namespace,
+                "read_only": True,
+            }
             persisted = {
-                "schema": "arc.recovery.persisted-legacy-head.v1",
+                "schema": "arc.recovery.persisted-legacy-head.v3",
                 "source_main_commit": self.commit,
                 "capture_id": capture,
                 "node": name,
@@ -1344,9 +1453,9 @@ print(json.dumps(value,sort_keys=True))
                 "capture_files_sha256": f"{index + 245:064x}",
                 "capture_source_sha256": f"{index + 246:064x}",
                 "source_data_index_sha256": f"{index + 247:064x}",
-                "state_wal_sha256": f"{index + 248:064x}",
+                "state_wal_sha256": wal_hash,
                 "state_wal_size": 3,
-                "snapshot_sha256": f"{index + 249:064x}",
+                "snapshot_sha256": snapshot_hash,
                 "snapshot_size": 8,
                 "source_file_identity": {"state_wal": {}, "snapshot": {}},
                 "archived_final_wal": {
@@ -1360,7 +1469,9 @@ print(json.dumps(value,sort_keys=True))
                         "mode": 0o100600,
                     },
                     "selected_prefix_bytes": 3,
-                    "selected_prefix_sha256": f"{index + 248:064x}",
+                    "selected_prefix_sha256": (
+                        sha(self.wal.read_bytes()) if index == 0 else f"{index + 248:064x}"
+                    ),
                     "post_capture_suffix_bytes": 0,
                     "post_capture_suffix_sha256": None,
                     "post_capture_suffix_classification": "none",
@@ -1370,7 +1481,7 @@ print(json.dumps(value,sort_keys=True))
                 },
                 "staged_file_contract": {
                     "state_wal": {
-                        "sha256": f"{index + 248:064x}",
+                        "sha256": wal_hash,
                         "size": 3,
                         "mode": 0o100400,
                         "uid": 0,
@@ -1378,7 +1489,7 @@ print(json.dumps(value,sort_keys=True))
                         "nlink": 1,
                     },
                     "snapshot": {
-                        "sha256": f"{index + 249:064x}",
+                        "sha256": snapshot_hash,
                         "size": 8,
                         "mode": 0o100400,
                         "uid": 0,
@@ -1405,6 +1516,26 @@ print(json.dumps(value,sort_keys=True))
                     "validator_set_id": 1,
                     "allow_unbound_legacy_wal": True,
                     "read_only": True,
+                },
+                "legacy_dag_round": {
+                    "source_consensus_round": 10_000_001 + index,
+                    "namespace_sha256": dag_namespace_sha,
+                    "inspection": dag_inspection,
+                    "inspection_sha256": sha(canonical(dag_inspection)),
+                },
+                "trusted_anchor_ancestry": {
+                    "anchor_height": 137_145,
+                    "anchor_block_hash": (
+                        "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90"
+                    ),
+                    "anchor_state_root": (
+                        "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d"
+                    ),
+                    "classification": (
+                        "valid_anchor_descendant" if index == 0 else "conflicting_anchor"
+                    ),
+                    "inspection": anchor_inspection,
+                    "inspection_sha256": sha(canonical(anchor_inspection)),
                 },
                 "completed_at": all_stopped,
                 "rerun_reexecutes_export": True,
@@ -2071,6 +2202,47 @@ print(json.dumps(value,sort_keys=True))
                 0o400,
             )
 
+    def write_source_preselection(self) -> None:
+        bundle = json.loads(self.bundle.read_text())
+        boundary = json.loads(self.boundary.read_text())
+        canonical_source, selection = builder.select_canonical_source(None, bundle, None)
+        selected = next(
+            row for row in bundle["nodes"] if row["node"] == canonical_source["node"]
+        )["persisted_head"]
+        pair = builder.persisted_source_pair(
+            selected["value"], "fixture selected source pair"
+        )
+        value = {
+            "schema": "arc.recovery.canonical-source-preselection.v1",
+            "source_main_commit": self.commit,
+            "freeze_plan_sha256": self.freeze_sha,
+            "legacy_maintenance_evidence_bundle_sha256": sha(self.bundle.read_bytes()),
+            "legacy_maintenance_boundary_sha256": sha(self.boundary.read_bytes()),
+            "source_height": canonical_source["source_height"],
+            "transition_height": canonical_source["source_height"] + 1,
+            "source_block_hash": canonical_source["source_block_hash"],
+            "source_state_root": canonical_source["source_state_root"],
+            "source_consensus_round": canonical_source["source_consensus_round"],
+            "observed_cutoff_height": boundary["observed_cutoff_height"],
+            "reopening_floor_height": boundary["legacy_public_max_height"],
+            "selected_source_pair": {
+                "node": canonical_source["node"],
+                "persisted_head_schema": selected["value"]["schema"],
+                "persisted_head_sha256": selected["sha256"],
+                "state_wal": pair["state_wal"],
+                "snapshot": pair["snapshot"],
+            },
+            "canonical_source": canonical_source,
+            "canonical_source_selection": selection,
+        }
+        payload = canonical(value)
+        write(self.source_preselection, payload, 0o400)
+        write(
+            self.source_preselection.with_name(self.source_preselection.name + ".sha256"),
+            f"{sha(payload)}  {self.source_preselection.name}\n".encode(),
+            0o400,
+        )
+
     def write_union_maintenance(self, stopped_names: set[str]) -> None:
         """Rewrite the canonical active fixture as an exact mixed-state union."""
 
@@ -2084,7 +2256,17 @@ print(json.dumps(value,sort_keys=True))
             name = active_transition["node"]
             if name not in stopped_names:
                 continue
+            active_persisted = next(
+                row["persisted_head"]["value"]
+                for row in bundle["nodes"]
+                if row["node"] == name
+            )
             stable_head = copy.deepcopy(active_transition["stable_head"])
+            stable_head = {
+                "height": 137_000 - index,
+                "block_hash": f"{index + 6400:064x}",
+                "state_root": f"{index + 6500:064x}",
+            }
             fence = builder.quarantine_rounds.wrap(
                 {
                     "schema": "arc.recovery.fixture-persistent-restart-fence.v1",
@@ -2103,6 +2285,27 @@ print(json.dumps(value,sort_keys=True))
                 "source_inputs": {
                     "source_pair_role": "preauthorization-boundary",
                     "live_source_capture_sha256": live_capture_sha,
+                    "fixed_state_wal": {
+                        "sha256": active_persisted["state_wal_sha256"],
+                        "size": active_persisted["state_wal_size"],
+                    },
+                    "fixed_snapshot": {
+                        "sha256": active_persisted["snapshot_sha256"],
+                        "size": active_persisted["snapshot_size"],
+                    },
+                },
+                "legacy_dag_round": copy.deepcopy(active_persisted["legacy_dag_round"]),
+                "trusted_anchor_ancestry": {
+                    "anchor_height": 137_145,
+                    "anchor_block_hash": (
+                        "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90"
+                    ),
+                    "anchor_state_root": (
+                        "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d"
+                    ),
+                    "classification": "below_trusted_anchor",
+                    "inspection": None,
+                    "inspection_sha256": sha(canonical(None)),
                 },
             }
             persisted_wrapper = builder.quarantine_rounds.wrap(persisted)
@@ -2366,6 +2569,7 @@ print(json.dumps(value,sort_keys=True))
             0o400,
         )
         self.write_validator_receipts()
+        self.write_source_preselection()
 
     def remote_verification(
         self,
@@ -2527,6 +2731,7 @@ print(json.dumps(value,sort_keys=True))
             freeze_plan_sha256=self.freeze_sha,
             legacy_public_height_receipt=self.height,
             legacy_maintenance_evidence_bundle=self.bundle,
+            canonical_source_preselection=self.source_preselection,
             legacy_maintenance_boundary=self.boundary,
             legacy_late_fork_source_set=self.late_fork_source_set,
             offline_stop_evidence=self.offline_stop,
@@ -2841,6 +3046,14 @@ print(json.dumps(value,sort_keys=True))
             "legacy-maintenance-evidence-bundle.json.sha256": art(
                 "legacy_maintenance_evidence_bundle_sidecar",
                 "legacy-maintenance-evidence-bundle.json.sha256",
+            ),
+            "canonical-source-preselection.json": art(
+                "canonical_source_preselection",
+                "canonical-source-preselection.json",
+            ),
+            "canonical-source-preselection.json.sha256": art(
+                "canonical_source_preselection_sidecar",
+                "canonical-source-preselection.json.sha256",
             ),
             "legacy-maintenance-boundary.json": art(
                 "legacy_maintenance_boundary", "legacy-maintenance-boundary.json"
@@ -3219,15 +3432,26 @@ class ProductionManifestBuilderTests(unittest.TestCase):
             stat.S_IMODE(self.fixture.output.with_name(self.fixture.output.name + ".sha256").stat().st_mode),
             0o400,
         )
-        self.assertEqual(value["chain"]["legacy_observed_cutoff_height"], 137507)
+        self.assertEqual(value["chain"]["legacy_observed_cutoff_height"], 141_067)
         self.assertEqual(value["chain"]["legacy_continuity_safety_margin"], 128)
-        self.assertEqual(value["chain"]["legacy_public_max_height"], 137635)
+        self.assertEqual(value["chain"]["legacy_public_max_height"], 141_195)
         self.assertFalse(value["chain"]["legacy_global_absence_claimed"])
         self.assertEqual(
             value["chain"]["legacy_maintenance_boundary_sha256"],
             value["artifacts"]["legacy_maintenance_boundary"]["sha256"],
         )
-        self.assertEqual(value["chain"]["source_height"], 137145)
+        self.assertEqual(value["chain"]["source_height"], 141_062)
+        selection = value["chain"]["canonical_source_selection"]
+        self.assertEqual(selection["sha256"], sha(canonical(selection["value"])))
+        self.assertEqual(selection["value"]["selected"]["node"], "nyc")
+        self.assertEqual(
+            [row["classification"] for row in selection["value"]["candidates"]],
+            ["valid_anchor_descendant", *("conflicting_anchor" for _ in range(5))],
+        )
+        self.assertEqual(
+            value["artifacts"]["canonical_source_preselection"]["sha256"],
+            sha(self.fixture.source_preselection.read_bytes()),
+        )
         self.assertEqual(value["provenance"]["source_main_commit"], self.fixture.commit)
         installed = value["provenance"]["validator_installed_key_proof"]
         self.assertEqual(installed["schema"], "arc.recovery.validator-installed-key-proof.v1")
@@ -3351,10 +3575,12 @@ class ProductionManifestBuilderTests(unittest.TestCase):
             sha(self.fixture.bundle.read_bytes()),
         )
 
-    def test_prearchive_accepts_exact_all_stopped_zero_sample_union(self) -> None:
-        value, _digest = self.build_union_fixture(
-            {name for name, _host in builder.FLEET}
-        )
+    def test_prearchive_rejects_all_stopped_union_without_a_replay_pair(self) -> None:
+        with self.assertRaisesRegex(
+            builder.BuilderError,
+            "captured fleet has no valid descendant",
+        ):
+            self.build_union_fixture({name for name, _host in builder.FLEET})
         bundle = json.loads(self.fixture.bundle.read_text())
         stability = bundle["quarantine_stability_proof"]["value"]
         self.assertEqual(stability["nodes"], [])
@@ -3368,10 +3594,118 @@ class ProductionManifestBuilderTests(unittest.TestCase):
             ),
             (0, 0, 0),
         )
+
+    def test_select_source_seals_full_presign_decision_before_checkpoint_exists(self) -> None:
+        args = self.fixture.args()
+        args.output = self.fixture.root / "fresh-source-preselection.json"
+        digest = builder.select_source(args)
+        value = json.loads(args.output.read_text())
+        self.assertEqual(digest, sha(args.output.read_bytes()))
+        self.assertEqual(value["schema"], "arc.recovery.canonical-source-preselection.v1")
+        self.assertEqual(value["source_height"], 141_062)
+        self.assertEqual(value["transition_height"], 141_063)
+        self.assertEqual(value["selected_source_pair"]["node"], "nyc")
+        self.assertEqual(value["source_consensus_round"], 10_000_001)
+        self.assertEqual(value["observed_cutoff_height"], 141_067)
+        self.assertEqual(value["reopening_floor_height"], 141_195)
         self.assertEqual(
-            value["chain"]["legacy_maintenance_evidence_bundle_sha256"],
-            sha(self.fixture.bundle.read_bytes()),
+            value["canonical_source_selection"]["sha256"],
+            sha(canonical(value["canonical_source_selection"]["value"])),
         )
+
+    def test_canonical_selection_rejects_a_lower_supplied_descendant(self) -> None:
+        bundle = json.loads(self.fixture.bundle.read_text())
+        lax = bundle["nodes"][1]["persisted_head"]
+        lax["value"]["trusted_anchor_ancestry"]["classification"] = (
+            "valid_anchor_descendant"
+        )
+        inspection = lax["value"]["trusted_anchor_ancestry"]["inspection"]
+        inspection["block_hash"] = builder.TRUSTED_CHECKPOINT_ANCHOR_BLOCK_HASH
+        inspection["state_root"] = builder.TRUSTED_CHECKPOINT_ANCHOR_STATE_ROOT
+        lax["value"]["trusted_anchor_ancestry"]["inspection_sha256"] = sha(
+            canonical(inspection)
+        )
+        lax["sha256"] = sha(canonical(lax["value"]))
+        with self.assertRaisesRegex(
+            builder.BuilderError, "not the deterministic highest valid anchor descendant"
+        ):
+            builder.select_canonical_source(
+                self.fixture.args(), bundle, self.fixture.summary
+            )
+
+    def test_canonical_selection_allows_identical_maximal_replicas(self) -> None:
+        bundle = json.loads(self.fixture.bundle.read_text())
+        nyc_value = bundle["nodes"][0]["persisted_head"]["value"]
+        lax = bundle["nodes"][1]["persisted_head"]
+        lax_value = lax["value"]
+        lax_value["head"] = copy.deepcopy(nyc_value["head"])
+        lax_value["selected_source_head"] = copy.deepcopy(nyc_value["head"])
+        lax_value["state_wal_sha256"] = nyc_value["state_wal_sha256"]
+        lax_value["state_wal_size"] = nyc_value["state_wal_size"]
+        lax_value["snapshot_sha256"] = nyc_value["snapshot_sha256"]
+        lax_value["snapshot_size"] = nyc_value["snapshot_size"]
+        for field in ("state_wal", "snapshot"):
+            lax_value["staged_file_contract"][field] = copy.deepcopy(
+                nyc_value["staged_file_contract"][field]
+            )
+        ancestry = lax_value["trusted_anchor_ancestry"]
+        ancestry["classification"] = "valid_anchor_descendant"
+        ancestry["inspection"]["block_hash"] = builder.TRUSTED_CHECKPOINT_ANCHOR_BLOCK_HASH
+        ancestry["inspection"]["state_root"] = builder.TRUSTED_CHECKPOINT_ANCHOR_STATE_ROOT
+        ancestry["inspection"]["input_roots"]["state_wal"].update(
+            nyc_value["trusted_anchor_ancestry"]["inspection"]["input_roots"]["state_wal"]
+        )
+        ancestry["inspection"]["input_roots"]["snapshot"].update(
+            nyc_value["trusted_anchor_ancestry"]["inspection"]["input_roots"]["snapshot"]
+        )
+        ancestry["inspection_sha256"] = sha(canonical(ancestry["inspection"]))
+        lax["sha256"] = sha(canonical(lax_value))
+        source, selection = builder.select_canonical_source(
+            self.fixture.args(), bundle, self.fixture.summary
+        )
+        self.assertEqual(source["node"], "nyc")
+        self.assertEqual(
+            [
+                row["node"]
+                for row in selection["value"]["candidates"]
+                if row["classification"] == "valid_anchor_descendant"
+            ],
+            ["nyc", "lax"],
+        )
+
+    def test_canonical_selection_rejects_conflicting_equal_height_tuples(self) -> None:
+        bundle = json.loads(self.fixture.bundle.read_text())
+        lax = bundle["nodes"][1]["persisted_head"]
+        lax["value"]["head"]["height"] = 141_062
+        ancestry = lax["value"]["trusted_anchor_ancestry"]
+        ancestry["classification"] = "valid_anchor_descendant"
+        ancestry["inspection"]["block_hash"] = builder.TRUSTED_CHECKPOINT_ANCHOR_BLOCK_HASH
+        ancestry["inspection"]["state_root"] = builder.TRUSTED_CHECKPOINT_ANCHOR_STATE_ROOT
+        ancestry["inspection_sha256"] = sha(canonical(ancestry["inspection"]))
+        lax["sha256"] = sha(canonical(lax["value"]))
+        with self.assertRaisesRegex(builder.BuilderError, "disagree on their canonical tuple"):
+            builder.select_canonical_source(None, bundle, None)
+
+    def test_canonical_selection_accepts_a_stopped_highest_pair_projection(self) -> None:
+        bundle = json.loads(self.fixture.bundle.read_text())
+        nyc = bundle["nodes"][0]["persisted_head"]
+        value = nyc["value"]
+        roots = value["trusted_anchor_ancestry"]["inspection"]["input_roots"]
+        value["schema"] = builder.quarantine_rounds.PERSISTED_STOPPED_SCHEMA
+        value["source_inputs"] = {
+            "fixed_data_dir": copy.deepcopy(roots["data_dir"]),
+            "fixed_state_wal": copy.deepcopy(roots["state_wal"]),
+            "fixed_snapshot": copy.deepcopy(roots["snapshot"]),
+        }
+        value["staged_inputs"] = {
+            "genesis": copy.deepcopy(roots["genesis"]),
+            "legacy_validator_set": copy.deepcopy(roots["legacy_validator_set"]),
+        }
+        nyc["sha256"] = sha(canonical(value))
+        source, _selection = builder.select_canonical_source(
+            self.fixture.args(), bundle, self.fixture.summary
+        )
+        self.assertEqual(source["node"], "nyc")
 
     def test_private_input_stage_is_create_only_and_breaks_caller_path_replacement(self) -> None:
         args = self.fixture.args()
@@ -3696,10 +4030,11 @@ class ProductionManifestBuilderTests(unittest.TestCase):
         )
         self.fixture.rebuild_late_fork_source_set()
         self.fixture.write_validator_receipts()
+        self.fixture.write_source_preselection()
 
         value, _digest = self.fixture.build()
         self.assertEqual(
-            value["chain"]["legacy_public_max_height"], 137635
+            value["chain"]["legacy_public_max_height"], 141_195
         )
 
     def test_post_freeze_builder_does_not_cross_order_remote_utc_at_301_seconds(self) -> None:
@@ -3719,9 +4054,10 @@ class ProductionManifestBuilderTests(unittest.TestCase):
         )
         self.fixture.rebuild_late_fork_source_set()
         self.fixture.write_validator_receipts()
+        self.fixture.write_source_preselection()
 
         value, _digest = self.fixture.build()
-        self.assertEqual(value["chain"]["legacy_public_max_height"], 137635)
+        self.assertEqual(value["chain"]["legacy_public_max_height"], 141_195)
 
     def test_post_freeze_builder_rejects_after_quarantine_and_reordered_brackets(self) -> None:
         base = (

--- a/scripts/recovery/test_owner_emergency_recovery.py
+++ b/scripts/recovery/test_owner_emergency_recovery.py
@@ -53,6 +53,14 @@ class Fixture:
         self.public_sha = digest(self.public_raw)
         self.commit = "a" * 40
         self.checkpoint = "0x" + "b" * 64
+        self.source_height = 141_062
+        self.transition_height = self.source_height + 1
+        self.source_block_hash = "c" * 64
+        self.source_state_root = "d" * 64
+        self.source_consensus_round = 9_774_808
+        self.observed_cutoff_height = 141_062
+        self.reopening_floor_height = self.observed_cutoff_height + 128
+        self.legacy_maintenance_boundary_sha256 = "e" * 64
         self.run_id = 987654321
         self.run_attempt = 2
         self.workflow_id = 445566
@@ -99,7 +107,17 @@ class Fixture:
             },
             "schema": APPROVAL.RECEIPT_SCHEMA,
             "scope": APPROVAL.scope_value(
-                self.commit, self.checkpoint, self.public_sha
+                self.commit,
+                self.checkpoint,
+                self.public_sha,
+                self.source_height,
+                self.transition_height,
+                self.source_block_hash,
+                self.source_state_root,
+                self.source_consensus_round,
+                self.observed_cutoff_height,
+                self.reopening_floor_height,
+                self.legacy_maintenance_boundary_sha256,
             ),
             "signing_policy": APPROVAL.signing_policy(validators),
         }
@@ -198,6 +216,14 @@ class Fixture:
             "run_id": self.run_id,
             "run_json": self.run,
             "source_main_sha": self.commit,
+            "source_height": self.source_height,
+            "transition_height": self.transition_height,
+            "source_block_hash": self.source_block_hash,
+            "source_state_root": self.source_state_root,
+            "source_consensus_round": self.source_consensus_round,
+            "observed_cutoff_height": self.observed_cutoff_height,
+            "reopening_floor_height": self.reopening_floor_height,
+            "legacy_maintenance_boundary_sha256": self.legacy_maintenance_boundary_sha256,
             "validator_public_keys": self.public_keys,
             "validator_public_keys_sha256": self.public_sha,
             "workflow_json": self.workflow,
@@ -242,6 +268,22 @@ class OwnerEmergencyRecoveryTests(unittest.TestCase):
                 self.fixture.commit,
                 "--checkpoint-manifest-hash",
                 self.fixture.checkpoint,
+                "--source-height",
+                str(self.fixture.source_height),
+                "--transition-height",
+                str(self.fixture.transition_height),
+                "--source-block-hash",
+                self.fixture.source_block_hash,
+                "--source-state-root",
+                self.fixture.source_state_root,
+                "--source-consensus-round",
+                str(self.fixture.source_consensus_round),
+                "--observed-cutoff-height",
+                str(self.fixture.observed_cutoff_height),
+                "--reopening-floor-height",
+                str(self.fixture.reopening_floor_height),
+                "--legacy-maintenance-boundary-sha256",
+                self.fixture.legacy_maintenance_boundary_sha256,
                 "--validator-public-keys",
                 str(self.fixture.public_keys),
                 "--validator-public-keys-sha256",
@@ -298,6 +340,14 @@ class OwnerEmergencyRecoveryTests(unittest.TestCase):
             {"source_main_sha": "c" * 40},
             {"checkpoint_manifest_hash": "0x" + "d" * 64},
             {"validator_public_keys_sha256": "e" * 64},
+            {"source_height": self.fixture.source_height + 1},
+            {"transition_height": self.fixture.transition_height + 1},
+            {"source_block_hash": "0" * 64},
+            {"source_state_root": "1" * 64},
+            {"source_consensus_round": self.fixture.source_consensus_round + 1},
+            {"observed_cutoff_height": self.fixture.observed_cutoff_height + 1},
+            {"reopening_floor_height": self.fixture.reopening_floor_height + 1},
+            {"legacy_maintenance_boundary_sha256": "2" * 64},
             {"artifact_id": self.fixture.artifact_id + 1},
             {"artifact_digest": "sha256:" + "f" * 64},
         ):
@@ -375,12 +425,28 @@ class OwnerEmergencyRecoveryTests(unittest.TestCase):
             properties["decision"]["properties"]["authority_basis"]["const"],
             APPROVAL.AUTHORITY_BASIS,
         )
-        self.assertEqual(properties["scope"]["properties"]["source_height"]["const"], 137145)
-        self.assertEqual(properties["scope"]["properties"]["transition_height"]["const"], 137146)
+        self.assertEqual(properties["scope"]["properties"]["source_height"]["minimum"], 137145)
+        self.assertEqual(properties["scope"]["properties"]["transition_height"]["minimum"], 137146)
         self.assertEqual(
             properties["signing_policy"]["properties"]["signatures_required"]["const"],
             5,
         )
+
+    def test_scope_enforces_capture_derived_height_relationships(self) -> None:
+        scope = copy.deepcopy(self.fixture.receipt_value["scope"])
+        scope["transition_height"] += 1
+        with self.assertRaisesRegex(APPROVAL.ApprovalError, "source height plus one"):
+            APPROVAL.validate_scope(scope)
+
+        scope = copy.deepcopy(self.fixture.receipt_value["scope"])
+        scope["source_height"] = APPROVAL.TRUSTED_ANCHOR_HEIGHT - 1
+        with self.assertRaisesRegex(APPROVAL.ApprovalError, "below the reviewed history anchor"):
+            APPROVAL.validate_scope(scope)
+
+        scope = copy.deepcopy(self.fixture.receipt_value["scope"])
+        scope["reopening_floor_height"] += 1
+        with self.assertRaisesRegex(APPROVAL.ApprovalError, "cutoff plus 128"):
+            APPROVAL.validate_scope(scope)
 
 
 if __name__ == "__main__":

--- a/scripts/recovery/test_quarantine_rounds.py
+++ b/scripts/recovery/test_quarantine_rounds.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import copy
 import datetime as dt
+import hashlib
 import importlib.util
+import json
 from pathlib import Path
 import unittest
 
@@ -24,6 +26,43 @@ BASE = dt.datetime(2026, 8, 31, 12, 0, tzinfo=dt.timezone.utc)
 
 def utc(seconds: int) -> str:
     return (BASE + dt.timedelta(seconds=seconds)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def legacy_dag_round() -> dict:
+    namespace = {
+        "schema": "arc.recovery.legacy-dag-wal-namespace.v1",
+        "segment_names": [
+            "wal-00000007.bin", "wal-00000008.bin", "wal-00000009.bin",
+            "wal-00000010.bin",
+        ],
+        "inspected_tail": [
+            {"name": f"wal-{index:08d}.bin", "sha256": f"{index:064x}", "size": index}
+            for index in (8, 9, 10)
+        ],
+    }
+    namespace_sha = hashlib.sha256(
+        json.dumps(namespace, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    inspection = {
+        "schema": "arc.recovery.legacy-dag-round-inspection.v1",
+        "status": "VERIFIED_STOPPED_DAG_CURSOR",
+        "source_consensus_round": 10_280_531,
+        "first_segment": 7,
+        "last_segment": 10,
+        "segment_count": 4,
+        "inspected_first_segment": 8,
+        "inspected_segment_count": 3,
+        "inspected_entry_count": 17,
+        "namespace_sha256": namespace_sha,
+        "namespace": namespace,
+        "read_only": True,
+    }
+    return {
+        "source_consensus_round": inspection["source_consensus_round"],
+        "namespace_sha256": namespace_sha,
+        "inspection": inspection,
+        "inspection_sha256": qr.digest(inspection),
+    }
 
 
 def target_row(name: str) -> dict:
@@ -1239,6 +1278,35 @@ class QuarantineRoundTests(unittest.TestCase):
             value["rounds"][0]["result"] = qr.wrap(result_value)
             with self.assertRaises(qr.QuarantineRoundError):
                 qr.validate_generation_ledger(value)
+
+    def test_embedded_legacy_dag_round_is_self_authenticating(self) -> None:
+        value = legacy_dag_round()
+        self.assertIs(qr.validate_legacy_dag_round(value, "test"), value)
+
+    def test_embedded_legacy_dag_round_rejects_every_projection_tamper(self) -> None:
+        mutations = []
+        for mutate in (
+            lambda value: value.__setitem__(
+                "source_consensus_round", value["source_consensus_round"] + 1
+            ),
+            lambda value: value.__setitem__("inspection_sha256", "f" * 64),
+            lambda value: value.__setitem__("namespace_sha256", "e" * 64),
+            lambda value: value["inspection"].__setitem__("read_only", False),
+            lambda value: value["inspection"]["namespace"]["segment_names"].__setitem__(
+                1, "wal-00000011.bin"
+            ),
+            lambda value: value["inspection"]["namespace"]["inspected_tail"][0].__setitem__(
+                "sha256", "d" * 64
+            ),
+        ):
+            value = legacy_dag_round()
+            mutate(value)
+            mutations.append(value)
+        for value in mutations:
+            with self.subTest(value=value), self.assertRaises(
+                qr.QuarantineRoundError
+            ):
+                qr.validate_legacy_dag_round(value, "test")
 
 
 if __name__ == "__main__":

--- a/scripts/recovery/test_recovery_rollout.py
+++ b/scripts/recovery/test_recovery_rollout.py
@@ -1708,35 +1708,6 @@ class RecoveryRolloutTests(unittest.TestCase):
             ("persisted_head", "persisted-head"),
         )
         for index, (node, host) in enumerate(rollout.PRODUCTION_FLEET):
-            dag_namespace = {
-                "schema": "arc.recovery.legacy-dag-wal-namespace.v1",
-                "segment_names": ["wal-00000000.bin"],
-                "inspected_tail": [
-                    {
-                        "name": "wal-00000000.bin",
-                        "sha256": f"{index + 5400:064x}",
-                        "size": 8,
-                    }
-                ],
-            }
-            dag_inspection = {
-                "schema": "arc.recovery.legacy-dag-round-inspection.v1",
-                "status": "VERIFIED_STOPPED_DAG_CURSOR",
-                "source_consensus_round": 9_999 + index,
-                "first_segment": 0,
-                "last_segment": 0,
-                "segment_count": 1,
-                "inspected_first_segment": 0,
-                "inspected_segment_count": 1,
-                "inspected_entry_count": 1,
-                "namespace_sha256": hashlib.sha256(
-                    json.dumps(
-                        dag_namespace, sort_keys=True, separators=(",", ":")
-                    ).encode()
-                ).hexdigest(),
-                "namespace": dag_namespace,
-                "read_only": True,
-            }
             identity = {
                 "capture_id": capture_id,
                 "node": node,
@@ -1889,12 +1860,6 @@ class RecoveryRolloutTests(unittest.TestCase):
                         "preserved_by": (
                             "complete-content-indexed-stopped-legacy-source-v4"
                         ),
-                    },
-                    "legacy_dag_round": {
-                        "source_consensus_round": 9_999 + index,
-                        "namespace_sha256": dag_inspection["namespace_sha256"],
-                        "inspection": dag_inspection,
-                        "inspection_sha256": sha_value(dag_inspection),
                     },
                     "writer_stopped": True,
                     "restart_barrier_active": True,

--- a/scripts/recovery/test_recovery_rollout.py
+++ b/scripts/recovery/test_recovery_rollout.py
@@ -3494,6 +3494,9 @@ assert_exact_filter_group arc-caddy arc-rpc-filter 4242
         self.assertEqual(len(captured), 1)
         self.assertIn("arc_semantic_python -", captured[0])
         self.assertNotIn("python3 -", captured[0])
+        self.assertIn(
+            'receipt="$gate/${target}.${intent_sha}.json"', captured[0]
+        )
         self.assertIn("http://localhost/block/$height", captured[0])
         self.assertLess(
             captured[0].index("http://localhost/block/$height"),
@@ -3510,6 +3513,56 @@ assert_exact_filter_group arc-caddy arc-rpc-filter 4242
             check=False,
         )
         self.assertEqual(syntax.returncode, 0, syntax.stderr)
+
+        marker = (
+            'arc_semantic_python - "$receipt" "$rollout" "$target" '
+            '"$source_sha" "$intent_sha" "$height" "$block_hash" '
+            '"$state_root" "$node_name" "$hostname" <<\'PY\'\n'
+        )
+        receipt_program = captured[0].split(marker, 1)[1].split("\nPY\n", 1)[0]
+        gate = self.root / "intent-scoped-public-gate"
+        gate.mkdir(mode=0o700)
+        maintenance_sha = hashlib.sha256(
+            harness.maintenance_caddyfile(node).encode("utf-8")
+        ).hexdigest()
+        outputs: dict[str, bytes] = {}
+        for intent in ("a" * 64, "b" * 64):
+            path = gate / f"maintenance.{intent}.json"
+            arguments = [
+                sys.executable,
+                "-I",
+                "-",
+                str(path),
+                harness.digest,
+                "maintenance",
+                maintenance_sha,
+                intent,
+                "0",
+                "0" * 64,
+                "0" * 64,
+                node["name"],
+                node["host"],
+            ]
+            first = rollout.subprocess.run(
+                arguments,
+                input=receipt_program.encode("utf-8"),
+                capture_output=True,
+                check=False,
+            )
+            second = rollout.subprocess.run(
+                arguments,
+                input=receipt_program.encode("utf-8"),
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(first.returncode, 0, first.stderr.decode())
+            self.assertEqual(second.returncode, 0, second.stderr.decode())
+            self.assertEqual(first.stdout, second.stdout)
+            self.assertEqual(path.read_bytes(), first.stdout)
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o400)
+            outputs[intent] = first.stdout
+        self.assertEqual(len(list(gate.iterdir())), 2)
+        self.assertNotEqual(outputs["a" * 64], outputs["b" * 64])
 
     def test_partial_public_gate_promotion_recloses_every_host_to_maintenance(self) -> None:
         value = self.fixture(production=True)

--- a/scripts/recovery/test_recovery_rollout.py
+++ b/scripts/recovery/test_recovery_rollout.py
@@ -48,6 +48,8 @@ class ManifestFixture:
                 "legacy_public_height_receipt",
                 "legacy_maintenance_evidence_bundle",
                 "legacy_maintenance_evidence_bundle_sidecar",
+                "canonical_source_preselection",
+                "canonical_source_preselection_sidecar",
                 "legacy_maintenance_boundary",
                 "legacy_maintenance_boundary_sidecar",
                 "legacy_late_fork_source_set",
@@ -454,6 +456,71 @@ class ManifestFixture:
                     for index, row in enumerate(validator_key_receipt_chain["validators"])
                 ],
             }
+        source_height = 141_062 if production else 100
+        observed_cutoff_height = 141_070 if production else 110
+        canonical_source_selection = None
+        if production:
+            selection_candidates = []
+            for index, (name, _host) in enumerate(rollout.PRODUCTION_FLEET):
+                if index == 0:
+                    candidate_height = source_height
+                    block_hash = "1" * 64
+                    state_root = "5" * 64
+                    classification = "valid_anchor_descendant"
+                    persisted_sha = "1" * 64
+                elif index == 1:
+                    candidate_height = observed_cutoff_height
+                    block_hash = "8" * 64
+                    state_root = "9" * 64
+                    classification = "conflicting_anchor"
+                    persisted_sha = "a" * 64
+                else:
+                    candidate_height = 137_145 - index
+                    block_hash = f"{index + 2:x}" * 64
+                    state_root = f"{index + 3:x}" * 64
+                    classification = "below_trusted_anchor"
+                    persisted_sha = f"{index + 4:x}" * 64
+                selection_candidates.append(
+                    {
+                        "node": name,
+                        "persisted_head_schema": "arc.recovery.persisted-legacy-head.v3",
+                        "persisted_head_sha256": persisted_sha,
+                        "source_height": candidate_height,
+                        "source_block_hash": block_hash,
+                        "source_state_root": state_root,
+                        "classification": classification,
+                        "anchor_inspection_sha256": f"{index + 10:x}" * 64,
+                    }
+                )
+            selection_value = {
+                "schema": "arc.recovery.canonical-source-selection.v1",
+                "selection_rule": "highest-valid-anchor-descendant-tuple",
+                "equivalent_maximal_pair_rule": (
+                    "first-production-fleet-node-with-matching-source-pair"
+                ),
+                "trusted_anchor": {
+                    "height": 137_145,
+                    "block_hash": "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90",
+                    "state_root": "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d",
+                },
+                "candidates": selection_candidates,
+                "selected": {
+                    key: selection_candidates[0][key]
+                    for key in (
+                        "node",
+                        "source_height",
+                        "source_block_hash",
+                        "source_state_root",
+                        "persisted_head_sha256",
+                    )
+                },
+            }
+            canonical_source_selection = {
+                "value": selection_value,
+                "sha256": hashlib.sha256(
+                    rollout.canonical_bytes(selection_value)
+                ).hexdigest(),
+            }
         self.value = {
             "schema": rollout.SCHEMA,
             "rollout_id": "recovery-v3-test",
@@ -500,8 +567,10 @@ class ManifestFixture:
                 "protocol_version": "3.0.0",
                 "recovery_epoch": 7,
                 "validator_set_id": 9,
-                "source_height": 100,
-                "legacy_public_max_height": 238 if production else 110,
+                "source_height": source_height,
+                "legacy_public_max_height": (
+                    observed_cutoff_height + 128 if production else 110
+                ),
                 **(
                     {
                         "legacy_maintenance_evidence_bundle_sha256": artifacts[
@@ -513,7 +582,7 @@ class ManifestFixture:
                         "legacy_late_fork_source_set_sha256": artifacts[
                             "legacy_late_fork_source_set"
                         ]["sha256"],
-                        "legacy_observed_cutoff_height": 110,
+                        "legacy_observed_cutoff_height": observed_cutoff_height,
                         "legacy_continuity_safety_margin": 128,
                         "legacy_global_absence_claimed": False,
                         "legacy_official_origins": [
@@ -528,6 +597,33 @@ class ManifestFixture:
                         "legacy_quarantine_threat_model": copy.deepcopy(
                             rollout.LEGACY_QUARANTINE_THREAT_MODEL
                         ),
+                        "canonical_source": {
+                            "node": "nyc",
+                            "source_height": source_height,
+                            "source_block_hash": "1" * 64,
+                            "source_state_root": "5" * 64,
+                            "source_consensus_round": 9876,
+                            "snapshot_sha256": artifacts["source_snapshot"]["sha256"],
+                            "wal_sha256": artifacts["source_wal"]["sha256"],
+                            "persisted_head_sha256": "1" * 64,
+                            "legacy_dag_round_inspection_sha256": "2" * 64,
+                            "legacy_dag_wal_namespace_sha256": "3" * 64,
+                        },
+                        "canonical_source_selection": canonical_source_selection,
+                        "trusted_anchor": {
+                            "schema": "arc.recovery.trusted-anchor-proof.v1",
+                            "height": 137_145,
+                            "block_hash": "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90",
+                            "state_root": "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d",
+                            "inspection_sha256": "4" * 64,
+                            "inspector_binary_sha256": artifacts["binary"]["sha256"],
+                            "source_snapshot_sha256": artifacts["source_snapshot"]["sha256"],
+                            "source_wal_sha256": artifacts["source_wal"]["sha256"],
+                            "genesis_sha256": artifacts["genesis"]["sha256"],
+                            "legacy_validator_set_sha256": artifacts[
+                                "legacy_validator_set"
+                            ]["sha256"],
+                        },
                     }
                     if production
                     else {}
@@ -536,7 +632,7 @@ class ManifestFixture:
                 "created_at_unix_ms": 1_787_857_623_000,
                 "source_block_hash": "0x" + "1" * 64,
                 "source_state_root": "0x" + "5" * 64,
-                "transition_height": 101,
+                "transition_height": source_height + 1,
                 "transition_block_hash": "0x" + "2" * 64,
                 "full_state_root": "0x" + "3" * 64,
                 "recovery_domain": "0x" + "6" * 64,
@@ -1650,6 +1746,36 @@ class RecoveryRolloutTests(unittest.TestCase):
             persisted_head = tuple_at(
                 public_origins[index]["info_after_height"] + 6, index + 60
             )
+            dag_namespace = {
+                "schema": "arc.recovery.legacy-dag-wal-namespace.v1",
+                "segment_names": ["wal-00000001.bin"],
+                "inspected_tail": [
+                    {
+                        "name": "wal-00000001.bin",
+                        "sha256": f"{index + 5400:064x}",
+                        "size": 64 + index,
+                    }
+                ],
+            }
+            dag_namespace_sha = hashlib.sha256(
+                json.dumps(
+                    dag_namespace, sort_keys=True, separators=(",", ":")
+                ).encode("utf-8")
+            ).hexdigest()
+            dag_inspection = {
+                "schema": "arc.recovery.legacy-dag-round-inspection.v1",
+                "status": "VERIFIED_STOPPED_DAG_CURSOR",
+                "source_consensus_round": 10_000_001 + index,
+                "first_segment": 1,
+                "last_segment": 1,
+                "segment_count": 1,
+                "inspected_first_segment": 1,
+                "inspected_segment_count": 1,
+                "inspected_entry_count": 1,
+                "namespace_sha256": dag_namespace_sha,
+                "namespace": dag_namespace,
+                "read_only": True,
+            }
             objects = {
                 "stopped_status": {
                     "schema": "arc.recovery.offline-stop-status.v1",
@@ -1739,6 +1865,12 @@ class RecoveryRolloutTests(unittest.TestCase):
                     "state_wal_sha256": f"{index + 5200:064x}",
                     "state_wal_size": 8,
                     "head": persisted_head,
+                    "legacy_dag_round": {
+                        "source_consensus_round": 10_000_001 + index,
+                        "namespace_sha256": dag_namespace_sha,
+                        "inspection": dag_inspection,
+                        "inspection_sha256": sha_value(dag_inspection),
+                    },
                     "archived_final_wal": {
                         "path": f"/private/archive/{node}/state.wal",
                         "sha256": f"{index + 5300:064x}",
@@ -2627,12 +2759,17 @@ class RecoveryRolloutTests(unittest.TestCase):
                 "legacy_reopening_policy",
                 "legacy_late_fork_circuit",
                 "legacy_quarantine_threat_model",
+                "canonical_source",
+                "canonical_source_selection",
+                "trusted_anchor",
             },
         )
         self.assertTrue(
             {
                 "legacy_maintenance_evidence_bundle",
                 "legacy_maintenance_evidence_bundle_sidecar",
+                "canonical_source_preselection",
+                "canonical_source_preselection_sidecar",
                 "legacy_maintenance_boundary",
                 "legacy_maintenance_boundary_sidecar",
                 "legacy_late_fork_source_set",
@@ -3405,10 +3542,11 @@ assert_exact_filter_group arc-caddy arc-rpc-filter 4242
             }
 
         harness._set_public_gate_config = mock.Mock(side_effect=transition)
+        public_floor = value["chain"]["legacy_public_max_height"]
         with self.assertRaisesRegex(rollout.RolloutError, "PUBLIC_GATE_OPEN_INCOMPLETE"):
             harness.open_public_gate(
-                (239, "1" * 64, "2" * 64),
-                (240, "3" * 64, "4" * 64),
+                (public_floor + 1, "1" * 64, "2" * 64),
+                (public_floor + 2, "3" * 64, "4" * 64),
             )
         self.assertFalse(harness.production_public_gate_open)
         maintenance_names = [name for target, name in calls if target == "maintenance"]
@@ -4476,6 +4614,37 @@ sha256sum() {{ printf '%s  %s\\n' "{'b' * 64}" "$1"; }}
                 "maxStalenessSeconds": 90,
             },
         )
+
+        lax_value = copy.deepcopy(value)
+        selection = lax_value["chain"]["canonical_source_selection"]["value"]
+        selection["candidates"][0]["classification"] = "conflicting_anchor"
+        lax_candidate = selection["candidates"][1]
+        lax_candidate.update(
+            {
+                "source_height": lax_value["chain"]["source_height"],
+                "source_block_hash": lax_value["chain"]["source_block_hash"].removeprefix("0x"),
+                "source_state_root": lax_value["chain"]["source_state_root"].removeprefix("0x"),
+                "classification": "valid_anchor_descendant",
+            }
+        )
+        selection["selected"] = {
+            field: lax_candidate[field]
+            for field in (
+                "node", "source_height", "source_block_hash", "source_state_root",
+                "persisted_head_sha256",
+            )
+        }
+        lax_value["chain"]["canonical_source"].update(
+            {"node": "lax", "persisted_head_sha256": lax_candidate["persisted_head_sha256"]}
+        )
+        lax_value["chain"]["canonical_source_selection"]["sha256"] = hashlib.sha256(
+            rollout.canonical_bytes(selection)
+        ).hexdigest()
+        lax_config = rollout.RecoveryRollout(
+            lax_value, "d" * 64, output=io.StringIO()
+        ).frontend_config()
+        self.assertEqual(lax_config["checkpoint"]["legacySourceId"], "v3-lax")
+        self.assertEqual(lax_config["checkpoint"]["v3SourceId"], "v3-lax")
 
         fork_value = copy.deepcopy(value)
         fork_value["archive"].update(

--- a/scripts/recovery/test_recovery_rollout.py
+++ b/scripts/recovery/test_recovery_rollout.py
@@ -1612,6 +1612,35 @@ class RecoveryRolloutTests(unittest.TestCase):
             ("persisted_head", "persisted-head"),
         )
         for index, (node, host) in enumerate(rollout.PRODUCTION_FLEET):
+            dag_namespace = {
+                "schema": "arc.recovery.legacy-dag-wal-namespace.v1",
+                "segment_names": ["wal-00000000.bin"],
+                "inspected_tail": [
+                    {
+                        "name": "wal-00000000.bin",
+                        "sha256": f"{index + 5400:064x}",
+                        "size": 8,
+                    }
+                ],
+            }
+            dag_inspection = {
+                "schema": "arc.recovery.legacy-dag-round-inspection.v1",
+                "status": "VERIFIED_STOPPED_DAG_CURSOR",
+                "source_consensus_round": 9_999 + index,
+                "first_segment": 0,
+                "last_segment": 0,
+                "segment_count": 1,
+                "inspected_first_segment": 0,
+                "inspected_segment_count": 1,
+                "inspected_entry_count": 1,
+                "namespace_sha256": hashlib.sha256(
+                    json.dumps(
+                        dag_namespace, sort_keys=True, separators=(",", ":")
+                    ).encode()
+                ).hexdigest(),
+                "namespace": dag_namespace,
+                "read_only": True,
+            }
             identity = {
                 "capture_id": capture_id,
                 "node": node,
@@ -1699,7 +1728,7 @@ class RecoveryRolloutTests(unittest.TestCase):
                     "network_quarantine_receipt_sha256": receipt_sha,
                 },
                 "persisted_head": {
-                    "schema": "arc.recovery.persisted-legacy-head.v1",
+                    "schema": "arc.recovery.persisted-legacy-head.v3",
                     **identity,
                     "source_main_commit": source_commit,
                     "source_pair_role": "post-quarantine-final-export",
@@ -1728,6 +1757,12 @@ class RecoveryRolloutTests(unittest.TestCase):
                         "preserved_by": (
                             "complete-content-indexed-stopped-legacy-source-v4"
                         ),
+                    },
+                    "legacy_dag_round": {
+                        "source_consensus_round": 9_999 + index,
+                        "namespace_sha256": dag_inspection["namespace_sha256"],
+                        "inspection": dag_inspection,
+                        "inspection_sha256": sha_value(dag_inspection),
                     },
                     "writer_stopped": True,
                     "restart_barrier_active": True,

--- a/scripts/recovery/test_recovery_rollout.py
+++ b/scripts/recovery/test_recovery_rollout.py
@@ -799,6 +799,18 @@ class RecoveryRolloutTests(unittest.TestCase):
         }
 
     @staticmethod
+    def prime_checkpoint_identity(harness, payload_hash: str = "a" * 64):
+        harness.verified_checkpoint_identity = {
+            "checkpoint_sha256": harness.manifest["artifacts"]["checkpoint"][
+                "sha256"
+            ],
+            "checkpoint_manifest_hash": harness.chain[
+                "approved_checkpoint_manifest_hash"
+            ].removeprefix("0x"),
+            "checkpoint_payload_hash": payload_hash,
+        }
+
+    @staticmethod
     def public_tls_evidence(
         harness,
         node,
@@ -3367,10 +3379,17 @@ class RecoveryRolloutTests(unittest.TestCase):
         harness.production_public_gate_open = False
         initial_height = value["chain"]["legacy_public_max_height"] + 1
         final_height = initial_height + value["checks"]["min_height_advance"]
-        receipt_sha = harness.open_public_gate(
-            (initial_height, "1" * 64, "2" * 64),
-            (final_height, "3" * 64, "4" * 64),
+        initial = (initial_height, "1" * 64, "2" * 64)
+        final = (final_height, "3" * 64, "4" * 64)
+        post = (final_height + 1, "5" * 64, "6" * 64)
+        harness.wait_nodes_ready = mock.Mock()
+        harness.prove_production_runtime_inventory = mock.Mock()
+        harness.prove_boundary = mock.Mock()
+        harness.prove_advancing_convergence = mock.Mock(
+            return_value=(initial, final)
         )
+        harness.wait_convergence = mock.Mock(return_value=post)
+        receipt_sha = harness.open_public_gate()
         self.assertEqual(receipt_sha, "b" * 64)
         self.assertTrue(harness.production_public_gate_open)
         self.assertEqual(harness._set_public_gate_config.call_count, 6)
@@ -3380,6 +3399,10 @@ class RecoveryRolloutTests(unittest.TestCase):
         ]
         self.assertEqual(len(promoted), 6)
         self.assertEqual(set(promoted), {node["name"] for node in value["validators"]})
+        self.assertEqual(harness.wait_nodes_ready.call_count, 2)
+        self.assertEqual(harness.prove_boundary.call_count, 2)
+        harness.prove_production_runtime_inventory.assert_called_once_with()
+        harness.wait_convergence.assert_called_once_with(minimum_height=final_height)
         intent = harness._rollback_journal_write.call_args_list[0].args[1]
         self.assertGreater(
             intent["initial"]["height"], value["chain"]["legacy_public_max_height"]
@@ -3471,6 +3494,14 @@ assert_exact_filter_group arc-caddy arc-rpc-filter 4242
         self.assertEqual(len(captured), 1)
         self.assertIn("arc_semantic_python -", captured[0])
         self.assertNotIn("python3 -", captured[0])
+        self.assertIn("http://localhost/block/$height", captured[0])
+        self.assertLess(
+            captured[0].index("http://localhost/block/$height"),
+            captured[0].index('temporary=$(mktemp "$root/.Caddyfile.active.'),
+        )
+        self.assertEqual(
+            harness.ssh.call_args.args[2][-1], harness.validator_rpc_socket(node)
+        )
         syntax = rollout.subprocess.run(
             ["/bin/sh", "-n"],
             input=captured[0],
@@ -3508,16 +3539,70 @@ assert_exact_filter_group arc-caddy arc-rpc-filter 4242
 
         harness._set_public_gate_config = mock.Mock(side_effect=transition)
         public_floor = value["chain"]["legacy_public_max_height"]
+        initial = (public_floor + 1, "1" * 64, "2" * 64)
+        final = (public_floor + 2, "3" * 64, "4" * 64)
+        harness.wait_nodes_ready = mock.Mock()
+        harness.prove_production_runtime_inventory = mock.Mock()
+        harness.prove_boundary = mock.Mock()
+        harness.prove_advancing_convergence = mock.Mock(
+            return_value=(initial, final)
+        )
         with self.assertRaisesRegex(rollout.RolloutError, "PUBLIC_GATE_OPEN_INCOMPLETE"):
-            harness.open_public_gate(
-                (public_floor + 1, "1" * 64, "2" * 64),
-                (public_floor + 2, "3" * 64, "4" * 64),
-            )
+            harness.open_public_gate()
         self.assertFalse(harness.production_public_gate_open)
         maintenance_names = [name for target, name in calls if target == "maintenance"]
         self.assertEqual(len(maintenance_names), 6)
         self.assertEqual(
             set(maintenance_names), {node["name"] for node in value["validators"]}
+        )
+
+    def test_post_promotion_divergence_recloses_every_host_to_maintenance(self) -> None:
+        value = self.fixture(production=True)
+        harness = rollout.RecoveryRollout(value, "d" * 64, output=io.StringIO())
+        harness.production_public_gate_open = False
+        harness._rollback_journal_write = mock.Mock(return_value="a" * 64)
+        calls: list[tuple[str, str]] = []
+
+        def transition(node, *, target, intent_sha256, final=None):
+            calls.append((target, node["name"]))
+            commitment = final or (0, "0" * 64, "0" * 64)
+            return {
+                "schema": "arc.recovery.public-gate-host.v1",
+                "rollout_manifest_sha256": harness.digest,
+                "state": target,
+                "active_caddyfile_sha256": "5" * 64,
+                "promotion_intent_sha256": intent_sha256,
+                "height": commitment[0],
+                "block_hash": commitment[1],
+                "state_root": commitment[2],
+                "node": node["name"],
+                "host": node["host"],
+            }
+
+        public_floor = value["chain"]["legacy_public_max_height"]
+        initial = (public_floor + 1, "1" * 64, "2" * 64)
+        final = (
+            initial[0] + value["checks"]["min_height_advance"],
+            "3" * 64,
+            "4" * 64,
+        )
+        harness._set_public_gate_config = mock.Mock(side_effect=transition)
+        harness.wait_nodes_ready = mock.Mock(
+            side_effect=[None, rollout.RolloutError("simulated post-switch divergence")]
+        )
+        harness.prove_production_runtime_inventory = mock.Mock()
+        harness.prove_boundary = mock.Mock()
+        harness.prove_advancing_convergence = mock.Mock(
+            return_value=(initial, final)
+        )
+        with self.assertRaisesRegex(
+            rollout.RolloutError, "simulated post-switch divergence"
+        ):
+            harness.open_public_gate()
+        self.assertFalse(harness.production_public_gate_open)
+        self.assertEqual(
+            {name for target, name in calls if target == "maintenance"},
+            {node["name"] for node in value["validators"]},
         )
 
     def test_manifest_rejects_public_listener_and_protected_override(self) -> None:
@@ -4417,6 +4502,7 @@ sha256sum() {{ printf '%s  %s\\n' "{'b' * 64}" "$1"; }}
         body = {
             "status": "VERIFIED_QUORUM",
             "manifest_hash": value["chain"]["approved_checkpoint_manifest_hash"],
+            "payload_hash": "a" * 64,
             "genesis_hash": value["chain"]["genesis_hash"],
             "full_state_root": value["chain"]["full_state_root"],
             "source_height": 100,
@@ -4436,6 +4522,29 @@ sha256sum() {{ printf '%s  %s\\n' "{'b' * 64}" "$1"; }}
         inspected = dict(body, status="UNTRUSTED_INSPECTION")
         with mock.patch.object(rollout, "run_checked", side_effect=[SimpleNamespace(stdout=json.dumps(inspected)), SimpleNamespace(stdout=json.dumps(body))]):
             harness.verify_checkpoint()
+        self.assertEqual(
+            harness.verified_checkpoint_identity,
+            {
+                "checkpoint_sha256": value["artifacts"]["checkpoint"]["sha256"],
+                "checkpoint_manifest_hash": value["chain"][
+                    "approved_checkpoint_manifest_hash"
+                ].removeprefix("0x"),
+                "checkpoint_payload_hash": "a" * 64,
+            },
+        )
+        wrong_payload = dict(body, payload_hash="b" * 64)
+        with mock.patch.object(
+            rollout,
+            "run_checked",
+            side_effect=[
+                SimpleNamespace(stdout=json.dumps(inspected)),
+                SimpleNamespace(stdout=json.dumps(wrong_payload)),
+            ],
+        ):
+            with self.assertRaisesRegex(
+                rollout.RolloutError, "inspect/verify payload hashes differ"
+            ):
+                harness.verify_checkpoint()
         bad = dict(body, transition_height=102)
         with mock.patch.object(rollout, "run_checked", side_effect=[SimpleNamespace(stdout=json.dumps(inspected)), SimpleNamespace(stdout=json.dumps(bad))]):
             with self.assertRaisesRegex(rollout.RolloutError, "transition_height differs"):
@@ -4528,7 +4637,15 @@ sha256sum() {{ printf '%s  %s\\n' "{'b' * 64}" "$1"; }}
 
     def test_frontend_config_binds_source_boundary_domain_and_all_six_v3_replicas(self) -> None:
         value = self.fixture(production=True)
+        unverified = rollout.RecoveryRollout(
+            value, "d" * 64, output=io.StringIO()
+        )
+        with self.assertRaisesRegex(
+            rollout.RolloutError, "same-process sealed checkpoint verification"
+        ):
+            unverified.frontend_config()
         harness = rollout.RecoveryRollout(value, "d" * 64, output=io.StringIO())
+        self.prime_checkpoint_identity(harness)
         reward_evidence = self.two_receipt_evidence()
         config = harness.frontend_config()
         checkpoint = config["checkpoint"]
@@ -4547,6 +4664,11 @@ sha256sum() {{ printf '%s  %s\\n' "{'b' * 64}" "$1"; }}
         self.assertEqual(checkpoint["recoveryEpoch"], 7)
         self.assertEqual(checkpoint["validatorSetId"], 9)
         self.assertEqual(checkpoint["protocolVersion"], "3.0.0")
+        self.assertEqual(
+            checkpoint["checkpointFileSha256"],
+            value["artifacts"]["checkpoint"]["sha256"],
+        )
+        self.assertEqual(checkpoint["checkpointPayloadHash"], "a" * 64)
         self.assertEqual(
             checkpoint["recoveryDomain"], value["chain"]["recovery_domain"].removeprefix("0x")
         )
@@ -4605,9 +4727,11 @@ sha256sum() {{ printf '%s  %s\\n' "{'b' * 64}" "$1"; }}
         lax_value["chain"]["canonical_source_selection"]["sha256"] = hashlib.sha256(
             rollout.canonical_bytes(selection)
         ).hexdigest()
-        lax_config = rollout.RecoveryRollout(
+        lax_harness = rollout.RecoveryRollout(
             lax_value, "d" * 64, output=io.StringIO()
-        ).frontend_config()
+        )
+        self.prime_checkpoint_identity(lax_harness)
+        lax_config = lax_harness.frontend_config()
         self.assertEqual(lax_config["checkpoint"]["legacySourceId"], "v3-lax")
         self.assertEqual(lax_config["checkpoint"]["v3SourceId"], "v3-lax")
 
@@ -4620,6 +4744,7 @@ sha256sum() {{ printf '%s  %s\\n' "{'b' * 64}" "$1"; }}
             }
         )
         fork_harness = rollout.RecoveryRollout(fork_value, "d" * 64, output=io.StringIO())
+        self.prime_checkpoint_identity(fork_harness)
         proof = {
             "schema": "arc.legacy-archive.query.v1",
             "read_only": True,
@@ -4648,6 +4773,17 @@ sha256sum() {{ printf '%s  %s\\n' "{'b' * 64}" "$1"; }}
             "node": "nyc",
             "bundle_sha256": "1" * 64,
             "inventory_sha256": "2" * 64,
+            **{
+                field: proof[field]
+                for field in (
+                    "binding_index_sha256", "binding_sha256",
+                    "checkpoint_sha256", "checkpoint_manifest_hash",
+                    "checkpoint_payload_hash", "source_height",
+                    "source_block_hash", "source_state_root",
+                    "source_consensus_round", "recovery_epoch",
+                    "validator_set_id",
+                )
+            },
         }
         def archive_browser_boundary(
             node, path, *, method, origin=None, data=None, timeout=20
@@ -4695,7 +4831,8 @@ sha256sum() {{ printf '%s  %s\\n' "{'b' * 64}" "$1"; }}
             equal_or_lower = copy.deepcopy(proof)
             equal_or_lower["source_height"] = archive_height
             fork_harness._http_json.return_value = equal_or_lower
-            exposed = fork_harness.frontend_config([archived_fork])["sources"][-1]
+            height_bound_archive = dict(archived_fork, source_height=archive_height)
+            exposed = fork_harness.frontend_config([height_bound_archive])["sources"][-1]
             self.assertEqual(exposed["archive"]["sourceHeight"], archive_height)
             self.assertEqual(
                 exposed["archive"]["canonicalCheckpointHeight"],
@@ -4716,6 +4853,23 @@ sha256sum() {{ printf '%s  %s\\n' "{'b' * 64}" "$1"; }}
         fork_harness._http_json = mock.Mock(return_value=forged_bundle)
         with self.assertRaisesRegex(rollout.RolloutError, "bundle root differs"):
             fork_harness.frontend_config([archived_fork])
+        for field in (
+            "binding_index_sha256", "binding_sha256", "checkpoint_sha256",
+            "checkpoint_manifest_hash", "checkpoint_payload_hash",
+            "source_block_hash", "source_state_root", "source_height",
+            "source_consensus_round", "recovery_epoch", "validator_set_id",
+        ):
+            forged = copy.deepcopy(proof)
+            forged[field] = (
+                forged[field] + 1
+                if isinstance(forged[field], int)
+                else "f" * 64
+            )
+            fork_harness._http_json = mock.Mock(return_value=forged)
+            with self.subTest(immutable_archive_field=field), self.assertRaisesRegex(
+                rollout.RolloutError, "immutable binding tree"
+            ):
+                fork_harness.frontend_config([archived_fork])
         fork_harness._http_json = mock.Mock(return_value=proof)
         fork_harness._http_status_headers = mock.Mock(
             side_effect=lambda node, path, *, method, origin=None, data=None, timeout=20: (
@@ -4740,6 +4894,9 @@ sha256sum() {{ printf '%s  %s\\n' "{'b' * 64}" "$1"; }}
             fork_harness.frontend_config([archived_fork])
 
         blocked = self.root / "frontend.blocked.json"
+        harness.verify_checkpoint = mock.Mock(
+            side_effect=lambda: self.prime_checkpoint_identity(harness)
+        )
         harness.verify_live = mock.Mock(side_effect=rollout.RolloutError("height gate pending"))
         with self.assertRaisesRegex(rollout.RolloutError, "height gate pending"):
             rollout.write_frontend_config(
@@ -4890,6 +5047,31 @@ sha256sum() {{ printf '%s  %s\\n' "{'b' * 64}" "$1"; }}
             "validator_set_id": value["chain"]["validator_set_id"],
         }
         harness._http_json = mock.Mock(return_value=proof)
+        harness.verify_checkpoint = mock.Mock(
+            side_effect=lambda: self.prime_checkpoint_identity(harness)
+        )
+        harness._enrich_legacy_archive_fork_rows = mock.Mock(
+            return_value={
+                value["validators"][0]["name"]: {
+                    "node": value["validators"][0]["name"],
+                    "bundle_name": f"legacy-{value['validators'][0]['name']}.tar.zst",
+                    "inventory_name": f"legacy-{value['validators'][0]['name']}.inventory",
+                    "bundle_sha256": "1" * 64,
+                    "inventory_sha256": "2" * 64,
+                    **{
+                        field: proof[field]
+                        for field in (
+                            "binding_index_sha256", "binding_sha256",
+                            "checkpoint_sha256", "checkpoint_manifest_hash",
+                            "checkpoint_payload_hash", "source_height",
+                            "source_block_hash", "source_state_root",
+                            "source_consensus_round", "recovery_epoch",
+                            "validator_set_id",
+                        )
+                    },
+                }
+            }
+        )
         harness._http_status_headers = mock.Mock(
             side_effect=lambda node, path, *, method, origin=None, data=None, timeout=20: (
                 (405, {})
@@ -5217,6 +5399,11 @@ assert_udp_listener_owner 10001 "$ARC_TEST_EXPECTED_PID" validator-quic-p2p
         )
         harness = rollout.RecoveryRollout(value, "d" * 64, output=io.StringIO())
         events: list[str] = []
+        def verify_checkpoint():
+            events.append("checkpoint-verified")
+            self.prime_checkpoint_identity(harness)
+
+        harness.verify_checkpoint = mock.Mock(side_effect=verify_checkpoint)
         harness.verify_production_archive = mock.Mock(
             side_effect=lambda: events.append("archive-verified") or "2" * 64
         )
@@ -5235,7 +5422,13 @@ assert_udp_listener_owner 10001 "$ARC_TEST_EXPECTED_PID" validator-quic-p2p
             harness, output, reward_evidence=reward_evidence
         )
         self.assertEqual(
-            events, ["archive-verified", "metadata-loaded", "live-verified"]
+            events,
+            [
+                "checkpoint-verified",
+                "archive-verified",
+                "metadata-loaded",
+                "live-verified",
+            ],
         )
         self.assertTrue(output.exists())
 
@@ -5951,7 +6144,7 @@ assert_udp_listener_owner 10001 "$ARC_TEST_EXPECTED_PID" validator-quic-p2p
         reward_sha256 = harness.persist_reward_evidence(evidence)
         gate_payload = rollout.canonical_bytes(
             {
-                "schema": "arc.recovery.public-gate-open-receipt.v1",
+                "schema": "arc.recovery.public-gate-open-receipt.v2",
                 "rollout_manifest_sha256": harness.digest,
             }
         )
@@ -6122,6 +6315,9 @@ assert_udp_listener_owner 10001 "$ARC_TEST_EXPECTED_PID" validator-quic-p2p
     def test_receipt_mode_frontend_publication_requires_two_bound_receipts(self) -> None:
         value = self.fixture(production=True, reward_receipt=True)
         harness = rollout.RecoveryRollout(value, "d" * 64, output=io.StringIO())
+        harness.verify_checkpoint = mock.Mock(
+            side_effect=lambda: self.prime_checkpoint_identity(harness)
+        )
         harness.verify_live = mock.Mock()
         with self.assertRaisesRegex(rollout.RolloutError, "requires --reward-evidence"):
             rollout.write_frontend_config(harness, self.root / "missing-evidence.json")
@@ -6276,11 +6472,16 @@ assert_udp_listener_owner 10001 "$ARC_TEST_EXPECTED_PID" validator-quic-p2p
         source = MODULE_PATH.read_text(encoding="utf-8")
         before_start = source.index('self._rollback_journal_event(5, "QUORUM-START"')
         preflight = source.index('self._prove_public_tls_fleet(phase="preflight")')
-        public_open = source.index('self.open_public_gate(promotion_initial, promotion_final)')
+        archive_verify = source.index(
+            'self.verify_production_archive(verify_live_captures=True)',
+            before_start,
+        )
+        public_open = source.index('self.open_public_gate()', archive_verify)
         post_rollout = source.index(
             'self._prove_public_tls_fleet(phase="post-rollout")'
         )
         self.assertLess(preflight, before_start)
+        self.assertLess(archive_verify, public_open)
         self.assertLess(public_open, post_rollout)
 
     def test_gateway_is_https_only_loopback_limited_and_fail_closed(self) -> None:

--- a/scripts/release/assemble-cutover-assets.py
+++ b/scripts/release/assemble-cutover-assets.py
@@ -45,8 +45,8 @@ HANDOFF_FILES = {
 BOUNDARY_OUTPUT = "arc-legacy-maintenance-boundary.json"
 CHECKPOINT_DESCRIPTOR_OUTPUT = "arc-recovery-checkpoint-descriptor.json"
 POLICY_OUTPUT = "arc-cutover-policy.json"
-CANONICAL_BOUNDARY_HEIGHT = 137_145
-REQUIRED_POST_CUTOVER_MIN_HEIGHT = 137_146
+TRUSTED_CHECKPOINT_MIN_HEIGHT = 137_145
+COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT = 137_146
 OLD_CLAIM_SUBMIT_LISTENER_PORTS = [9090, 3001]
 EXPECTED_RECOVERY_VALIDATORS = (
     (
@@ -339,6 +339,28 @@ def validate_boundary(
         ) != (name, host, f"http://{host}:9090"):
             fail(f"legacy maintenance node {index} topology differs")
 
+    canonical_source = chain["canonical_source"]
+    source_node = next(
+        (row for row in boundary_nodes if row.get("node") == canonical_source["node"]),
+        None,
+    )
+    source_head = (
+        source_node.get("final_persisted_head", {}).get("tuple", {})
+        if isinstance(source_node, dict)
+        else {}
+    )
+    if (
+        not isinstance(source_node, dict)
+        or source_node.get("final_persisted_head", {}).get("evidence_sha256")
+        != canonical_source["persisted_head_sha256"]
+        or source_head.get("height") != chain["source_height"]
+        or str(source_head.get("block_hash", "")).removeprefix("0x")
+        != str(chain["source_block_hash"]).removeprefix("0x")
+        or str(source_head.get("state_root", "")).removeprefix("0x")
+        != str(chain["source_state_root"]).removeprefix("0x")
+    ):
+        fail("recovery manifest source tuple differs from its selected captured head")
+
     # The final sealed manifest itself is an input to the owner-signed policy;
     # keep the argument used so static analyzers cannot mistake it for an
     # unbound parse.
@@ -445,7 +467,7 @@ def validate_checkpoint_outputs(
         "validator_set_id": chain["validator_set_id"],
         "protocol_version": chain["protocol_version"],
         "validator_count": recovery.REQUIRED_VALIDATORS,
-        "community_rewards_v1_activation_height": REQUIRED_POST_CUTOVER_MIN_HEIGHT,
+        "community_rewards_v1_activation_height": COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT,
     }
     hash_fields = {
         "manifest_hash",
@@ -678,6 +700,7 @@ def build_checkpoint_descriptor(
             "size_bytes": checkpoint_size_bytes,
             "sha256": checkpoint_sha256,
         },
+        "canonical_source": dict(manifest["chain"]["canonical_source"]),
         "canonical_inspection": checkpoint_identity,
         "checkpoint_certificate": checkpoint_certificate,
         "approved_validators": validators,
@@ -779,6 +802,9 @@ def build_policy(
         "legacy_admission_cutoff_utc": boundary["all_controlled_stopped_at"],
         "canonical_boundary_height": identity["source_height"],
         "required_post_cutover_min_height": identity["transition_height"],
+        "legacy_observed_cutoff_height": boundary["observed_cutoff_height"],
+        "legacy_continuity_safety_margin": boundary["continuity_safety_margin"],
+        "legacy_public_max_height": boundary["legacy_public_max_height"],
         "required_recovery_epoch": identity["recovery_epoch"],
         "required_validator_set_id": identity["validator_set_id"],
         "required_validator_count": identity["validator_count"],
@@ -911,17 +937,20 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         chain = manifest["chain"]
         if (
-            chain["source_height"] != CANONICAL_BOUNDARY_HEIGHT
-            or chain["legacy_public_max_height"] != CANONICAL_BOUNDARY_HEIGHT
-            or chain["transition_height"] != REQUIRED_POST_CUTOVER_MIN_HEIGHT
+            chain["source_height"] < TRUSTED_CHECKPOINT_MIN_HEIGHT
+            or chain["transition_height"] != chain["source_height"] + 1
+            or chain["legacy_observed_cutoff_height"] < chain["source_height"]
+            or chain["legacy_public_max_height"]
+            != chain["legacy_observed_cutoff_height"]
+            + recovery.LEGACY_CONTINUITY_SAFETY_MARGIN
             or chain["recovery_epoch"] != 1
             or chain["validator_set_id"] != 1
             or chain["protocol_version"] != "3.0.0"
             or len(manifest["validators"]) != recovery.REQUIRED_VALIDATORS
         ):
             fail(
-                "recovery manifest does not bind canonical v3.0.0 H/H+1, "
-                "legacy ceiling H, epoch 1, set 1, and six validators"
+                "recovery manifest does not bind capture-derived v3.0.0 H/H+1, "
+                "reopening floor F=cutoff+128, epoch 1, set 1, and six validators"
             )
 
         inspected, verified = run_checkpoint_cli(

--- a/scripts/release/build-postrelease-public-truth.py
+++ b/scripts/release/build-postrelease-public-truth.py
@@ -1974,7 +1974,9 @@ def validate_release(
     return published_at, dict(sorted(normalized.items()))
 
 
-def validate_network(config: dict[str, Any], source_sha: str) -> dict[str, Any]:
+def validate_network(
+    config: dict[str, Any], source_sha: str, manifest: Mapping[str, Any]
+) -> dict[str, Any]:
     exact_keys(
         config,
         {"schema", "state", "network", "checkpoint", "sources", "services", "notices"},
@@ -2004,18 +2006,36 @@ def validate_network(config: dict[str, Any], source_sha: str) -> dict[str, Any]:
     height = positive_int(checkpoint["height"], "checkpoint.height")
     recovery_height = positive_int(checkpoint["recoveryHeight"], "checkpoint.recoveryHeight")
     legacy_max = positive_int(checkpoint["legacyPublicMaxHeight"], "checkpoint.legacyPublicMaxHeight")
-    if height != 137_145 or recovery_height != height + 1 or legacy_max < recovery_height:
-        fail("frontend checkpoint does not preserve the reviewed H/H+1 recovery boundary")
+    if height < 137_145 or recovery_height != height + 1:
+        fail(
+            "frontend checkpoint does not preserve capture-derived H/H+1 "
+            "above trusted anchor 137145"
+        )
     if (
         not isinstance(checkpoint["protocolVersion"], str)
         or PROTOCOL_VERSION_RE.fullmatch(checkpoint["protocolVersion"]) is None
     ):
         fail("frontend checkpoint is not protocol v3")
+    chain = manifest.get("chain")
+    canonical_source = chain.get("canonical_source") if isinstance(chain, dict) else None
+    canonical_node = (
+        canonical_source.get("node") if isinstance(canonical_source, dict) else None
+    )
+    if canonical_node not in {name for name, _host in PRODUCTION_FLEET}:
+        fail("rollout manifest omits its captured canonical source node")
+    source_id = f"v3-{canonical_node}"
     if (
         checkpoint["recoveryEpoch"] != RECOVERY_EPOCH
         or checkpoint["validatorSetId"] != VALIDATOR_SET_ID
-        or checkpoint["legacySourceId"] != "v3-nyc"
-        or checkpoint["v3SourceId"] != "v3-nyc"
+        or checkpoint["legacySourceId"] != source_id
+        or checkpoint["v3SourceId"] != source_id
+        or height != chain.get("source_height")
+        or recovery_height != chain.get("transition_height")
+        or legacy_max != chain.get("legacy_public_max_height")
+        or chain_hash(checkpoint["blockHash"], "checkpoint.blockHash")
+        != chain_hash(chain.get("source_block_hash"), "manifest source block hash")
+        or chain_hash(checkpoint["stateRoot"], "checkpoint.stateRoot")
+        != chain_hash(chain.get("source_state_root"), "manifest source state root")
     ):
         fail("frontend checkpoint differs from the reviewed recovery identity")
     for field in (
@@ -2151,7 +2171,8 @@ def validate_network(config: dict[str, Any], source_sha: str) -> dict[str, Any]:
         or interlock.get("maxStalenessSeconds") != 90
         or isinstance(interlock.get("observedCutoffHeight"), bool)
         or not isinstance(interlock.get("observedCutoffHeight"), int)
-        or interlock["observedCutoffHeight"] < 1
+        or interlock["observedCutoffHeight"] < height
+        or legacy_max != interlock["observedCutoffHeight"] + 128
     ):
         fail("frontend live gate does not require all six validators")
     for field in ("sourceSetSha256", "boundarySha256", "toolSha256"):
@@ -2900,6 +2921,9 @@ def render_readme_block(
 > All six protocol-v3 validators serve the retained canonical chain through
 > block **{checkpoint['height']:,}**, continue at **{checkpoint['recoveryHeight']:,}**, and are
 > required to agree before the public console reports the network as healthy.
+> Checkpoint height H is distinct from maintenance reopening floor
+> F=**{checkpoint['legacyPublicMaxHeight']:,}**; every v3 validator must advance
+> strictly above F before canonical public surfaces reopen.
 > The six prior public histories remain available as explicit, immutable,
 > read-only noncanonical fork views; no legacy block was erased or renumbered.
 > The recovered network bytes were first accepted on Pages from verified config
@@ -3021,7 +3045,7 @@ def build(args: argparse.Namespace) -> tuple[Path, Path]:
 
         pages, pages_hashes = validate_pages(args, config_raw)
         frontend_sha = pages["acceptedConfigCommit"]
-        checkpoint = validate_network(config, source_sha)
+        checkpoint = validate_network(config, source_sha, manifest)
         worker, reward_base, receipt_count = validate_reward(
             reward, manifest, source_sha
         )

--- a/scripts/release/build-postrelease-public-truth.py
+++ b/scripts/release/build-postrelease-public-truth.py
@@ -34,7 +34,7 @@ import tempfile
 import zipfile
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, NoReturn, Sequence
+from typing import Any, Mapping, NoReturn, Sequence
 
 
 STATUS_SCHEMA = "arc.public-production-status.v1"
@@ -48,6 +48,8 @@ CHAIN_ID = "0x415243"
 PROTOCOL_VERSION_RE = re.compile(r"^3\.[0-9]+\.[0-9]+$")
 RECOVERY_EPOCH = 1
 VALIDATOR_SET_ID = 1
+LEGACY_CONTINUITY_SAFETY_MARGIN = 128
+RECOVERY_FRONTEND_PROJECTION_TIMEOUT_SECONDS = 30 * 60 * 60
 REWARD_PER_RECEIPT_BASE = 2_500_000_000
 PUBLIC_CONSOLE = "https://ferrumvir.github.io/arc-chain/"
 PUBLIC_EXPLORER = PUBLIC_CONSOLE + "explorer/"
@@ -380,7 +382,13 @@ if blake3_short(b"") != "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93c
     raise RuntimeError("public-truth BLAKE3 known-answer self-test failed")
 
 
-def load_bytes(path: Path, label: str, maximum: int = MAX_INPUT_BYTES) -> bytes:
+def load_bytes(
+    path: Path,
+    label: str,
+    maximum: int = MAX_INPUT_BYTES,
+    *,
+    allow_empty: bool = False,
+) -> bytes:
     descriptor = -1
     try:
         flags = os.O_RDONLY
@@ -390,7 +398,7 @@ def load_bytes(path: Path, label: str, maximum: int = MAX_INPUT_BYTES) -> bytes:
         before = os.fstat(descriptor)
         if not stat.S_ISREG(before.st_mode):
             fail(f"{label} must be a non-symlink regular file")
-        if before.st_size <= 0 or before.st_size > maximum:
+        if before.st_size > maximum or (before.st_size == 0 and not allow_empty):
             fail(f"{label} has an unsupported size")
         chunks: list[bytes] = []
         remaining = maximum + 1
@@ -1999,7 +2007,8 @@ def validate_network(
             "height", "recoveryHeight", "legacyPublicMaxHeight", "blockHash",
             "stateRoot", "manifestHash", "boundaryBlockHash", "boundaryStateRoot",
             "recoveryEpoch", "validatorSetId", "protocolVersion", "recoveryDomain",
-            "legacySourceId", "v3SourceId",
+            "checkpointFileSha256", "checkpointPayloadHash", "legacySourceId",
+            "v3SourceId",
         },
         "frontend checkpoint",
     )
@@ -2011,22 +2020,96 @@ def validate_network(
             "frontend checkpoint does not preserve capture-derived H/H+1 "
             "above trusted anchor 137145"
         )
-    if (
-        not isinstance(checkpoint["protocolVersion"], str)
-        or PROTOCOL_VERSION_RE.fullmatch(checkpoint["protocolVersion"]) is None
-    ):
-        fail("frontend checkpoint is not protocol v3")
     chain = manifest.get("chain")
-    canonical_source = chain.get("canonical_source") if isinstance(chain, dict) else None
+    manifest_archive = manifest.get("archive")
+    artifacts = manifest.get("artifacts")
+    rollout_id = manifest.get("rollout_id")
+    if (
+        not isinstance(chain, dict)
+        or not isinstance(manifest_archive, dict)
+        or not isinstance(artifacts, dict)
+        or not isinstance(rollout_id, str)
+        or not rollout_id
+    ):
+        fail("rollout manifest omits its production chain/archive identity")
+    canonical_source = chain.get("canonical_source")
     canonical_node = (
         canonical_source.get("node") if isinstance(canonical_source, dict) else None
     )
     if canonical_node not in {name for name, _host in PRODUCTION_FLEET}:
         fail("rollout manifest omits its captured canonical source node")
+    manifest_epoch = positive_int(
+        chain.get("recovery_epoch"), "manifest recovery epoch"
+    )
+    manifest_validator_set = positive_int(
+        chain.get("validator_set_id"), "manifest validator set ID"
+    )
+    observed_cutoff = positive_int(
+        chain.get("legacy_observed_cutoff_height"),
+        "manifest legacy observed cutoff height",
+    )
+    continuity_margin = positive_int(
+        chain.get("legacy_continuity_safety_margin"),
+        "manifest legacy continuity safety margin",
+    )
+    protocol_version = chain.get("protocol_version")
+    if (
+        not isinstance(protocol_version, str)
+        or PROTOCOL_VERSION_RE.fullmatch(protocol_version) is None
+        or not isinstance(checkpoint["protocolVersion"], str)
+        or PROTOCOL_VERSION_RE.fullmatch(checkpoint["protocolVersion"]) is None
+    ):
+        fail("frontend checkpoint is not protocol v3")
+    if continuity_margin != LEGACY_CONTINUITY_SAFETY_MARGIN:
+        fail("rollout manifest continuity safety margin is not exactly 128")
+    if observed_cutoff < height or legacy_max != observed_cutoff + continuity_margin:
+        fail("rollout manifest does not prove the exact F=C+128 reopening floor")
+
+    checkpoint_artifact = artifacts.get("checkpoint")
+    interlock_artifact = artifacts.get("legacy_late_fork_interlock_tool")
+    if not isinstance(checkpoint_artifact, dict) or not isinstance(
+        interlock_artifact, dict
+    ):
+        fail("rollout manifest omits checkpoint or interlock artifacts")
+    manifest_checkpoint_sha = hash_value(
+        checkpoint_artifact.get("sha256"), "manifest checkpoint artifact SHA-256"
+    )
+    checkpoint_payload_hash = hash_value(
+        checkpoint.get("checkpointPayloadHash"),
+        "frontend canonical checkpoint payload hash",
+    )
+    manifest_interlock_tool_sha = hash_value(
+        interlock_artifact.get("sha256"), "manifest interlock tool SHA-256"
+    )
+    expected_capture_id = hash_value(
+        manifest_archive.get("capture_id"), "manifest archive capture ID"
+    )
+    expected_archive_roots = {
+        "rolloutManifestSha256": hash_value(
+            manifest_archive.get("prearchive_rollout_sha256"),
+            "manifest prearchive rollout SHA-256",
+        ),
+        "archiveManifestSha256": hash_value(
+            manifest_archive.get("archive_manifest_sha256"),
+            "manifest archive-manifest SHA-256",
+        ),
+        "completeSha256": hash_value(
+            manifest_archive.get("complete_sha256"),
+            "manifest archive COMPLETE SHA-256",
+        ),
+    }
+    if any(value == "0" * 64 for value in expected_archive_roots.values()):
+        fail("public truth requires a fully finalized archive manifest")
+
     source_id = f"v3-{canonical_node}"
     if (
-        checkpoint["recoveryEpoch"] != RECOVERY_EPOCH
-        or checkpoint["validatorSetId"] != VALIDATOR_SET_ID
+        chain.get("chain_id") != CHAIN_ID
+        or checkpoint["recoveryEpoch"] != manifest_epoch
+        or checkpoint["validatorSetId"] != manifest_validator_set
+        or manifest_epoch != RECOVERY_EPOCH
+        or manifest_validator_set != VALIDATOR_SET_ID
+        or checkpoint["protocolVersion"] != protocol_version
+        or checkpoint.get("checkpointFileSha256") != manifest_checkpoint_sha
         or checkpoint["legacySourceId"] != source_id
         or checkpoint["v3SourceId"] != source_id
         or height != chain.get("source_height")
@@ -2036,16 +2119,31 @@ def validate_network(
         != chain_hash(chain.get("source_block_hash"), "manifest source block hash")
         or chain_hash(checkpoint["stateRoot"], "checkpoint.stateRoot")
         != chain_hash(chain.get("source_state_root"), "manifest source state root")
+        or chain_hash(checkpoint["manifestHash"], "checkpoint.manifestHash")
+        != chain_hash(
+            chain.get("approved_checkpoint_manifest_hash"),
+            "manifest approved checkpoint manifest hash",
+        )
+        or chain_hash(
+            checkpoint["boundaryBlockHash"], "checkpoint.boundaryBlockHash"
+        )
+        != chain_hash(
+            chain.get("transition_block_hash"), "manifest transition block hash"
+        )
+        or chain_hash(
+            checkpoint["boundaryStateRoot"], "checkpoint.boundaryStateRoot"
+        )
+        != chain_hash(chain.get("full_state_root"), "manifest full state root")
+        or chain_hash(checkpoint["recoveryDomain"], "checkpoint.recoveryDomain")
+        != chain_hash(chain.get("recovery_domain"), "manifest recovery domain")
     ):
         fail("frontend checkpoint differs from the reviewed recovery identity")
-    for field in (
-        "blockHash", "stateRoot", "manifestHash", "boundaryBlockHash",
-        "boundaryStateRoot", "recoveryDomain",
-    ):
-        chain_hash(checkpoint[field], f"checkpoint.{field}")
     sources = config["sources"]
-    if not isinstance(sources, list) or len(sources) != 12:
-        fail("frontend sources must contain only the six validators and six legacy forks")
+    # The former `len(sources) != 12` invariant incorrectly presented every
+    # stopped capture as a noncanonical fork. The producer emits six v3 rows
+    # plus only the captures actually classified valid_noncanonical_fork.
+    if not isinstance(sources, list) or not 6 <= len(sources) <= 12:
+        fail("frontend sources must contain six validators and only captured legacy forks")
     if any(not isinstance(row, dict) for row in sources):
         fail("frontend source rows must be objects")
     identifiers = [row.get("id") for row in sources]
@@ -2060,9 +2158,12 @@ def validate_network(
         (f"v3-{name}", f"https://{host}") for name, host in PRODUCTION_FLEET
     ]
     actual_v3 = [(row.get("id"), row.get("baseUrl")) for row in v3]
-    if actual_v3 != expected_v3:
+    if (
+        actual_v3 != expected_v3
+        or sources[: len(PRODUCTION_FLEET)] != v3
+        or len(v3) + len(forks) != len(sources)
+    ):
         fail("frontend config does not expose the exact six protocol-v3 validators")
-    replica_groups: set[str] = set()
     for (name, _host), row in zip(PRODUCTION_FLEET, v3, strict=True):
         exact_keys(
             row,
@@ -2074,36 +2175,31 @@ def validate_network(
             row["name"] != f"ARC v3 {name.upper()}"
             or row["region"] != name.upper()
             or row["enabled"] is not True
-            or not isinstance(replica_group, str)
-            or not replica_group
+            or replica_group != rollout_id
         ):
             fail(f"frontend v3 source {name} differs from its rollout identity")
-        replica_groups.add(replica_group)
-    if len(replica_groups) != 1:
-        fail("frontend validators do not share one rollout identity")
-    if len(forks) != 6:
-        fail("frontend config does not preserve exactly six legacy fork views")
-    expected_forks = [
-        (f"legacy-fork-{name}", f"https://{host}/legacy/{name}")
-        for name, host in PRODUCTION_FLEET
-    ]
-    if [(row.get("id"), row.get("baseUrl")) for row in forks] != expected_forks:
-        fail("frontend legacy forks differ from the exact six archived validators")
+    fleet_hosts = dict(PRODUCTION_FLEET)
+    fleet_order = {name: index for index, (name, _host) in enumerate(PRODUCTION_FLEET)}
     capture_ids: set[str] = set()
-    for (name, _host), row in zip(PRODUCTION_FLEET, forks, strict=True):
+    fork_nodes: list[str] = []
+    previous_fleet_index = -1
+    for index, row in enumerate(forks):
         exact_keys(
             row,
             {
                 "id", "name", "region", "kind", "baseUrl", "enabled",
                 "replicaGroup", "description", "archive",
             },
-            f"frontend legacy source {name}",
+            f"frontend legacy source {index}",
         )
-        archive = row.get("archive")
-        if not isinstance(archive, dict):
+        archive_view = row.get("archive")
+        if not isinstance(archive_view, dict):
             fail("a legacy history lacks its archive commitment")
+        name = archive_view.get("node")
+        if not isinstance(name, str) or name not in fleet_hosts:
+            fail("a legacy history does not name a production capture")
         exact_keys(
-            archive,
+            archive_view,
             {
                 "schema", "readOnly", "classification", "captureId", "node",
                 "rolloutManifestSha256", "archiveManifestSha256", "completeSha256",
@@ -2114,25 +2210,37 @@ def validate_network(
             },
             f"frontend legacy source {name} archive",
         )
+        fleet_index = fleet_order[name]
         if (
-            row.get("enabled") is not True
+            fleet_index <= previous_fleet_index
+            or name == canonical_node
+            or row.get("id") != f"legacy-fork-{name}"
+            or row.get("baseUrl") != f"https://{fleet_hosts[name]}/legacy/{name}"
+            or row.get("enabled") is not True
             or row.get("name") != f"Preserved legacy fork · {name.upper()}"
             or row.get("region") != name.upper()
             or row.get("description")
             != "Explicit immutable historical fork; diagnostic only and never canonical."
-            or archive.get("readOnly") is not True
-            or archive.get("schema") != "arc.legacy-archive.source.v1"
-            or archive.get("classification") != "valid_noncanonical_fork"
-            or archive.get("node") != name
-            or archive.get("provenancePath") != "/provenance"
-            or archive.get("canonicalCheckpointHeight") != height
-            or isinstance(archive.get("sourceHeight"), bool)
-            or not isinstance(archive.get("sourceHeight"), int)
-            or archive["sourceHeight"] < 0
+            or archive_view.get("readOnly") is not True
+            or archive_view.get("schema") != "arc.legacy-archive.source.v1"
+            or archive_view.get("classification") != "valid_noncanonical_fork"
+            or archive_view.get("node") != name
+            or archive_view.get("provenancePath") != "/provenance"
+            or archive_view.get("canonicalCheckpointHeight") != height
+            or isinstance(archive_view.get("sourceHeight"), bool)
+            or not isinstance(archive_view.get("sourceHeight"), int)
+            or archive_view["sourceHeight"] < 0
         ):
             fail("a legacy history is not explicit, read-only, and noncanonical")
-        capture_id = hash_value(archive["captureId"], f"legacy source {name} captureId")
-        if row.get("replicaGroup") != f"legacy-capture-{capture_id}":
+        previous_fleet_index = fleet_index
+        fork_nodes.append(name)
+        capture_id = hash_value(
+            archive_view["captureId"], f"legacy source {name} captureId"
+        )
+        if (
+            capture_id != expected_capture_id
+            or row.get("replicaGroup") != f"legacy-capture-{expected_capture_id}"
+        ):
             fail(f"legacy source {name} is not bound to its capture identity")
         capture_ids.add(capture_id)
         for field in (
@@ -2141,12 +2249,13 @@ def validate_network(
             "checkpointSha256", "checkpointManifestHash", "checkpointPayloadHash",
             "sourceBlockHash", "sourceStateRoot",
         ):
-            chain_hash(archive[field], f"legacy source {name} archive.{field}")
-        if chain_hash(archive["checkpointManifestHash"], f"legacy source {name} checkpoint") != chain_hash(
-            checkpoint["manifestHash"], "checkpoint.manifestHash"
-        ):
-            fail(f"legacy source {name} refers to another checkpoint manifest")
-    if len(capture_ids) != 1:
+            chain_hash(archive_view[field], f"legacy source {name} archive.{field}")
+        for field, expected in expected_archive_roots.items():
+            if chain_hash(
+                archive_view[field], f"legacy source {name} archive.{field}"
+            ) != expected:
+                fail(f"legacy source {name} {field} differs from the sealed manifest")
+    if capture_ids and capture_ids != {expected_capture_id}:
         fail("frontend legacy forks do not share one sealed capture")
     services = config["services"]
     if not isinstance(services, dict):
@@ -2164,6 +2273,14 @@ def validate_network(
         },
         "frontend maintenance interlock",
     )
+    expected_source_set_sha = hash_value(
+        chain.get("legacy_late_fork_source_set_sha256"),
+        "manifest late-fork source-set SHA-256",
+    )
+    expected_boundary_sha = hash_value(
+        chain.get("legacy_maintenance_boundary_sha256"),
+        "manifest maintenance-boundary SHA-256",
+    )
     if (
         interlock.get("schema") != "arc.frontend.maintenance-interlock.v1"
         or interlock.get("path") != "/maintenance/status"
@@ -2171,13 +2288,33 @@ def validate_network(
         or interlock.get("maxStalenessSeconds") != 90
         or isinstance(interlock.get("observedCutoffHeight"), bool)
         or not isinstance(interlock.get("observedCutoffHeight"), int)
-        or interlock["observedCutoffHeight"] < height
-        or legacy_max != interlock["observedCutoffHeight"] + 128
+        or interlock["observedCutoffHeight"] != observed_cutoff
+        or legacy_max != interlock["observedCutoffHeight"] + continuity_margin
+        or interlock.get("sourceSetSha256") != expected_source_set_sha
+        or interlock.get("boundarySha256") != expected_boundary_sha
+        or interlock.get("toolSha256") != manifest_interlock_tool_sha
     ):
-        fail("frontend live gate does not require all six validators")
-    for field in ("sourceSetSha256", "boundarySha256", "toolSha256"):
-        hash_value(interlock[field], f"frontend maintenance interlock.{field}")
-    return checkpoint
+        fail("frontend live gate differs from the sealed all-six interlock")
+
+    # Per-fork checkpoint, binding, inventory, and source roots are
+    # intentionally candidate-specific: a valid noncanonical capture is
+    # expected to differ from the selected checkpoint. They are authenticated
+    # by the exact recovery verifier's deterministic frontend-config
+    # projection below, which derives them from the capture-bound immutable
+    # archive rather than trusting the supplied frontend JSON.
+    validated_checkpoint = dict(checkpoint)
+    validated_checkpoint.update(
+        {
+            "checkpointFileSha256": manifest_checkpoint_sha,
+            "checkpointPayloadHash": checkpoint_payload_hash,
+            "legacyContinuitySafetyMargin": continuity_margin,
+            "legacyObservedCutoffHeight": observed_cutoff,
+            "legacyForkCount": len(fork_nodes),
+            "legacyForkNodes": fork_nodes,
+            "rolloutId": rollout_id,
+        }
+    )
+    return validated_checkpoint
 
 
 def validate_reward(
@@ -2727,15 +2864,31 @@ def validate_published_acceptance(
 def run_recovery_verify(
     manifest_path: Path,
     reward_path: Path,
+    config_path: Path,
     manifest_raw: bytes,
     reward_raw: bytes,
+    config_raw: bytes,
     temporary_root: Path,
 ) -> dict[str, Any]:
+    """Rebuild the public config with the exact verifier and require byte identity.
+
+    ``frontend-config`` includes the same final all-six live/reward gate as
+    ``verify`` and additionally authenticates the finalized archive before
+    deriving every frontend field.  Using that command here avoids a duplicate
+    live pass while making the archive checkpoint payload hash come from the
+    exact capture-bound provenance path instead of an unauthenticated value in
+    the supplied frontend JSON.
+    """
+
     verifier, verifier_sha = repository_tool(
         RECOVERY_VERIFIER_RELATIVE, "recovery rollout verifier"
     )
     stdout_path = temporary_root / "recovery-verify.stdout"
     stderr_path = temporary_root / "recovery-verify.stderr"
+    projected_config_path = temporary_root / "recovery-projected-frontend.json"
+    projected_sidecar_path = projected_config_path.with_name(
+        projected_config_path.name + ".sha256"
+    )
     with stdout_path.open("xb") as stdout, stderr_path.open("xb") as stderr:
         result = subprocess.run(
             [
@@ -2743,25 +2896,58 @@ def run_recovery_verify(
                 "-B",
                 "-I",
                 str(verifier),
-                "verify",
+                "frontend-config",
                 "--manifest",
                 str(manifest_path),
                 "--reward-evidence",
                 str(reward_path),
+                "--output",
+                str(projected_config_path),
             ],
             stdin=subprocess.DEVNULL,
             stdout=stdout,
             stderr=stderr,
             check=False,
-            timeout=30 * 60,
+            # The nested immutable-archive verifier alone has a reviewed
+            # 24-hour bound. Leave room for the subsequent all-six live and
+            # reward checks while retaining a finite outer watchdog.
+            timeout=RECOVERY_FRONTEND_PROJECTION_TIMEOUT_SECONDS,
         )
-    stderr_raw = load_bytes(stderr_path, "recovery verifier stderr", maximum=16 * 1024 * 1024)
+    stderr_raw = load_bytes(
+        stderr_path,
+        "recovery verifier stderr",
+        maximum=16 * 1024 * 1024,
+        allow_empty=True,
+    )
     if result.returncode != 0:
         detail = stderr_raw.decode("utf-8", errors="replace").strip()[-1000:]
         fail(f"exact checked-in recovery verifier failed closed: {detail or f'exit {result.returncode}'}")
     stdout_raw = load_bytes(stdout_path, "recovery verifier stdout", maximum=16 * 1024 * 1024)
-    if not stdout_raw or b"VERIFIED locked rollout sha256=" not in stdout_raw:
+    projected_raw = load_bytes(
+        projected_config_path,
+        "recovery-projected frontend config",
+        maximum=MAX_INPUT_BYTES,
+    )
+    projected_sidecar_raw = load_bytes(
+        projected_sidecar_path,
+        "recovery-projected frontend config sidecar",
+        maximum=1024,
+    )
+    projected_sha = sha256(projected_raw)
+    if projected_sidecar_raw != (
+        f"{projected_sha}  {projected_config_path.name}\n".encode("ascii")
+    ):
+        fail("recovery-projected frontend config sidecar differs")
+    expected_terminal = (
+        f"FRONTEND CONFIG {projected_config_path} sha256={projected_sha} "
+        f"rollout_sha256={sha256(manifest_raw)}\n"
+    ).encode("utf-8")
+    if (
+        stdout_raw.count(b"FRONTEND CONFIG ") != 1
+        or not stdout_raw.endswith(expected_terminal)
+    ):
         fail("exact checked-in recovery verifier produced no terminal verification record")
+    require_exact_frontend_projection(config_raw, projected_raw)
     _verifier_after, verifier_after_sha = repository_tool(
         RECOVERY_VERIFIER_RELATIVE, "recovery rollout verifier"
     )
@@ -2770,15 +2956,31 @@ def run_recovery_verify(
     if (
         load_bytes(manifest_path, "rollout manifest", maximum=MAX_INPUT_BYTES) != manifest_raw
         or load_bytes(reward_path, "reward evidence", maximum=MAX_INPUT_BYTES) != reward_raw
+        or load_bytes(config_path, "frontend config", maximum=MAX_INPUT_BYTES)
+        != config_raw
     ):
-        fail("sealed rollout or reward evidence changed during live verification")
+        fail("sealed rollout, reward evidence, or frontend config changed during verification")
     return {
+        "frontendConfigSha256": projected_sha,
+        "frontendProjectionSidecarSha256": sha256(projected_sidecar_raw),
         "manifestSha256": sha256(manifest_raw),
         "rewardEvidenceSha256": sha256(reward_raw),
         "stdoutSha256": sha256(stdout_raw),
         "verifierPath": RECOVERY_VERIFIER_RELATIVE.as_posix(),
         "verifierSha256": verifier_sha,
     }
+
+
+def require_exact_frontend_projection(
+    supplied_raw: bytes, projected_raw: bytes
+) -> None:
+    """Fail unless public bytes are the verifier's exact deterministic projection."""
+
+    if supplied_raw != projected_raw:
+        fail(
+            "frontend config differs from the exact capture-bound sealed-manifest "
+            "projection"
+        )
 
 
 def run_product_surface_verify(
@@ -2914,6 +3116,16 @@ def render_readme_block(
     each_arc = arc_text(reward_base)
     short_source = source_sha[:12]
     short_frontend = frontend_sha[:12]
+    fork_count = checkpoint["legacyForkCount"]
+    fork_summary = (
+        "No divergent capture requires an alternate public fork view."
+        if fork_count == 0
+        else (
+            f"**{fork_count}** divergent captured history "
+            f"{'view is' if fork_count == 1 else 'views are'} available as explicit, "
+            "immutable, read-only noncanonical forks."
+        )
+    )
     return f"""{BEGIN_MARKER}
 > **Live public testnet (evidence sealed after {published_at}):** The immutable
 > [v0.8.0 release](https://github.com/FerrumVir/arc-chain/releases/tag/v0.8.0)
@@ -2921,11 +3133,18 @@ def render_readme_block(
 > All six protocol-v3 validators serve the retained canonical chain through
 > block **{checkpoint['height']:,}**, continue at **{checkpoint['recoveryHeight']:,}**, and are
 > required to agree before the public console reports the network as healthy.
-> Checkpoint height H is distinct from maintenance reopening floor
-> F=**{checkpoint['legacyPublicMaxHeight']:,}**; every v3 validator must advance
-> strictly above F before canonical public surfaces reopen.
-> The six prior public histories remain available as explicit, immutable,
-> read-only noncanonical fork views; no legacy block was erased or renumbered.
+> Checkpoint height H is distinct from the last observed legacy height
+> C=**{checkpoint['legacyObservedCutoffHeight']:,}**. The sealed continuity margin is
+> **{checkpoint['legacyContinuitySafetyMargin']} blocks**, so
+> F=C+128=**{checkpoint['legacyPublicMaxHeight']:,}**; every v3 validator must advance
+> strictly above F before canonical public surfaces reopen. The H+1 boundary
+> block/state are `{chain_hash(checkpoint['boundaryBlockHash'], 'checkpoint.boundaryBlockHash')}` /
+> `{chain_hash(checkpoint['boundaryStateRoot'], 'checkpoint.boundaryStateRoot')}`;
+> recovery domain `{chain_hash(checkpoint['recoveryDomain'], 'checkpoint.recoveryDomain')}`,
+> epoch **{checkpoint['recoveryEpoch']}**, validator set **{checkpoint['validatorSetId']}**.
+> All six stopped captures remain preservation-bound. Selected or equivalent
+> canonical history is retained by v3. {fork_summary} No legacy block was erased
+> or renumbered.
 > The recovered network bytes were first accepted on Pages from verified config
 > commit [`{short_frontend}`](https://github.com/FerrumVir/arc-chain/commit/{frontend_sha}).
 > This block and its machine-readable status are published only by a subsequent
@@ -3057,8 +3276,10 @@ def build(args: argparse.Namespace) -> tuple[Path, Path]:
         recovery = run_recovery_verify(
             args.rollout_manifest,
             args.reward_evidence,
+            args.frontend_config,
             manifest_raw,
             reward_raw,
+            config_raw,
             temporary_root,
         )
         product_surfaces = run_product_surface_verify(
@@ -3138,17 +3359,39 @@ def build(args: argparse.Namespace) -> tuple[Path, Path]:
         },
         "checkpoint": {
             "blockHash": chain_hash(checkpoint["blockHash"], "checkpoint.blockHash"),
+            "boundaryBlockHash": chain_hash(
+                checkpoint["boundaryBlockHash"], "checkpoint.boundaryBlockHash"
+            ),
+            "boundaryStateRoot": chain_hash(
+                checkpoint["boundaryStateRoot"], "checkpoint.boundaryStateRoot"
+            ),
+            "checkpointFileSha256": checkpoint["checkpointFileSha256"],
+            "checkpointPayloadHash": checkpoint["checkpointPayloadHash"],
             "height": checkpoint["height"],
+            "legacyContinuitySafetyMargin": checkpoint[
+                "legacyContinuitySafetyMargin"
+            ],
+            "legacyObservedCutoffHeight": checkpoint[
+                "legacyObservedCutoffHeight"
+            ],
             "legacyPublicMaxHeight": checkpoint["legacyPublicMaxHeight"],
+            "legacyReopeningFormula": "F=C+128",
             "manifestHash": chain_hash(checkpoint["manifestHash"], "checkpoint.manifestHash"),
             "protocolVersion": checkpoint["protocolVersion"],
+            "recoveryDomain": chain_hash(
+                checkpoint["recoveryDomain"], "checkpoint.recoveryDomain"
+            ),
+            "recoveryEpoch": checkpoint["recoveryEpoch"],
             "recoveryHeight": checkpoint["recoveryHeight"],
             "stateRoot": chain_hash(checkpoint["stateRoot"], "checkpoint.stateRoot"),
+            "validatorSetId": checkpoint["validatorSetId"],
         },
         "fleet": {
-            "legacyForkCount": 6,
+            "legacyForkCount": checkpoint["legacyForkCount"],
+            "legacyForkNodes": checkpoint["legacyForkNodes"],
             "legacyForkPolicy": "immutable-read-only-noncanonical",
             "requiredHealthyValidators": 6,
+            "rolloutId": checkpoint["rolloutId"],
             "validatorCount": 6,
         },
         "network": config["network"],

--- a/scripts/release/build-postrelease-public-truth.py
+++ b/scripts/release/build-postrelease-public-truth.py
@@ -49,7 +49,12 @@ PROTOCOL_VERSION_RE = re.compile(r"^3\.[0-9]+\.[0-9]+$")
 RECOVERY_EPOCH = 1
 VALIDATOR_SET_ID = 1
 LEGACY_CONTINUITY_SAFETY_MARGIN = 128
-RECOVERY_FRONTEND_PROJECTION_TIMEOUT_SECONDS = 30 * 60 * 60
+# The exact projection deliberately nests the complete archive verifier (up to
+# 24h), bounded per-object/per-fork provenance reads, and fresh all-six live,
+# convergence, and reward checks. Keep the outer watchdog beyond the sum of
+# every valid inner watchdog so it never kills a slow operation that remains
+# inside the reviewed contract.
+RECOVERY_FRONTEND_PROJECTION_TIMEOUT_SECONDS = 72 * 60 * 60
 REWARD_PER_RECEIPT_BASE = 2_500_000_000
 PUBLIC_CONSOLE = "https://ferrumvir.github.io/arc-chain/"
 PUBLIC_EXPLORER = PUBLIC_CONSOLE + "explorer/"
@@ -2183,6 +2188,9 @@ def validate_network(
     capture_ids: set[str] = set()
     fork_nodes: list[str] = []
     previous_fleet_index = -1
+    # Selection is only through H. The selected source node may itself retain
+    # a divergent post-H legacy tail, so archive classification—not node name—
+    # decides whether that capture receives a noncanonical history view.
     for index, row in enumerate(forks):
         exact_keys(
             row,
@@ -2213,7 +2221,6 @@ def validate_network(
         fleet_index = fleet_order[name]
         if (
             fleet_index <= previous_fleet_index
-            or name == canonical_node
             or row.get("id") != f"legacy-fork-{name}"
             or row.get("baseUrl") != f"https://{fleet_hosts[name]}/legacy/{name}"
             or row.get("enabled") is not True

--- a/scripts/release/restore-validator-vault.py
+++ b/scripts/release/restore-validator-vault.py
@@ -111,6 +111,18 @@ artifact_provenance = importlib.util.module_from_spec(_PROVENANCE_SPEC)
 sys.modules[_PROVENANCE_SPEC.name] = artifact_provenance
 _PROVENANCE_SPEC.loader.exec_module(artifact_provenance)
 
+_QUARANTINE_ROUNDS_PATH = (
+    Path(__file__).resolve().parents[1] / "recovery" / "quarantine_rounds.py"
+)
+_QUARANTINE_ROUNDS_SPEC = importlib.util.spec_from_file_location(
+    "arc_quarantine_rounds_for_vault", _QUARANTINE_ROUNDS_PATH
+)
+if _QUARANTINE_ROUNDS_SPEC is None or _QUARANTINE_ROUNDS_SPEC.loader is None:
+    raise RuntimeError("cannot load quarantine-generation validator")
+quarantine_rounds = importlib.util.module_from_spec(_QUARANTINE_ROUNDS_SPEC)
+sys.modules[_QUARANTINE_ROUNDS_SPEC.name] = quarantine_rounds
+_QUARANTINE_ROUNDS_SPEC.loader.exec_module(quarantine_rounds)
+
 
 def sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
@@ -1789,6 +1801,8 @@ def load_legacy_maintenance_evidence_bundle(
     freeze_sha256: str,
     freeze_plan: Any,
 ) -> tuple[dict[str, Any], dict[str, dict[str, Any]], str]:
+    """Validate the generation-ledger tagged union emitted by archive-fleet."""
+
     value, expected = load_private_sealed_json(
         path,
         sidecar,
@@ -1799,30 +1813,23 @@ def load_legacy_maintenance_evidence_bundle(
     bundle = exact_object(
         value,
         {
-            "schema",
-            "source_main_commit",
-            "freeze_plan_sha256",
-            "capture_id",
-            "first_quarantine_started_at",
-            "all_controlled_stopped_at",
-            "challenge",
+            "schema", "source_main_commit", "freeze_plan_sha256", "capture_id",
+            "first_quarantine_started_at", "all_controlled_stopped_at", "challenge",
+            "live_observation_selection",
             "authenticated_prefence_height_cross_proof",
-            "network_quarantine_challenge",
-            "quarantine_stability_proof",
-            "nodes",
-            "object_inventory",
+            "quarantine_generation_ledger", "network_quarantine_challenge",
+            "quarantine_stability_proof", "nodes", "object_inventory",
             "aggregate_root_sha256",
         },
         "legacy maintenance evidence bundle",
     )
     capture_id = capture_id_for_freeze_hash(freeze_sha256)
-    expected_identity = {
-        "schema": MAINTENANCE_EVIDENCE_BUNDLE_SCHEMA,
-        "source_main_commit": source_commit,
-        "freeze_plan_sha256": freeze_sha256,
-        "capture_id": capture_id,
-    }
-    if any(bundle.get(field) != item for field, item in expected_identity.items()):
+    if (
+        bundle.get("schema") != MAINTENANCE_EVIDENCE_BUNDLE_SCHEMA
+        or bundle.get("source_main_commit") != source_commit
+        or bundle.get("freeze_plan_sha256") != freeze_sha256
+        or bundle.get("capture_id") != capture_id
+    ):
         fail("legacy maintenance evidence bundle source/freeze identity differs")
     first = require_utc_seconds(
         bundle.get("first_quarantine_started_at"), "maintenance first quarantine"
@@ -1833,90 +1840,138 @@ def load_legacy_maintenance_evidence_bundle(
     if first > stopped:
         fail("legacy maintenance evidence timestamps are reversed")
     challenge = require_hash(bundle.get("challenge"), "maintenance quarantine challenge")
-    inventory_expected: list[dict[str, Any]] = []
+    inventory: list[dict[str, Any]] = []
 
     def sealed(raw: object, node: str, role: str, label: str) -> tuple[dict[str, Any], str]:
         wrapper = exact_object(raw, {"value", "sha256"}, label)
-        object_value = wrapper.get("value")
-        if not isinstance(object_value, dict):
+        inner = wrapper.get("value")
+        if not isinstance(inner, dict):
             fail(f"{label} value is not an object")
-        object_sha = require_hash(wrapper.get("sha256"), f"{label} digest")
-        payload = canonical_json_bytes(object_value)
-        if hashlib.sha256(payload).hexdigest() != object_sha:
+        payload = canonical_json_bytes(inner)
+        root = require_hash(wrapper.get("sha256"), f"{label} digest")
+        if hashlib.sha256(payload).hexdigest() != root:
             fail(f"{label} digest is not reproducible")
-        inventory_expected.append(
-            {"node": node, "role": role, "sha256": object_sha, "size": len(payload)}
-        )
-        return object_value, object_sha
+        inventory.append({"node": node, "role": role, "sha256": root, "size": len(payload)})
+        return inner, root
 
+    # Inventory order is consensus-like: it must match the producer exactly.
     authenticated, _authenticated_sha = sealed(
-        bundle.get("authenticated_prefence_height_cross_proof"),
-        "fleet",
+        bundle.get("authenticated_prefence_height_cross_proof"), "fleet",
         "authenticated-prefence-height-cross-proof",
         "maintenance authenticated pre-fence proof",
     )
+    selection, selection_sha = sealed(
+        bundle.get("live_observation_selection"), "fleet", "live-observation-selection",
+        "maintenance live-observation selection",
+    )
+    ledger, ledger_sha = sealed(
+        bundle.get("quarantine_generation_ledger"), "fleet",
+        "quarantine-generation-ledger", "maintenance quarantine-generation ledger",
+    )
+    challenge_receipt, _challenge_sha = sealed(
+        bundle.get("network_quarantine_challenge"), "fleet",
+        "network-quarantine-challenge", "maintenance quarantine challenge receipt",
+    )
+    stability, _stability_sha = sealed(
+        bundle.get("quarantine_stability_proof"), "fleet",
+        "network-quarantine-stability-proof", "maintenance quarantine stability proof",
+    )
+
+    selection = exact_object(
+        selection,
+        {
+            "schema", "source_main_commit", "freeze_plan_sha256", "capture_id",
+            "observation_generation", "observation_generation_receipt",
+            "observation_generation_receipt_path",
+            "observation_generation_receipt_sha256", "drive_prefreeze_receipt_path",
+            "drive_prefreeze_receipt_sha256", "generation_created_at", "selected_at",
+            "max_selection_age_seconds", "labels", "nodes",
+        },
+        "maintenance live-observation selection",
+    )
+    generation = selection.get("observation_generation_receipt")
+    drive = generation.get("drive_prefreeze_receipt") if isinstance(generation, dict) else None
+    if not isinstance(generation, dict) or not isinstance(drive, dict):
+        fail("maintenance live-observation generation receipt differs")
+    if set(drive) != {"path", "value", "sha256"} or not isinstance(drive.get("value"), dict):
+        fail("maintenance live-observation Drive receipt wrapper differs")
+    if (
+        hashlib.sha256(canonical_json_bytes(generation)).hexdigest()
+        != selection.get("observation_generation_receipt_sha256")
+        or hashlib.sha256(canonical_json_bytes(drive["value"])).hexdigest()
+        != drive.get("sha256")
+        or selection.get("schema") != "arc.recovery.legacy-live-observation-selection.v1"
+        or (selection.get("source_main_commit"), selection.get("freeze_plan_sha256"),
+            selection.get("capture_id")) != (source_commit, freeze_sha256, capture_id)
+        or selection.get("observation_generation") != generation.get("observation_generation")
+        or selection.get("drive_prefreeze_receipt_sha256") != drive.get("sha256")
+        or selection.get("drive_prefreeze_receipt_path") != drive.get("path")
+        or selection.get("generation_created_at") != generation.get("created_at")
+        or selection.get("max_selection_age_seconds") != 300
+        or selection.get("labels") != ["diagnostic", "noncanonical", "nonreward"]
+    ):
+        fail("maintenance live-observation selection identity differs")
+    try:
+        created_at = datetime.datetime.strptime(
+            str(selection.get("generation_created_at")), "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+        selected_at = datetime.datetime.strptime(
+            str(selection.get("selected_at")), "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+    except ValueError:
+        fail("maintenance live-observation selection timestamp differs")
+    if not 0 <= (selected_at - created_at).total_seconds() <= 300:
+        fail("maintenance live-observation selection age differs")
+    selection_rows = selection.get("nodes")
+    if not isinstance(selection_rows, list) or [
+        row.get("node") for row in selection_rows if isinstance(row, dict)
+    ] != list(LOWER_NODE_ORDER):
+        fail("maintenance live-observation selection topology differs")
+    for raw_row in selection_rows:
+        row = exact_object(
+            raw_row, {"node", "created_at", "completed_at", "root_sha256", "receipt_sha256"},
+            "maintenance live-observation selection node",
+        )
+        try:
+            row_first = datetime.datetime.strptime(str(row.get("created_at")), "%Y-%m-%dT%H:%M:%S.%fZ")
+            row_last = datetime.datetime.strptime(str(row.get("completed_at")), "%Y-%m-%dT%H:%M:%S.%fZ")
+        except ValueError:
+            fail("maintenance live-observation selection node timestamp differs")
+        if row_first > row_last:
+            fail("maintenance live-observation selection node timestamps are reversed")
+        require_hash(row.get("root_sha256"), "maintenance live-observation root")
+        require_hash(row.get("receipt_sha256"), "maintenance live-observation receipt")
+
     authenticated = exact_object(
         authenticated,
         {
-            "schema",
-            "source_main_commit",
-            "freeze_plan_sha256",
-            "capture_id",
-            "legacy_public_height_receipt_sha256",
-            "challenge",
-            "started_at",
-            "completed_at",
-            "conservative_height_floor",
-            "nodes",
+            "schema", "source_main_commit", "freeze_plan_sha256", "capture_id",
+            "legacy_public_height_receipt_sha256", "challenge", "started_at",
+            "completed_at", "conservative_height_floor", "nodes",
         },
         "maintenance authenticated pre-fence fleet proof",
     )
+    expected_topology = [(node.lower(), host) for node, _address, host in PRODUCTION_FLEET]
+    authenticated_rows = authenticated.get("nodes")
     if (
         authenticated.get("schema") != AUTHENTICATED_HEIGHT_FLEET_SCHEMA
-        or authenticated.get("source_main_commit") != source_commit
-        or authenticated.get("freeze_plan_sha256") != freeze_sha256
-        or authenticated.get("capture_id") != capture_id
-        or authenticated.get("challenge") != challenge
-    ):
-        fail("maintenance authenticated pre-fence fleet proof identity differs")
-    require_hash(
-        authenticated.get("legacy_public_height_receipt_sha256"),
-        "maintenance public-height receipt root",
-    )
-    require_uint(
-        authenticated.get("conservative_height_floor"),
-        "maintenance conservative height floor",
-    )
-    if require_utc_seconds(authenticated.get("started_at"), "authenticated proof start") > require_utc_seconds(
-        authenticated.get("completed_at"), "authenticated proof completion"
-    ):
-        fail("maintenance authenticated proof timestamps are reversed")
-    authenticated_rows = authenticated.get("nodes")
-    expected_topology = [(name.lower(), host) for name, _address, host in PRODUCTION_FLEET]
-    if (
-        not isinstance(authenticated_rows, list)
-        or [(row.get("node"), row.get("host")) for row in authenticated_rows if isinstance(row, dict)]
+        or (authenticated.get("source_main_commit"), authenticated.get("freeze_plan_sha256"),
+            authenticated.get("capture_id"), authenticated.get("challenge"))
+        != (source_commit, freeze_sha256, capture_id, challenge)
+        or not isinstance(authenticated_rows, list)
+        or [(row.get("node"), row.get("host")) for row in authenticated_rows]
         != expected_topology
     ):
-        fail("maintenance authenticated proof topology differs")
-    for index, row in enumerate(authenticated_rows):
-        item = exact_object(
-            row,
-            {"node", "host", "proof", "proof_sha256"},
-            f"maintenance authenticated node {index}",
-        )
-        if not isinstance(item["proof"], dict):
-            fail("maintenance authenticated node proof is not an object")
-        proof_sha = require_hash(item["proof_sha256"], "maintenance authenticated node proof root")
-        if hashlib.sha256(canonical_json_bytes(item["proof"])).hexdigest() != proof_sha:
-            fail("maintenance authenticated node proof root is not reproducible")
+        fail("maintenance authenticated pre-fence fleet proof identity differs")
+    require_hash(authenticated.get("legacy_public_height_receipt_sha256"), "maintenance public height")
+    require_uint(authenticated.get("conservative_height_floor"), "maintenance height floor")
+    for row in authenticated_rows:
+        item = exact_object(row, {"node", "host", "proof", "proof_sha256"}, "maintenance authenticated node")
+        if not isinstance(item.get("proof"), dict) or hashlib.sha256(
+            canonical_json_bytes(item["proof"])
+        ).hexdigest() != require_hash(item.get("proof_sha256"), "maintenance authenticated node proof"):
+            fail("maintenance authenticated node proof is not reproducible")
 
-    challenge_receipt, _challenge_sha = sealed(
-        bundle.get("network_quarantine_challenge"),
-        "fleet",
-        "network-quarantine-challenge",
-        "maintenance quarantine challenge receipt",
-    )
     if challenge_receipt != {
         "schema": "arc.recovery.legacy-network-quarantine-challenge.v1",
         "freeze_plan_sha256": freeze_sha256,
@@ -1925,133 +1980,312 @@ def load_legacy_maintenance_evidence_bundle(
     }:
         fail("maintenance quarantine challenge receipt differs")
 
-    stability, _stability_sha = sealed(
-        bundle.get("quarantine_stability_proof"),
-        "fleet",
-        "network-quarantine-stability-proof",
-        "maintenance quarantine stability proof",
-    )
+    try:
+        ledger_state = quarantine_rounds.validate_generation_ledger(ledger)
+    except quarantine_rounds.QuarantineRoundError as error:
+        fail(f"maintenance quarantine-generation ledger differs: {error}")
+    if (
+        (ledger_state.get("freeze_plan_sha256"), ledger_state.get("capture_id"))
+        != (freeze_sha256, capture_id)
+        or (ledger_state.get("live_observation_selection_sha256"),
+            ledger_state.get("live_observation_generation"),
+            ledger_state.get("observation_generation_receipt_sha256"),
+            ledger_state.get("drive_prefreeze_receipt_sha256"))
+        != (selection_sha, selection.get("observation_generation"),
+            selection.get("observation_generation_receipt_sha256"),
+            selection.get("drive_prefreeze_receipt_sha256"))
+        or ledger.get("first_secured_at") != bundle.get("first_quarantine_started_at")
+        or ledger_state.get("all_nodes_secured_at") > stopped
+    ):
+        fail("maintenance quarantine-generation ledger identity/timeline differs")
+    transition_wrappers: dict[str, dict[str, Any]] = {}
+    projections: dict[str, dict[str, Any]] = {}
+    for round_wrapper in ledger.get("rounds", []):
+        for wrapper in round_wrapper["result"]["value"]["transitions"]:
+            transition = wrapper["value"]
+            node = transition["node"]
+            if node in transition_wrappers:
+                fail("maintenance generation ledger repeats a node transition")
+            transition_wrappers[node] = wrapper
+            try:
+                projections[node] = quarantine_rounds.validate_node_transition(transition)
+            except quarantine_rounds.QuarantineRoundError as error:
+                fail(f"maintenance {node} transition differs: {error}")
+            if projections[node].get("source_main_commit") != source_commit:
+                fail(f"maintenance {node} transition source commit differs")
+    if set(transition_wrappers) != set(LOWER_NODE_ORDER):
+        fail("maintenance generation-ledger transition partition differs")
+    active_topology = [
+        row for row in expected_topology
+        if projections[row[0]]["kind"] == quarantine_rounds.ACTIVE_TRANSITION_KIND
+    ]
+    active_roots = [
+        {"node": node, "sha256": transition_wrappers[node]["sha256"]}
+        for node, _host in active_topology
+    ]
     stability = exact_object(
         stability,
         {
-            "schema",
-            "source_main_commit",
-            "freeze_plan_sha256",
-            "capture_id",
-            "challenge",
-            "interval_seconds",
-            "sample_count",
-            "started_at",
-            "completed_at",
-            "monotonic_elapsed_ns",
-            "fleet_heads",
-            "nodes",
-            "global_absence_claimed",
+            "schema", "source_main_commit", "freeze_plan_sha256", "capture_id",
+            "challenge", "interval_seconds", "sample_count", "started_at",
+            "completed_at", "monotonic_elapsed_ns", "fleet_heads", "nodes",
+            "global_absence_claimed", "quarantine_generation_ledger_sha256",
+            "active_transition_sha256s",
         },
         "maintenance quarantine stability proof",
     )
+    elapsed = require_uint(stability.get("monotonic_elapsed_ns"), "maintenance stability elapsed")
     if (
         stability.get("schema") != "arc.recovery.legacy-network-quarantine-stability.v1"
-        or stability.get("source_main_commit") != source_commit
-        or stability.get("freeze_plan_sha256") != freeze_sha256
-        or stability.get("capture_id") != capture_id
-        or stability.get("challenge") != challenge
-        or stability.get("interval_seconds") != 120
-        or stability.get("sample_count") != 2
+        or (stability.get("source_main_commit"), stability.get("freeze_plan_sha256"),
+            stability.get("capture_id"), stability.get("challenge"))
+        != (source_commit, freeze_sha256, capture_id, challenge)
+        or stability.get("quarantine_generation_ledger_sha256") != ledger_sha
+        or stability.get("active_transition_sha256s") != active_roots
+        or stability.get("interval_seconds") != (120 if active_topology else 0)
+        or stability.get("sample_count") != (2 if active_topology else 0)
+        or (active_topology and elapsed < 120_000_000_000)
+        or (not active_topology and elapsed != 0)
         or stability.get("global_absence_claimed") is not False
-        or require_uint(stability.get("monotonic_elapsed_ns"), "maintenance stability elapsed")
-        < 120_000_000_000
     ):
         fail("maintenance quarantine stability proof differs")
-    stability_started = require_utc_seconds(stability.get("started_at"), "stability start")
-    stability_completed = require_utc_seconds(
-        stability.get("completed_at"), "stability completion"
-    )
-    if not first <= stability_started <= stability_completed <= stopped:
-        fail("maintenance quarantine stability timestamps are outside the quarantine/stop window")
     stability_rows = stability.get("nodes")
     stability_heads = stability.get("fleet_heads")
     if (
-        not isinstance(stability_rows, list)
-        or not isinstance(stability_heads, list)
-        or [(row.get("node"), row.get("host")) for row in stability_rows if isinstance(row, dict)]
-        != expected_topology
-        or [(row.get("node"), row.get("host")) for row in stability_heads if isinstance(row, dict)]
-        != expected_topology
+        not isinstance(stability_rows, list) or not isinstance(stability_heads, list)
+        or [(row.get("node"), row.get("host")) for row in stability_rows] != active_topology
+        or [(row.get("node"), row.get("host")) for row in stability_heads] != active_topology
     ):
         fail("maintenance quarantine stability topology differs")
+    for row, head_row, (node, host) in zip(stability_rows, stability_heads, active_topology):
+        item = exact_object(row, {"node", "host", "samples", "output_deny_packets"}, f"maintenance {node} stability row")
+        samples = item.get("samples")
+        if not isinstance(samples, list) or len(samples) != 2:
+            fail(f"maintenance {node} stability samples differ")
+        heads: list[dict[str, Any]] = []
+        counters: list[int] = []
+        writer: object = None
+        for index, raw_sample in enumerate(samples):
+            wrapper = exact_object(raw_sample, {"value", "sha256"}, f"maintenance {node} stability sample")
+            sample = wrapper.get("value")
+            if not isinstance(sample, dict) or hashlib.sha256(canonical_json_bytes(sample)).hexdigest() != require_hash(
+                wrapper.get("sha256"), f"maintenance {node} stability sample root"
+            ):
+                fail(f"maintenance {node} stability sample root differs")
+            if (
+                sample.get("schema") != "arc.recovery.legacy-network-quarantine-stability-sample.v1"
+                or (sample.get("capture_id"), sample.get("node"),
+                    sample.get("freeze_plan_sha256"), sample.get("challenge"),
+                    sample.get("sample_index"))
+                != (capture_id, node, freeze_sha256, challenge, index)
+                or sample.get("global_absence_claimed") is not False
+            ):
+                fail(f"maintenance {node} stability sample identity differs")
+            head = exact_object(
+                sample.get("head"),
+                {"height", "block_hash", "state_root", "response_sha256", "stable_attempt"},
+                f"maintenance {node} stability head",
+            )
+            projected = {
+                "height": require_uint(head.get("height"), f"maintenance {node} stability height"),
+                "block_hash": require_hash(head.get("block_hash"), f"maintenance {node} stability block"),
+                "state_root": require_hash(head.get("state_root"), f"maintenance {node} stability state"),
+            }
+            if projected["height"] < 1:
+                fail(f"maintenance {node} stability height is not positive")
+            response_roots = exact_object(head.get("response_sha256"), {"info_before", "latest", "exact", "info_after"}, f"maintenance {node} response roots")
+            for root in response_roots.values():
+                require_hash(root, f"maintenance {node} stability response")
+            if not 1 <= require_uint(head.get("stable_attempt"), f"maintenance {node} stability attempt") <= 10:
+                fail(f"maintenance {node} stability attempt differs")
+            heads.append(projected)
+            counters.append(require_uint(sample.get("output_deny_packets"), f"maintenance {node} deny counter"))
+            if writer is None:
+                writer = sample.get("writer")
+            elif sample.get("writer") != writer:
+                fail(f"maintenance {node} stability writer changed")
+        if (
+            heads[0] != heads[1]
+            or head_row != {"node": node, "host": host, "head": heads[0]}
+            or counters[1] < counters[0]
+            or item.get("output_deny_packets") != {"sample_0": counters[0], "sample_1": counters[1]}
+        ):
+            fail(f"maintenance {node} stability contract differs")
 
     rows = bundle.get("nodes")
     if not isinstance(rows, list) or len(rows) != len(PRODUCTION_FLEET):
         fail("legacy maintenance evidence bundle must contain six ordered nodes")
-    node_fields = {
-        "node",
-        "host",
-        "stopped_status",
-        "quarantine_status",
-        "post_proof_quarantine_status",
-        "external_quarantine_proof",
-        "public_cross_proof",
-        "persisted_head",
-    }
-    role_fields = (
-        ("stopped_status", "stopped-status", "arc.recovery.offline-stop-status.v1"),
-        ("quarantine_status", "quarantine-status", "arc.recovery.legacy-network-quarantine-status.v1"),
-        ("post_proof_quarantine_status", "post-proof-quarantine-status", "arc.recovery.legacy-network-quarantine-status.v1"),
-        ("external_quarantine_proof", "external-quarantine-proof", "arc.recovery.legacy-network-quarantine-external-proof.v1"),
-        ("public_cross_proof", "public-cross-proof", "arc.recovery.legacy-network-quarantine-public-cross-proof.v1"),
-        ("persisted_head", "persisted-head", "arc.recovery.persisted-legacy-head.v1"),
-    )
+
+    def validate_dag_and_anchor(persisted: dict[str, Any], node: str) -> None:
+        try:
+            quarantine_rounds.validate_legacy_dag_round(persisted.get("legacy_dag_round"), f"maintenance {node}")
+        except quarantine_rounds.QuarantineRoundError as error:
+            fail(f"maintenance {node} persisted DAG round differs: {error}")
+        head = exact_object(persisted.get("head"), {"height", "block_hash", "state_root"}, f"maintenance {node} persisted head")
+        height = require_uint(head.get("height"), f"maintenance {node} persisted height")
+        if height < 1:
+            fail(f"maintenance {node} persisted height is not positive")
+        require_hash(head.get("block_hash"), f"maintenance {node} persisted block")
+        require_hash(head.get("state_root"), f"maintenance {node} persisted state")
+        anchor = exact_object(
+            persisted.get("trusted_anchor_ancestry"),
+            {"anchor_height", "anchor_block_hash", "anchor_state_root", "classification", "inspection", "inspection_sha256"},
+            f"maintenance {node} trusted anchor",
+        )
+        inspection = anchor.get("inspection")
+        if (
+            anchor.get("anchor_height") != 137145
+            or anchor.get("anchor_block_hash") != "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90"
+            or anchor.get("anchor_state_root") != "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d"
+            or anchor.get("inspection_sha256") != hashlib.sha256(canonical_json_bytes(inspection)).hexdigest()
+        ):
+            fail(f"maintenance {node} trusted-anchor binding differs")
+        if height < anchor["anchor_height"]:
+            if anchor.get("classification") != "below_trusted_anchor" or inspection is not None:
+                fail(f"maintenance {node} below-anchor classification differs")
+        else:
+            inspected = exact_object(inspection, {"schema", "height", "block_hash", "state_root", "input_roots"}, f"maintenance {node} anchor inspection")
+            if inspected.get("schema") != "arc.recovery.legacy-block-inspection.v1" or inspected.get("height") != 137145:
+                fail(f"maintenance {node} anchor inspection differs")
+            observed_block = require_hash(inspected.get("block_hash"), f"maintenance {node} anchor block")
+            observed_state = require_hash(inspected.get("state_root"), f"maintenance {node} anchor state")
+            expected_class = "valid_anchor_descendant" if (
+                observed_block == anchor["anchor_block_hash"] and observed_state == anchor["anchor_state_root"]
+            ) else "conflicting_anchor"
+            if anchor.get("classification") != expected_class:
+                fail(f"maintenance {node} anchor classification differs")
+
     by_node: dict[str, dict[str, Any]] = {}
+    active_fields = {
+        "node", "host", "stopped_status", "network_quarantine_receipt",
+        "quarantine_status", "quarantine_monitor", "post_proof_quarantine_status",
+        "external_quarantine_proof", "public_cross_proof", "persisted_head",
+    }
+    stopped_fields = {"node", "host", "transition_kind", "transition_receipt", "current_status", "persisted_head"}
     for (upper_node, _address, host), raw_row in zip(PRODUCTION_FLEET, rows):
         node = upper_node.lower()
-        item = exact_object(raw_row, node_fields, "maintenance evidence node")
-        if (item.get("node"), item.get("host")) != (node, host):
-            fail("legacy maintenance evidence bundle topology differs")
-        normalized: dict[str, Any] = {"node": node, "host": host}
-        for field, role, schema in role_fields:
-            object_value, object_sha = sealed(
-                item.get(field), node, role, f"maintenance {node} {role}"
-            )
-            if (
-                object_value.get("schema") != schema
-                or object_value.get("capture_id") != capture_id
-                or object_value.get("node") != node
-                or object_value.get("freeze_plan_sha256") != freeze_sha256
+        projection = projections[node]
+        if projection["kind"] == quarantine_rounds.STOPPED_PRECOMMIT_TRANSITION_KIND:
+            item = exact_object(raw_row, stopped_fields, f"maintenance stopped node {node}")
+            if (item.get("node"), item.get("host"), item.get("transition_kind")) != (
+                node, host, quarantine_rounds.STOPPED_PRECOMMIT_TRANSITION_KIND
             ):
-                fail(f"maintenance {node} {role} identity differs")
-            normalized[field] = {"value": object_value, "sha256": object_sha}
-        if (
-            normalized["stopped_status"]["value"].get("stopped") is not True
-            or normalized["stopped_status"]["value"].get("restart_fenced") is not True
-            or normalized["quarantine_status"]["value"].get("active") is not True
-            or normalized["quarantine_status"]["value"].get("enabled") is not True
-            or normalized["post_proof_quarantine_status"]["value"].get("active") is not True
-            or normalized["post_proof_quarantine_status"]["value"].get("enabled") is not True
-            or normalized["external_quarantine_proof"]["value"].get("host") != host
-            or normalized["external_quarantine_proof"]["value"].get("challenge") != challenge
-            or normalized["external_quarantine_proof"]["value"].get("global_absence_claimed") is not False
-            or normalized["public_cross_proof"]["value"].get("challenge") != challenge
-            or normalized["public_cross_proof"]["value"].get("global_absence_claimed") is not False
-            or normalized["persisted_head"]["value"].get("source_main_commit") != source_commit
-            or normalized["persisted_head"]["value"].get("writer_stopped") is not True
-            or normalized["persisted_head"]["value"].get("restart_barrier_active") is not True
-            or normalized["persisted_head"]["value"].get("network_quarantine_active") is not True
-            or normalized["persisted_head"]["value"].get("global_absence_claimed") is not False
+                fail("legacy maintenance stopped node topology/kind differs")
+            transition, transition_sha = sealed(item.get("transition_receipt"), node, "persistently-stopped-transition", f"maintenance {node} stopped transition")
+            current, current_sha = sealed(item.get("current_status"), node, "stopped-current-status", f"maintenance {node} stopped current status")
+            persisted, persisted_sha = sealed(item.get("persisted_head"), node, "persisted-head", f"maintenance {node} stopped persisted head")
+            if item.get("transition_receipt") != transition_wrappers[node]:
+                fail(f"maintenance {node} stopped transition differs from the generation ledger")
+            try:
+                quarantine_rounds.validate_prior_fenced_status(current, transition=transition, transition_sha256=transition_sha)
+            except quarantine_rounds.QuarantineRoundError as error:
+                fail(f"maintenance {node} stopped current status differs: {error}")
+            if (
+                persisted.get("schema") != "arc.recovery.persisted-legacy-head-stopped-precommit.v2"
+                or (persisted.get("source_main_commit"), persisted.get("capture_id"),
+                    persisted.get("node"), persisted.get("host"),
+                    persisted.get("freeze_plan_sha256"))
+                != (source_commit, capture_id, node, host, freeze_sha256)
+                or persisted.get("source_pair_role") != "preauthorization-boundary"
+                or persisted.get("head") != projection.get("stable_head")
+                or transition.get("persisted_head") != {"value": persisted, "sha256": persisted_sha}
+            ):
+                fail(f"maintenance {node} stopped persisted-head binding differs")
+            validate_dag_and_anchor(persisted, node)
+            by_node[upper_node] = {
+                "node": node, "host": host,
+                "transition_kind": quarantine_rounds.STOPPED_PRECOMMIT_TRANSITION_KIND,
+                "transition_receipt": {"value": transition, "sha256": transition_sha},
+                "current_status": {"value": current, "sha256": current_sha},
+                "persisted_head": {"value": persisted, "sha256": persisted_sha},
+            }
+            continue
+
+        item = exact_object(raw_row, active_fields, f"maintenance active node {node}")
+        if (item.get("node"), item.get("host")) != (node, host):
+            fail("legacy maintenance active node topology differs")
+        normalized: dict[str, Any] = {"node": node, "host": host, "transition_kind": quarantine_rounds.ACTIVE_TRANSITION_KIND}
+        for field, role in (
+            ("stopped_status", "stopped-status"),
+            ("network_quarantine_receipt", "network-quarantine-receipt"),
+            ("quarantine_status", "quarantine-status"),
+            ("quarantine_monitor", "network-quarantine-monitor"),
+            ("post_proof_quarantine_status", "post-proof-quarantine-status"),
+            ("external_quarantine_proof", "external-quarantine-proof"),
+            ("public_cross_proof", "public-cross-proof"),
+            ("persisted_head", "persisted-head"),
         ):
-            fail(f"maintenance {node} stopped/persisted state differs")
+            inner, root = sealed(item.get(field), node, role, f"maintenance {node} {role}")
+            if (inner.get("capture_id"), inner.get("node"), inner.get("freeze_plan_sha256")) != (capture_id, node, freeze_sha256):
+                fail(f"maintenance {node} {role} identity differs")
+            normalized[field] = {"value": inner, "sha256": root}
+        stopped_status = normalized["stopped_status"]["value"]
+        network = normalized["network_quarantine_receipt"]
+        status = normalized["quarantine_status"]["value"]
+        monitor = normalized["quarantine_monitor"]["value"]
+        post_status = normalized["post_proof_quarantine_status"]["value"]
+        external = normalized["external_quarantine_proof"]["value"]
+        public_cross = normalized["public_cross_proof"]["value"]
+        persisted = normalized["persisted_head"]["value"]
+        if network != transition_wrappers[node]["value"].get("network_quarantine_receipt"):
+            fail(f"maintenance {node} network receipt differs from its transition")
+        if (
+            stopped_status.get("schema") != "arc.recovery.offline-stop-status.v1"
+            or stopped_status.get("stopped") is not True
+            or stopped_status.get("restart_fenced") is not True
+            or status.get("schema") != "arc.recovery.legacy-network-quarantine-status.v1"
+            or status.get("active") is not True or status.get("enabled") is not True
+            or status.get("receipt_sha256") != network["sha256"]
+            or post_status.get("schema") != "arc.recovery.legacy-network-quarantine-status.v1"
+            or post_status.get("active") is not True or post_status.get("enabled") is not True
+            or post_status.get("receipt_sha256") != network["sha256"]
+            or monitor.get("schema") != "arc.recovery.legacy-network-quarantine-monitor.v1"
+            or monitor.get("network_quarantine_receipt_sha256") != network["sha256"]
+            or monitor.get("incident_latched") is not False
+            or monitor.get("continuous_fail_closed") is not True
+            or monitor.get("automatic_unfence") is not False
+            or monitor.get("global_absence_claimed") is not False
+            or external.get("schema") != "arc.recovery.legacy-network-quarantine-external-proof.v1"
+            or external.get("host") != host or external.get("challenge") != challenge
+            or external.get("network_quarantine_receipt_sha256") != network["sha256"]
+            or external.get("before_status_sha256") != normalized["quarantine_status"]["sha256"]
+            or hashlib.sha256(canonical_json_bytes(external.get("after_status"))).hexdigest() != external.get("after_status_sha256")
+            or external.get("ssh_status_reproved") is not True
+            or external.get("global_absence_claimed") is not False
+            or public_cross.get("schema") != "arc.recovery.legacy-network-quarantine-public-cross-proof.v1"
+            or public_cross.get("challenge") != challenge
+            or public_cross.get("network_quarantine_receipt_sha256") != network["sha256"]
+            or hashlib.sha256(canonical_json_bytes(public_cross.get("quarantine_status"))).hexdigest() != public_cross.get("quarantine_status_sha256")
+            or public_cross.get("fenced_head_covers_public_info_after") is not True
+            or public_cross.get("public_latest_hash_matches") is not True
+            or public_cross.get("global_absence_claimed") is not False
+            or persisted.get("schema") not in {"arc.recovery.persisted-legacy-head.v3", "arc.recovery.persisted-legacy-head.v4"}
+            or persisted.get("source_main_commit") != source_commit
+            or persisted.get("source_pair_role") != "post-quarantine-final-export"
+            or persisted.get("selected_source_head") != persisted.get("head")
+            or persisted.get("writer_stopped") is not True
+            or persisted.get("restart_barrier_active") is not True
+            or persisted.get("network_quarantine_active") is not True
+            or persisted.get("global_absence_claimed") is not False
+        ):
+            fail(f"maintenance {node} retained active object policy differs")
+        require_hash(persisted.get("final_source_capture_sha256"), f"maintenance {node} final source capture")
+        require_hash(persisted.get("stop_after_round_receipt_sha256"), f"maintenance {node} stop-after-round receipt")
+        validate_dag_and_anchor(persisted, node)
+        persisted_head = persisted["head"]
+        transition_head = projection["stable_head"]
+        if persisted_head["height"] < transition_head["height"] or (
+            persisted_head["height"] == transition_head["height"] and persisted_head != transition_head
+        ):
+            fail(f"maintenance {node} persisted head precedes its transition")
         by_node[upper_node] = normalized
 
-    if bundle.get("object_inventory") != inventory_expected:
+    if bundle.get("object_inventory") != inventory:
         fail("legacy maintenance evidence bundle inventory differs from its sealed objects")
-    inventory_root = hashlib.sha256(
-        canonical_json_bytes(
-            {
-                "schema": "arc.recovery.legacy-maintenance-evidence-inventory.v1",
-                "objects": inventory_expected,
-            }
-        )
-    ).hexdigest()
+    inventory_root = hashlib.sha256(canonical_json_bytes({
+        "schema": "arc.recovery.legacy-maintenance-evidence-inventory.v1",
+        "objects": inventory,
+    })).hexdigest()
     if bundle.get("aggregate_root_sha256") != inventory_root:
         fail("legacy maintenance evidence aggregate root is not reproducible")
     return bundle, by_node, expected
@@ -2082,6 +2316,11 @@ def load_legacy_maintenance_boundary(
             "first_quarantine_started_at", "all_controlled_stopped_at", "created_at",
             "official_origin_scope", "legacy_public_height_receipt",
             "authenticated_prefence_height_cross_proof_sha256",
+            "legacy_live_observation_selection_sha256",
+            "legacy_live_observation_generation",
+            "observation_generation_receipt_sha256",
+            "drive_prefreeze_receipt_sha256",
+            "quarantine_generation_ledger_sha256",
             "legacy_maintenance_evidence_bundle_sha256",
             "network_quarantine_stability_proof_sha256", "network_quarantine_challenge",
             "tools", "nodes", "evidence_heights", "observed_cutoff_height",
@@ -2130,10 +2369,20 @@ def load_legacy_maintenance_boundary(
     require_utc_seconds(public_root.get("completed_at"), "legacy public-height completion")
     require_uint(public_root.get("observed_max_height"), "legacy public observed maximum")
     authenticated_root = evidence_bundle["authenticated_prefence_height_cross_proof"]["sha256"]
+    selection = evidence_bundle["live_observation_selection"]
+    ledger_root = evidence_bundle["quarantine_generation_ledger"]["sha256"]
     stability_root = evidence_bundle["quarantine_stability_proof"]["sha256"]
     if (
         boundary.get("legacy_maintenance_evidence_bundle_sha256") != evidence_bundle_sha256
         or boundary.get("authenticated_prefence_height_cross_proof_sha256") != authenticated_root
+        or boundary.get("legacy_live_observation_selection_sha256") != selection["sha256"]
+        or boundary.get("legacy_live_observation_generation")
+        != selection["value"].get("observation_generation")
+        or boundary.get("observation_generation_receipt_sha256")
+        != selection["value"].get("observation_generation_receipt_sha256")
+        or boundary.get("drive_prefreeze_receipt_sha256")
+        != selection["value"].get("drive_prefreeze_receipt_sha256")
+        or boundary.get("quarantine_generation_ledger_sha256") != ledger_root
         or boundary.get("network_quarantine_stability_proof_sha256") != stability_root
         or boundary.get("network_quarantine_challenge") != evidence_bundle.get("challenge")
     ):
@@ -2185,12 +2434,16 @@ def load_legacy_maintenance_boundary(
     auth_rows = evidence_bundle["authenticated_prefence_height_cross_proof"]["value"]["nodes"]
     if not isinstance(rows, list) or len(rows) != len(PRODUCTION_FLEET):
         fail("legacy maintenance boundary must contain six ordered nodes")
-    node_fields = {
+    active_node_fields = {
         "node", "host", "origin", "public_observation",
         "authenticated_prefence_proof_sha256", "network_quarantine_receipt_sha256",
         "quarantine_status_sha256", "post_proof_quarantine_status_sha256",
         "external_quarantine_proof_sha256", "public_cross_proof_sha256",
         "initial_post_quarantine_head", "post_quarantine_head", "final_persisted_head",
+    }
+    stopped_node_fields = {
+        "node", "host", "origin", "transition_kind",
+        "transition_receipt_sha256", "final_persisted_head",
     }
 
     def observation(raw: object, label: str) -> dict[str, Any]:
@@ -2203,11 +2456,35 @@ def load_legacy_maintenance_boundary(
         return wrapper
 
     for index, (origin, row, bundle_row, auth_row) in enumerate(zip(origins, rows, bundle_rows, auth_rows)):
-        item = exact_object(row, node_fields, f"legacy maintenance boundary node {index}")
+        is_stopped = bundle_row.get("transition_kind") == quarantine_rounds.STOPPED_PRECOMMIT_TRANSITION_KIND
+        item = exact_object(
+            row,
+            stopped_node_fields if is_stopped else active_node_fields,
+            f"legacy maintenance boundary node {index}",
+        )
         if (item.get("node"), item.get("host"), item.get("origin")) != (
             origin["node"], origin["host"], origin["origin"]
         ):
             fail("legacy maintenance boundary topology differs")
+        if is_stopped:
+            if (
+                item.get("transition_kind")
+                != quarantine_rounds.STOPPED_PRECOMMIT_TRANSITION_KIND
+                or item.get("transition_receipt_sha256")
+                != bundle_row["transition_receipt"]["sha256"]
+            ):
+                fail(f"legacy maintenance {origin['node']} stopped transition root differs")
+            final = observation(
+                item.get("final_persisted_head"),
+                f"legacy maintenance {origin['node']} final_persisted_head",
+            )
+            persisted = bundle_row["persisted_head"]
+            if (
+                final["evidence_sha256"] != persisted["sha256"]
+                or final["tuple"] != persisted["value"].get("head")
+            ):
+                fail(f"legacy maintenance {origin['node']} stopped persisted root differs")
+            continue
         for field in (
             "authenticated_prefence_proof_sha256", "network_quarantine_receipt_sha256",
             "quarantine_status_sha256", "post_proof_quarantine_status_sha256",
@@ -2291,6 +2568,11 @@ def load_offline_stop_evidence(
             "legacy_maintenance_boundary",
             "legacy_maintenance_boundary_sha256",
             "legacy_maintenance_evidence_bundle_sha256",
+            "legacy_live_observation_selection_sha256",
+            "legacy_live_observation_generation",
+            "observation_generation_receipt_sha256",
+            "drive_prefreeze_receipt_sha256",
+            "quarantine_generation_ledger_sha256",
             "nodes",
         },
         "offline-stop evidence",
@@ -2317,6 +2599,26 @@ def load_offline_stop_evidence(
         or evidence.get("legacy_maintenance_evidence_bundle_sha256") != evidence_bundle_sha256
         or evidence.get("legacy_maintenance_evidence_bundle_sha256")
         != maintenance_boundary["legacy_maintenance_evidence_bundle_sha256"]
+        or evidence.get("legacy_live_observation_selection_sha256")
+        != evidence_bundle["live_observation_selection"]["sha256"]
+        or evidence.get("legacy_live_observation_generation")
+        != evidence_bundle["live_observation_selection"]["value"].get(
+            "observation_generation"
+        )
+        or evidence.get("observation_generation_receipt_sha256")
+        != evidence_bundle["live_observation_selection"]["value"].get(
+            "observation_generation_receipt_sha256"
+        )
+        or evidence.get("drive_prefreeze_receipt_sha256")
+        != evidence_bundle["live_observation_selection"]["value"].get(
+            "drive_prefreeze_receipt_sha256"
+        )
+        or evidence.get("quarantine_generation_ledger_sha256")
+        != evidence_bundle["quarantine_generation_ledger"]["sha256"]
+        or evidence.get("legacy_live_observation_selection_sha256")
+        != maintenance_boundary["legacy_live_observation_selection_sha256"]
+        or evidence.get("quarantine_generation_ledger_sha256")
+        != maintenance_boundary["quarantine_generation_ledger_sha256"]
     ):
         fail("offline-stop evidence maintenance bundle/boundary binding differs")
     cross = exact_object(
@@ -2343,7 +2645,7 @@ def load_offline_stop_evidence(
     plan_rows = plan_value["nodes"]
     by_node: dict[str, dict[str, Any]] = {}
     completion_roots: set[str] = set()
-    node_fields = {
+    active_node_fields = {
         "node",
         "host",
         "validator_address",
@@ -2353,14 +2655,49 @@ def load_offline_stop_evidence(
         "stopped_status_sha256",
         "stopped_status_argv_sha256",
     }
+    stopped_node_fields = {
+        "node", "host", "transition_kind", "transition_receipt_sha256",
+        "current_status_sha256", "persisted_head_sha256",
+    }
     for (upper_node, _new_address, host), plan_node, row in zip(PRODUCTION_FLEET, plan_rows, rows):
         expected_node = upper_node.lower()
         legacy_address = require_hash(
             plan_node.get("validator_address"), f"{expected_node} legacy validator address"
         )
+        bundle_node = evidence_bundle_nodes[upper_node]
+        if bundle_node.get("transition_kind") == quarantine_rounds.STOPPED_PRECOMMIT_TRANSITION_KIND:
+            item = exact_object(
+                row, stopped_node_fields, "offline-stop persistently-stopped node evidence"
+            )
+            if (
+                plan_node.get("name") != expected_node
+                or plan_node.get("host") != host
+                or (item.get("node"), item.get("host"), item.get("transition_kind"))
+                != (expected_node, host, quarantine_rounds.STOPPED_PRECOMMIT_TRANSITION_KIND)
+                or item.get("transition_receipt_sha256")
+                != bundle_node["transition_receipt"]["sha256"]
+                or item.get("current_status_sha256")
+                != bundle_node["current_status"]["sha256"]
+                or item.get("persisted_head_sha256")
+                != bundle_node["persisted_head"]["sha256"]
+            ):
+                fail(f"offline-stop evidence {expected_node} stopped transition binding differs")
+            for field in (
+                "transition_receipt_sha256", "current_status_sha256",
+                "persisted_head_sha256",
+            ):
+                require_hash(item.get(field), f"{expected_node} {field}")
+            by_node[upper_node] = {
+                "transition_kind": quarantine_rounds.STOPPED_PRECOMMIT_TRANSITION_KIND,
+                "transition": bundle_node["transition_receipt"]["value"],
+                "transition_sha256": bundle_node["transition_receipt"]["sha256"],
+                "historical_status": bundle_node["current_status"]["value"],
+                "row": item,
+            }
+            continue
         item = exact_object(
             row,
-            node_fields,
+            active_node_fields,
             "offline-stop node evidence",
         )
         if (
@@ -2402,13 +2739,16 @@ def load_offline_stop_evidence(
             fail(f"offline-stop evidence {expected_node} argv hash is not reproducible")
         if hashlib.sha256(canonical_json_bytes(status)).hexdigest() != status_sha:
             fail(f"offline-stop evidence {expected_node} status hash is not reproducible")
-        bundle_status = evidence_bundle_nodes[upper_node]["stopped_status"]
+        bundle_status = bundle_node["stopped_status"]
         if bundle_status["sha256"] != status_sha or bundle_status["value"] != status:
             fail(f"offline-stop evidence {expected_node} status differs from the evidence bundle")
         if complete_sha in completion_roots:
             fail("offline-stop evidence repeats a validator completion root")
         completion_roots.add(complete_sha)
-        by_node[upper_node] = {"argv": argv, "status": status, "row": item}
+        by_node[upper_node] = {
+            "transition_kind": quarantine_rounds.ACTIVE_TRANSITION_KIND,
+            "argv": argv, "status": status, "row": item,
+        }
     return evidence, by_node, expected
 
 
@@ -2432,6 +2772,35 @@ def validate_fresh_stopped_status(
         fail(f"fresh {node} stopped-status hash differs from the authenticated evidence")
 
 
+def validate_fresh_persistently_stopped_status(
+    output: str,
+    *,
+    transition: dict[str, Any],
+    transition_sha256: str,
+    historical_status: dict[str, Any],
+    node: str,
+) -> None:
+    try:
+        raw = output.encode("ascii")
+        value = json.loads(raw)
+    except (UnicodeEncodeError, json.JSONDecodeError):
+        fail(f"fresh {node} persistently-stopped status is not canonical JSON")
+    if not isinstance(value, dict) or raw != canonical_json_bytes(value):
+        fail(f"fresh {node} persistently-stopped status is not canonical JSON")
+    try:
+        fresh_observed = quarantine_rounds.validate_prior_fenced_status(
+            value, transition=transition, transition_sha256=transition_sha256
+        )
+        historical_observed = quarantine_rounds.validate_prior_fenced_status(
+            historical_status, transition=transition,
+            transition_sha256=transition_sha256,
+        )
+    except quarantine_rounds.QuarantineRoundError as error:
+        fail(f"fresh {node} persistently-stopped status differs: {error}")
+    if fresh_observed < historical_observed:
+        fail(f"fresh {node} persistently-stopped status predates sealed evidence")
+
+
 def exact_control_line(output: str, label: str) -> str:
     if "\r" in output or not output.endswith("\n") or "\n" in output[:-1]:
         fail(f"{label} did not return exactly one newline-terminated control line")
@@ -2453,7 +2822,7 @@ case "$op" in
     test -f /proc/self/fd/9
     actual_helper=$(sha256sum /proc/self/fd/9 | cut -d' ' -f1)
     test "$actual_helper" = "$expected_helper"
-    test "$1" = stopped-status
+    case "$1" in stopped-status|quarantine-round-stopped-status) ;; *) exit 1 ;; esac
     /proc/self/fd/9 "$@"
     ;;
   probe)
@@ -3030,6 +3399,37 @@ def _install_verified(args: argparse.Namespace, proof: Any) -> None:
         # host.  A stale or merely self-hashed local JSON document cannot pass.
         def prove_node_stopped(node: str, host: str) -> None:
             node_evidence = stop_evidence[node]
+            if (
+                node_evidence["transition_kind"]
+                == quarantine_rounds.STOPPED_PRECOMMIT_TRANSITION_KIND
+            ):
+                fresh_status = run_ssh(
+                    pinned_ssh,
+                    ssh_sha256,
+                    transport_root,
+                    pinned_known_hosts,
+                    pinned_identity,
+                    identity_sha256,
+                    host,
+                    (
+                        "stopped-status",
+                        evidence["remote_helper_path"],
+                        evidence["remote_helper_sha256"],
+                        "quarantine-round-stopped-status",
+                        evidence["capture_id"],
+                        node.lower(),
+                        evidence["freeze_plan_sha256"],
+                        node_evidence["transition_sha256"],
+                    ),
+                )
+                validate_fresh_persistently_stopped_status(
+                    fresh_status,
+                    transition=node_evidence["transition"],
+                    transition_sha256=node_evidence["transition_sha256"],
+                    historical_status=node_evidence["historical_status"],
+                    node=node.lower(),
+                )
+                return
             fresh_status = run_ssh(
                 pinned_ssh,
                 ssh_sha256,

--- a/scripts/release/validate-cutover-derived-assets.py
+++ b/scripts/release/validate-cutover-derived-assets.py
@@ -177,6 +177,7 @@ def validate_descriptor(
         descriptor,
         {
             "approved_validators",
+            "canonical_source",
             "canonical_inspection",
             "capture_id",
             "checkpoint_certificate",
@@ -300,9 +301,12 @@ def validate_descriptor(
         inspection["format_version"] != 1
         or inspection["chain_id"] != "0x415243"
         or inspection["protocol_version"] != "3.0.0"
-        or inspection["source_height"] != 137145
-        or inspection["transition_height"] != 137146
-        or inspection["community_rewards_v1_activation_height"] != 137146
+        or inspection["source_height"] < cutover.TRUSTED_CHECKPOINT_MIN_HEIGHT
+        or inspection["transition_height"] != inspection["source_height"] + 1
+        or inspection["community_rewards_v1_activation_height"]
+        != cutover.COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT
+        or inspection["community_rewards_v1_activation_height"]
+        > inspection["transition_height"]
         or inspection["recovery_epoch"] != 1
         or inspection["validator_set_id"] != 1
         or inspection["validator_count"] != 6
@@ -323,6 +327,51 @@ def validate_descriptor(
         fail("canonical inspection network genesis must not be zero")
     require_int(inspection["source_consensus_round"], "source consensus round")
     require_int(inspection["created_at_unix_ms"], "checkpoint creation time", minimum=1)
+    canonical_source = require_keys(
+        descriptor["canonical_source"],
+        {
+            "node",
+            "source_height",
+            "source_block_hash",
+            "source_state_root",
+            "source_consensus_round",
+            "snapshot_sha256",
+            "wal_sha256",
+            "persisted_head_sha256",
+            "legacy_dag_round_inspection_sha256",
+            "legacy_dag_wal_namespace_sha256",
+        },
+        "canonical captured source",
+    )
+    if canonical_source["node"] not in {
+        name for name, _host in cutover.recovery.PRODUCTION_FLEET
+    }:
+        fail("canonical captured source node is not in the production fleet")
+    for key in (
+        "source_block_hash",
+        "source_state_root",
+        "snapshot_sha256",
+        "wal_sha256",
+        "persisted_head_sha256",
+        "legacy_dag_round_inspection_sha256",
+        "legacy_dag_wal_namespace_sha256",
+    ):
+        require_hash(canonical_source[key], f"canonical captured source {key}")
+    require_int(canonical_source["source_height"], "canonical captured source height")
+    require_int(
+        canonical_source["source_consensus_round"],
+        "canonical captured source consensus round",
+    )
+    if any(
+        canonical_source[field] != inspection[field]
+        for field in (
+            "source_height",
+            "source_block_hash",
+            "source_state_root",
+            "source_consensus_round",
+        )
+    ):
+        fail("canonical captured source differs from checkpoint inspection")
 
 
 def validate_boundary(
@@ -360,12 +409,26 @@ def validate_boundary(
         "threat_model",
     }
     require_keys(boundary, expected_fields, "legacy maintenance boundary")
+    source_height = descriptor["canonical_inspection"]["source_height"]
+    observed_cutoff = require_int(
+        boundary["observed_cutoff_height"], "legacy observed cutoff height"
+    )
+    continuity_margin = require_int(
+        boundary["continuity_safety_margin"],
+        "legacy continuity safety margin",
+        minimum=1,
+    )
+    legacy_public_max = require_int(
+        boundary["legacy_public_max_height"], "legacy public maximum height"
+    )
     if (
         boundary["schema"] != "arc.recovery.legacy-maintenance-boundary.v1"
         or boundary["source_main_commit"] != commit
         or boundary["freeze_plan_sha256"] != descriptor["freeze_plan_sha256"]
         or boundary["capture_id"] != descriptor["capture_id"]
-        or boundary["legacy_public_max_height"] != 137145
+        or observed_cutoff < source_height
+        or continuity_margin != cutover.recovery.LEGACY_CONTINUITY_SAFETY_MARGIN
+        or legacy_public_max != observed_cutoff + continuity_margin
         or boundary["global_absence_claimed"] is not False
     ):
         fail("legacy maintenance boundary identity differs")
@@ -384,6 +447,32 @@ def validate_boundary(
             cutover.exact_utc(boundary[key], f"legacy maintenance boundary {key}")
         except cutover.CutoverAssetError as error:
             fail(str(error))
+
+    nodes = boundary["nodes"]
+    if not isinstance(nodes, list) or len(nodes) != len(cutover.recovery.PRODUCTION_FLEET):
+        fail("legacy maintenance boundary does not contain the exact six-node fleet")
+    canonical_source = descriptor["canonical_source"]
+    source_node = next(
+        (row for row in nodes if row.get("node") == canonical_source["node"]),
+        None,
+    )
+    source_head = (
+        source_node.get("final_persisted_head", {}).get("tuple", {})
+        if isinstance(source_node, dict)
+        else {}
+    )
+    identity = descriptor["canonical_inspection"]
+    if (
+        not isinstance(source_node, dict)
+        or source_node.get("final_persisted_head", {}).get("evidence_sha256")
+        != canonical_source["persisted_head_sha256"]
+        or source_head.get("height") != identity["source_height"]
+        or str(source_head.get("block_hash", "")).removeprefix("0x")
+        != identity["source_block_hash"].removeprefix("0x")
+        or str(source_head.get("state_root", "")).removeprefix("0x")
+        != identity["source_state_root"].removeprefix("0x")
+    ):
+        fail("checkpoint source tuple differs from its selected captured head")
 
 
 def validate_policy(
@@ -415,7 +504,10 @@ def validate_policy(
         "global_legacy_absence_claimed",
         "legacy_admission_cutoff_utc",
         "legacy_exit_clean_claimed",
+        "legacy_continuity_safety_margin",
         "legacy_maintenance_boundary_sha256",
+        "legacy_observed_cutoff_height",
+        "legacy_public_max_height",
         "legacy_restart_allowed",
         "legacy_validators",
         "legacy_worker_rpc",
@@ -460,6 +552,12 @@ def validate_policy(
         != boundary["all_controlled_stopped_at"]
         or policy["legacy_admission_cutoff_utc"]
         != boundary["all_controlled_stopped_at"]
+        or policy["legacy_observed_cutoff_height"]
+        != boundary["observed_cutoff_height"]
+        or policy["legacy_continuity_safety_margin"]
+        != boundary["continuity_safety_margin"]
+        or policy["legacy_public_max_height"]
+        != boundary["legacy_public_max_height"]
     ):
         fail("cutover policy provenance/hash/time binding differs")
     projected = {

--- a/tests/release/documentation_contract_test.sh
+++ b/tests/release/documentation_contract_test.sh
@@ -674,6 +674,17 @@ hardened_canary_and_vault_commands_match_current_parsers() {
             'signing-key backup runbook omits its encrypted-at-rest staging boundary' \
             || return 1
     done
+    for literal in \
+        'commands below assume that `HOME` is protected by FileVault' \
+        'FileVault-disabled operator host' \
+        'dedicated encrypted APFS sparsebundle boundary' \
+        '`HOME`, `TMPDIR`, and' \
+        '`RUNNER_TEMP`'
+    do
+        require_literal "$CANARY_RUNBOOK" "$literal" \
+            'macOS canary runbook omits its encrypted-at-rest boundary' \
+            || return 1
+    done
     help="$(python3 "$CANARY_HELPER" plan --help)" || return 1
     for option in \
         --raw-actions-zip --model --expected-commit --expected-run-id \
@@ -940,6 +951,8 @@ required_embedded_python = {
         '"$reference_snapshot_size" "$reference_snapshot_sha256" <<\'PY\'',
     "final macOS artifact handoff builder":
         '"$pretag_run_attempt" <<\'PY\'',
+    "native macOS encrypted mount verifier":
+        '"$(/usr/bin/id -u)" <<\'PY\'',
     "native macOS handoff extractor":
         '"$ARC_MACOS_PROTECTED_MAIN_SHA" <<\'PY\'',
     "historical macOS canary root verifier":
@@ -1219,9 +1232,19 @@ require(
     "ARC_MACOS_PROTECTED_CHECKOUT='<absolute protected-main checkout on the canary Mac>'",
     'case "$ARC_MACOS_PROTECTED_CHECKOUT" in /*)',
     "ARC_MACOS_OLD_CANARY_SHA='c5ca31acecd0a48dd49c9236040dda442abe29a8'",
-    'ARC_MACOS_FINAL_INPUT_ROOT="$HOME/.arc-pretag-community-canary-input-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"',
-    'ARC_MACOS_OLD_CANARY_ROOT="$HOME/.arc-pretag-community-canary"',
-    'ARC_MACOS_FINAL_CANARY_ROOT="$HOME/.arc-pretag-community-canary-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"',
+    "ARC_MACOS_SECURE_IMAGE='<absolute pre-provisioned encrypted APFS sparsebundle path>'",
+    "ARC_MACOS_SECURE_HOME='<absolute mounted APFS canary home path>'",
+    'arc_require_macos_secure_canary_mount() {',
+    'image.get("image-encrypted") is not True',
+    'image.get("image-type") != "sparse bundle disk image"',
+    'disk.get("FilesystemType") != "apfs"',
+    'disk.get("DeviceNode") != mounts[0].get("dev-entry")',
+    'ARC_MACOS_FINAL_INPUT_ROOT="$ARC_MACOS_SECURE_HOME/.arc-pretag-community-canary-input-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"',
+    'ARC_MACOS_OLD_CANARY_ROOT="$ARC_MACOS_USER_HOME/.arc-pretag-community-canary"',
+    'ARC_MACOS_FINAL_CANARY_ROOT="$ARC_MACOS_SECURE_HOME/.arc-pretag-community-canary-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"',
+    'ARC_MACOS_PRIVATE_TMP="$ARC_MACOS_SECURE_HOME/.arc-pretag-community-canary-tmp-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"',
+    'HOME="$ARC_MACOS_SECURE_HOME"', 'TMPDIR="$ARC_MACOS_PRIVATE_TMP"',
+    'RUNNER_TEMP="$ARC_MACOS_PRIVATE_TMP"',
     'macos_final_handoff_guest="/var/tmp/arc-macos-final-canary-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"',
     '"$ARC_OPERATOR_LIMA_INSTANCE:$macos_final_handoff_guest/headless-macos-arm64-actions.zip"',
     '"schema", "repository", "commit", "run_id", "run_attempt"',
@@ -1231,19 +1254,28 @@ require(
     '"$macos_canary_helper" cleanup --root "$ARC_MACOS_OLD_CANARY_ROOT"',
     'test "$old_canary_status_rc" -eq 3',
     '/usr/sbin/lsof -nP -a -iTCP:19944 -sTCP:LISTEN',
-    '"$macos_canary_helper" plan',
-    '"$macos_canary_helper" install',
-    '"$macos_canary_helper" start --root "$ARC_MACOS_FINAL_CANARY_ROOT"',
-    '"$macos_canary_helper" status --root "$ARC_MACOS_FINAL_CANARY_ROOT"',
-    '"$macos_canary_helper" accept --root "$ARC_MACOS_FINAL_CANARY_ROOT"',
+    'macos_final_model="$ARC_MACOS_FINAL_INPUT_ROOT/llama-2-7b-chat.Q4_K_M.gguf"',
+    '/bin/cp -p "$macos_old_model" "$macos_final_model"',
+    'macos_final_model_destination="$ARC_MACOS_FINAL_CANARY_ROOT/model/llama-2-7b-chat.Q4_K_M.gguf"',
+    '/bin/mv "$macos_final_model" "$macos_final_model_destination"',
+    'macos_final_model="$macos_final_model_destination"',
+    'arc_macos_secure_canary plan',
+    'arc_macos_secure_canary install',
+    'arc_macos_secure_canary start --root "$ARC_MACOS_FINAL_CANARY_ROOT"',
+    'arc_macos_secure_canary status --root "$ARC_MACOS_FINAL_CANARY_ROOT"',
+    'arc_macos_secure_canary accept --root "$ARC_MACOS_FINAL_CANARY_ROOT"',
     'macos_canary_acceptance_source="$ARC_MACOS_FINAL_CANARY_ROOT/evidence/ACCEPTED.json"',
     '"artifact_digest": artifact_digest', '"archive_sha256": archive_sha256',
     'final macOS acceptance does not bind the exact root/artifact tuple',
-    'ARC_CANARY_TRANSFER_PARENT="$HOME/.arc-recovery-transfer"',
+    'ARC_CANARY_TRANSFER_PARENT="$ARC_MACOS_SECURE_HOME/.arc-recovery-transfer"',
     'ARC_CANARY_TRANSFER_ROOT="$ARC_CANARY_TRANSFER_PARENT/v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"',
     'lima_canary_drop_root=/var/tmp/arc-macos-canary-import-v0.8.0',
     '"$ARC_LIMACTL" copy --backend=scp',
 )
+if macos_transfer[1].count('--model "$macos_final_model"') != 2:
+    raise SystemExit("final canary does not use its encrypted model input exactly twice")
+if '--model "$macos_old_model"' in macos_transfer[1]:
+    raise SystemExit("final canary still consumes the model directly from unencrypted real HOME")
 require_order(
     macos_transfer[1],
     '"$ARC_LIMACTL" copy --backend=scp',
@@ -1251,11 +1283,13 @@ require_order(
     '"$macos_canary_helper" stop --root "$ARC_MACOS_OLD_CANARY_ROOT"',
     '"$macos_canary_helper" cleanup --root "$ARC_MACOS_OLD_CANARY_ROOT"',
     'test "$old_canary_status_rc" -eq 3',
-    '"$macos_canary_helper" plan',
-    '"$macos_canary_helper" install',
-    '"$macos_canary_helper" start --root "$ARC_MACOS_FINAL_CANARY_ROOT"',
-    '"$macos_canary_helper" status --root "$ARC_MACOS_FINAL_CANARY_ROOT"',
-    '"$macos_canary_helper" accept --root "$ARC_MACOS_FINAL_CANARY_ROOT"',
+    '/bin/cp -p "$macos_old_model" "$macos_final_model"',
+    'arc_macos_secure_canary plan',
+    '/bin/mv "$macos_final_model" "$macos_final_model_destination"',
+    'arc_macos_secure_canary install',
+    'arc_macos_secure_canary start --root "$ARC_MACOS_FINAL_CANARY_ROOT"',
+    'arc_macos_secure_canary status --root "$ARC_MACOS_FINAL_CANARY_ROOT"',
+    'arc_macos_secure_canary accept --root "$ARC_MACOS_FINAL_CANARY_ROOT"',
     'macos_canary_acceptance_source="$ARC_MACOS_FINAL_CANARY_ROOT/evidence/ACCEPTED.json"',
     'lima_canary_drop_root=/var/tmp/arc-macos-canary-import-v0.8.0',
 )
@@ -1828,15 +1862,15 @@ PY
     for literal in \
         'first of two **native macOS shell** blocks' \
         'Lima root shell open and untouched' \
-        '$HOME/.arc-recovery-transfer/v0.8.0-<protected-main-sha>' \
+        '$ARC_MACOS_SECURE_HOME/.arc-recovery-transfer/v0.8.0-<protected-main-sha>' \
         '# BEGIN LIMA FINAL MACOS CANARY HANDOFF STAGE' \
         'arc.recovery.macos-final-canary-handoff.v1' \
         '# BEGIN NATIVE MACOS CANARY TRANSFER' \
         "ARC_MACOS_PROTECTED_CHECKOUT='<absolute protected-main checkout on the canary Mac>'" \
         "ARC_MACOS_OLD_CANARY_SHA='c5ca31acecd0a48dd49c9236040dda442abe29a8'" \
-        'ARC_MACOS_FINAL_CANARY_ROOT="$HOME/.arc-pretag-community-canary-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"' \
+        'ARC_MACOS_FINAL_CANARY_ROOT="$ARC_MACOS_SECURE_HOME/.arc-pretag-community-canary-v0.8.0-$ARC_MACOS_PROTECTED_MAIN_SHA"' \
         'macos_canary_acceptance_source="$ARC_MACOS_FINAL_CANARY_ROOT/evidence/ACCEPTED.json"' \
-        'ARC_CANARY_TRANSFER_PARENT="$HOME/.arc-recovery-transfer"' \
+        'ARC_CANARY_TRANSFER_PARENT="$ARC_MACOS_SECURE_HOME/.arc-recovery-transfer"' \
         '"$ARC_LIMACTL" copy --backend=scp' \
         '# BEGIN LIMA ROOT SHELL REVALIDATION AND MACOS RECEIPT IMPORT' \
         ': "${operator_checkout:?the original Lima root shell was lost}"' \

--- a/tests/release/documentation_contract_test.sh
+++ b/tests/release/documentation_contract_test.sh
@@ -15,6 +15,7 @@ ROLLOUT="$REPO_ROOT/docs/VALIDATOR-FLEET-ROLLOUT.md"
 RECOVERY_README="$REPO_ROOT/scripts/recovery/README.md"
 OWNER_EMERGENCY_HELPER="$REPO_ROOT/scripts/recovery/owner-emergency-recovery.py"
 OWNER_EMERGENCY_SCHEMA="$REPO_ROOT/scripts/recovery/owner-emergency-recovery.schema.json"
+OWNER_EMERGENCY_WORKFLOW="$REPO_ROOT/.github/workflows/owner-emergency-recovery-approval.yml"
 ARCHIVE_TOOL="$REPO_ROOT/scripts/recovery/archive-fleet-to-drive.sh"
 DRIVE_PREFREEZE_GATE="$REPO_ROOT/scripts/recovery/verify-drive-prefreeze.sh"
 DRIVE_IDENTITY_HELPER="$REPO_ROOT/scripts/recovery/drive-account-identity.py"
@@ -936,7 +937,7 @@ required_embedded_python = {
     "legacy validator-set installer":
         '"$legacy_source" "$legacy_validator_set" <<\'PY\'',
     "reference snapshot/WAL verifier":
-        '"$reference_pair" "$reference_block_height" <<\'PY\'',
+        '"$reference_snapshot_size" "$reference_snapshot_sha256" <<\'PY\'',
     "final macOS artifact handoff builder":
         '"$pretag_run_attempt" <<\'PY\'',
     "native macOS handoff extractor":
@@ -1157,17 +1158,20 @@ require(
     '--receipt-output /secure/operator/VALIDATOR-KEY-INSTALL-RECEIPT.json',
 )
 require(
-    export[1], "reference_pair=/secure/operator/reference-pair",
-    '"state.snapshot.lz4"', "1_160_246",
-    "ecb4e39d45e6711cffcd78183851587e4deb37ad63163f541ef6c1f821a4ce47",
-    '"state.wal"', "83_385_625",
-    "3820e112af1684567f0336abe73ae9aafc4228d0e02a5fccb1ff32f64dfed44c",
-    '"latest.json"',
-    "0c9bcafd99375de7e3167c271350279c4d267dd9cf91de37aa830a2b817f80af",
-    '"snapshot-info.json"',
-    "98f327fb9c4405cd0f6e7c31052d571a024738df5bf6987ad78d9b1ba5856b49",
-    'read_locked(root_fd, "SHA256SUMS", 324)',
-    "reference_source_consensus_round=9774808", "reference_block_height=137145",
+    export[1], "canonical_source_preselection=/secure/operator/canonical-source-preselection.json",
+    "scripts/recovery/build-production-manifest.py select-source",
+    '--legacy-maintenance-evidence-bundle "$legacy_maintenance_evidence_bundle"',
+    '--legacy-maintenance-boundary "$legacy_maintenance_boundary"',
+    '--output "$canonical_source_preselection"',
+    "reference_source_consensus_round=\"$(/usr/bin/jq -er",
+    "reference_block_height=\"$(/usr/bin/jq -er",
+    'test "$transition_height" -eq "$((reference_block_height + 1))"',
+    'test "$reference_block_height" -le "$observed_cutoff_height"',
+    'test "$reopening_floor_height" -eq "$((observed_cutoff_height + 128))"',
+    'reference_pair="$(/usr/bin/mktemp -d',
+    '"$scp_tool" -q -B -i "$ssh_identity"',
+    '"state.wal": (int(sys.argv[2]), sys.argv[3])',
+    '"state.snapshot.lz4": (int(sys.argv[4]), sys.argv[5])',
     "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90",
     "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d",
     '"$arc_node_linux" recovery export',
@@ -1178,6 +1182,9 @@ require(
 )
 require_order(
     export[1],
+    "scripts/recovery/build-production-manifest.py select-source",
+    'reference_pair="$(/usr/bin/mktemp -d',
+    '"$scp_tool" -q -B -i "$ssh_identity"',
     'candidate_attempt_root="$(',
     '"$arc_node_linux" recovery export',
     'chmod 0400 "$candidate_attempt"',
@@ -1300,6 +1307,7 @@ require(
     '"$ARC_RECOVERY_PYTHON_PATH" -I scripts/recovery/build-production-manifest.py prearchive',
     'production_stage_root=/secure/operator/production-input-stage-v0.8.0',
     '--stage-root "$production_stage_root"',
+    '--canonical-source-preselection "$canonical_source_preselection"',
     '--source-snapshot "$reference_pair/state.snapshot.lz4"',
     '--source-wal "$reference_pair/state.wal"',
     'prearchive_existing=0', 'elif [ "$prearchive_existing" = 3 ]; then',
@@ -2042,6 +2050,7 @@ PY
         'scripts/recovery/archive-fleet-to-drive.sh seal-freeze-plan' \
         $'scripts/recovery/archive-fleet-to-drive.sh capture \\' \
         'scripts/release/restore-validator-vault.py install' \
+        'scripts/recovery/build-production-manifest.py select-source' \
         $'"$arc_node_linux" recovery export \\' \
         $'offline_signer "$signing_binary" recovery sign \\' \
         $'scripts/recovery/build-production-manifest.py prearchive \\' \
@@ -2189,21 +2198,29 @@ owner_emergency_recovery_receipt_replaces_ceremonial_approval() {
         'The six validator identities are not six independent human operators.' \
         '`owner_emergency_recovery`' \
         '`owner-emergency-recovery-approval.yml`' \
-        '`arc.recovery.owner-emergency-recovery.v2`' \
+        '`arc.recovery.owner-emergency-recovery.v3`' \
         'locally is not authorization.' \
         'root-owned mode-0700 attempt directory' \
         'input file becomes root-owned mode 0400.' \
-        'H=137145/H+1=137146' \
+        '`H/T=H+1/hash/state/final-round/C/F/boundary/checkpoint`' \
         'epoch/set 1/1' \
         'does not claim six-human' \
         'owner_recovery_gh_token="$(' \
         'arc_scoped_gh "$owner_recovery_gh_token" workflow run' \
         '-f expected_main_sha="$protected_main_sha"' \
         '-f checkpoint_manifest_hash="$checkpoint_manifest_hash"' \
+        '-f source_height="$reference_block_height"' \
+        '-f transition_height="$transition_height"' \
+        '-f source_block_hash="$source_block_hash"' \
+        '-f source_state_root="$source_state_root"' \
+        '-f source_consensus_round="$reference_source_consensus_round"' \
+        '-f observed_cutoff_height="$observed_cutoff_height"' \
+        '-f reopening_floor_height="$reopening_floor_height"' \
+        '-f legacy_maintenance_boundary_sha256="$legacy_maintenance_boundary_sha256"' \
         '-f validator_public_keys_sha256="$validator_public_keys_sha256"' \
         '-f nyc_public_key="$owner_recovery_nyc_public_key"' \
         '-f sgp_public_key="$owner_recovery_sgp_public_key"' \
-        '-f confirmation="AUTHORIZE ARC OWNER EMERGENCY RECOVERY $protected_main_sha"' \
+        '-f confirmation="AUTHORIZE ARC OWNER EMERGENCY RECOVERY $protected_main_sha H=$reference_block_height T=$transition_height HASH=$source_block_hash STATE=$source_state_root ROUND=$reference_source_consensus_round C=$observed_cutoff_height F=$reopening_floor_height BOUNDARY=$legacy_maintenance_boundary_sha256 CHECKPOINT=$checkpoint_manifest_hash"' \
         'GH_TOKEN="$owner_recovery_gh_token" scripts/release/wait-workflow-attempt.sh' \
         'actions/runs/$owner_recovery_run_id/attempts/$owner_recovery_run_attempt/jobs?per_page=100' \
         'arc-owner-emergency-recovery-$protected_main_sha-$owner_recovery_run_id-attempt-$owner_recovery_run_attempt' \
@@ -2222,6 +2239,14 @@ owner_emergency_recovery_receipt_replaces_ceremonial_approval() {
         '--artifact-digest "$owner_recovery_artifact_digest"' \
         '--source-main-sha "$protected_main_sha"' \
         '--checkpoint-manifest-hash "$checkpoint_manifest_hash"' \
+        '--source-height "$reference_block_height"' \
+        '--transition-height "$transition_height"' \
+        '--source-block-hash "$source_block_hash"' \
+        '--source-state-root "$source_state_root"' \
+        '--source-consensus-round "$reference_source_consensus_round"' \
+        '--observed-cutoff-height "$observed_cutoff_height"' \
+        '--reopening-floor-height "$reopening_floor_height"' \
+        '--legacy-maintenance-boundary-sha256 "$legacy_maintenance_boundary_sha256"' \
         '--validator-public-keys "$validator_public_keys"' \
         '--validator-public-keys-sha256 "$validator_public_keys_sha256"' \
         '--output "$owner_recovery_receipt"' \
@@ -2238,12 +2263,12 @@ owner_emergency_recovery_receipt_replaces_ceremonial_approval() {
         'Checkpoint signing has a separate, durable authorization boundary.' \
         '`owner-emergency-recovery-approval.yml`' \
         '`owner-emergency-recovery.py verify-github-artifact`' \
-        '`arc.recovery.owner-emergency-recovery.v2`' \
+        '`arc.recovery.owner-emergency-recovery.v3`' \
         'actor and triggering actor are both the pinned owner' \
         'exact-attempt jobs' \
         'text is not authorization.' \
         'GitHub-authenticated `owner_emergency_recovery` decision' \
-        'H=137145/H+1=137146' \
+        'capture-derived `H`, `T=H+1`' \
         'does not claim six-human approval'
     do
         require_literal "$PRODUCTION_RECOVERY_AUDIT" "$required" \
@@ -2271,6 +2296,64 @@ owner_emergency_recovery_receipt_replaces_ceremonial_approval() {
         printf 'local or ceremonial checkpoint approval remains in the recovery guide\n'
         return 1
     fi
+    python3 - "$RECOVERY_README" "$OWNER_EMERGENCY_WORKFLOW" <<'PY' || return 1
+import pathlib
+import re
+import sys
+
+readme = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+workflow = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+expected_inputs = [
+    "expected_main_sha", "checkpoint_manifest_hash", "source_height",
+    "transition_height", "source_block_hash", "source_state_root",
+    "source_consensus_round", "observed_cutoff_height", "reopening_floor_height",
+    "legacy_maintenance_boundary_sha256", "validator_public_keys_sha256",
+    "nyc_public_key", "lax_public_key", "ams_public_key", "lhr_public_key",
+    "nrt_public_key", "sgp_public_key", "confirmation",
+]
+inputs_body = workflow.split("    inputs:\n", 1)[1].split("\npermissions:\n", 1)[0]
+workflow_inputs = re.findall(r"(?m)^      ([a-z0-9_]+):$", inputs_body)
+assert workflow_inputs == expected_inputs, workflow_inputs
+expected_title = (
+    "run-name: Owner recovery approval for ${{ inputs.expected_main_sha }} "
+    "H=${{ inputs.source_height }} at ${{ inputs.checkpoint_manifest_hash }}"
+)
+assert workflow.count(expected_title) == 1
+
+dispatch = readme.split(
+    'arc_scoped_gh "$owner_recovery_gh_token" workflow run', 1
+)[1].split("owner_recovery_new_runs='[]'", 1)[0]
+dispatch_inputs = re.findall(r"(?m)^  -f ([a-z0-9_]+)=", dispatch)
+assert dispatch_inputs == expected_inputs, dispatch_inputs
+confirmation = (
+    '-f confirmation="AUTHORIZE ARC OWNER EMERGENCY RECOVERY '
+    '$protected_main_sha H=$reference_block_height T=$transition_height '
+    'HASH=$source_block_hash STATE=$source_state_root '
+    'ROUND=$reference_source_consensus_round C=$observed_cutoff_height '
+    'F=$reopening_floor_height BOUNDARY=$legacy_maintenance_boundary_sha256 '
+    'CHECKPOINT=$checkpoint_manifest_hash"'
+)
+assert dispatch.count(confirmation) == 1
+
+verification = readme.split(
+    '"$owner_recovery_helper" verify-github-artifact', 1
+)[1].split('for owner_recovery_output in', 1)[0]
+expected_verify_args = [
+    "workflow-json", "run-json", "jobs-json", "artifact-json", "artifact-zip",
+    "run-id", "run-attempt", "artifact-id", "artifact-digest", "source-main-sha",
+    "checkpoint-manifest-hash", "source-height", "transition-height",
+    "source-block-hash", "source-state-root", "source-consensus-round",
+    "observed-cutoff-height", "reopening-floor-height",
+    "legacy-maintenance-boundary-sha256", "validator-public-keys",
+    "validator-public-keys-sha256", "output", "max-age-seconds",
+]
+assert re.findall(r"(?m)^    --([a-z0-9-]+)(?: |$)", verification) == expected_verify_args
+
+signing = readme.split("signing_keys=(", 1)[1].split("\n)", 1)[0]
+assert re.findall(r"keys/([A-Z]+)\.validator-key\.json", signing) == [
+    "NYC", "LAX", "AMS", "LHR", "NRT"
+]
+PY
     test -f "$OWNER_EMERGENCY_HELPER" && test -f "$OWNER_EMERGENCY_SCHEMA" || {
         printf 'documented owner emergency helper or schema is missing\n'
         return 1

--- a/tests/release/helpers/mock-curl.sh
+++ b/tests/release/helpers/mock-curl.sh
@@ -152,7 +152,10 @@ render_asset() {
             printf '#!/usr/bin/env bash\n# release v%s\nexit 0\n' "$version" >"$destination"
             chmod +x "$destination"
             ;;
-        arc-cutover-policy.json|arc-legacy-maintenance-boundary.json|arc-recovery-checkpoint-descriptor.json)
+        arc-cutover-policy.json)
+            printf '{"canonical_boundary_height":137145,"legacy_observed_cutoff_height":137145,"legacy_continuity_safety_margin":128,"legacy_public_max_height":137273,"fixture_version":"%s"}\n' "$version" >"$destination"
+            ;;
+        arc-legacy-maintenance-boundary.json|arc-recovery-checkpoint-descriptor.json)
             printf '{"asset":"%s","fixture_version":"%s"}\n' "$asset" "$version" >"$destination"
             ;;
         *)
@@ -231,7 +234,7 @@ case "$url" in
         retirement_mode="${MOCK_V3_RETIREMENT_MODE:-ok}"
         [ "$retirement_mode" != offline ] || { [ "$retirement_host" != 149.28.153.31 ] || exit 7; }
         retirement_active=true
-        retirement_height=137146
+        retirement_height=137274
         retirement_manifest="0x$(printf '%064d' 1)"
         retirement_network_genesis="0x$(printf '%064d' 3)"
         retirement_node_version=0.8.0
@@ -239,7 +242,7 @@ case "$url" in
         case "$retirement_mode" in
             ok|offline|legacy-listener) ;;
             recovery-inactive) retirement_active=false ;;
-            low-height) retirement_height=137145 ;;
+            low-height) retirement_height=137273 ;;
             split-manifest)
                 [ "$retirement_host" != 149.28.153.31 ] \
                     || retirement_manifest="0x$(printf '%064d' 4)" ;;
@@ -251,7 +254,7 @@ case "$url" in
                     || retirement_validator=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ;;
             old-node) retirement_node_version=0.7.11 ;;
             duplicate-field) ;;
-            leading-zero-height) retirement_height=0137146 ;;
+            leading-zero-height) retirement_height=0137274 ;;
             huge-height) retirement_height=9999999999999999999 ;;
             exponent-height) retirement_height=1e9 ;;
             *) exit 22 ;;

--- a/tests/release/make_cutover_release_fixture.py
+++ b/tests/release/make_cutover_release_fixture.py
@@ -134,17 +134,33 @@ def main() -> int:
         {
             "chain_id": "0x415243",
             "genesis_hash": "0x" + "1" * 64,
-            "source_height": 137145,
-            "transition_height": 137146,
             "recovery_epoch": 1,
             "validator_set_id": 1,
-            "legacy_observed_cutoff_height": 137017,
-            "legacy_public_max_height": 137145,
+            "legacy_observed_cutoff_height": chain["source_height"],
+            "legacy_public_max_height": chain["source_height"] + 128,
         }
     )
-    boundary["observed_cutoff_height"] = 137017
-    boundary["legacy_public_max_height"] = 137145
-    boundary["evidence_heights"][-1]["height"] = 137017
+    source = chain["canonical_source"]
+    source_node = next(
+        row for row in boundary["nodes"] if row["node"] == source["node"]
+    )
+    source_node["final_persisted_head"] = {
+        "tuple": {
+            "height": chain["source_height"],
+            "block_hash": chain["source_block_hash"],
+            "state_root": chain["source_state_root"],
+        },
+        "evidence_sha256": source["persisted_head_sha256"],
+    }
+    source_evidence = next(
+        row
+        for row in boundary["evidence_heights"]
+        if row["node"] == source["node"] and row["label"] == "final_persisted_head"
+    )
+    source_evidence["height"] = chain["source_height"]
+    source_evidence["evidence_sha256"] = source["persisted_head_sha256"]
+    boundary["observed_cutoff_height"] = chain["source_height"]
+    boundary["legacy_public_max_height"] = chain["source_height"] + 128
 
     checkpoint = b"ARCCHKPT deterministic release fixture v1\n"
     checkpoint_sha256 = hashlib.sha256(checkpoint).hexdigest()
@@ -242,6 +258,8 @@ def main() -> int:
         linux[window]["artifact"]["files"]["arc-node-linux-x86_64"] = binary_sha256
         linux[window]["artifact"]["files"]["genesis.toml"] = genesis_sha256
     value["provenance"]["validator_key_receipt_chain"]["genesis_sha256"] = genesis_sha256
+    chain["trusted_anchor"]["inspector_binary_sha256"] = binary_sha256
+    chain["trusted_anchor"]["genesis_sha256"] = genesis_sha256
     value["provenance"]["validator_key_receipt_chain"][
         "offline_stop_evidence_sha256"
     ] = artifacts["offline_stop_evidence"]["sha256"]

--- a/tests/release/recovery_archive_contract_test.sh
+++ b/tests/release/recovery_archive_contract_test.sh
@@ -3615,7 +3615,8 @@ body=t[t.index("persisted_head()") : t.index("stage_input()")]
 ordered=[
     'verify_stop_journal_semantics', 'verify_legacy_restart_fence',
     'verify_legacy_network_quarantine', 'verify_capture_source',
-    'exec 8<"$binary"', '/proc/self/fd/8 recovery export',
+    'exec 8<"$binary"', '/proc/self/fd/8 recovery inspect-legacy-dag-round',
+    '/proc/self/fd/8 recovery export',
     '--validator-set-id 1 --allow-unbound-legacy-wal',
     '[ "$(hash_file /proc/self/fd/14)" = "$wal_before" ]',
 ]
@@ -3623,8 +3624,8 @@ positions=[body.index(item) for item in ordered]
 assert positions==sorted(positions)
 assert body.index('verify_capture_source "$capture_root"', positions[-1]) > positions[-1]
 for exact in (
-    'arc.recovery.persisted-legacy-head.v1',
-    'arc.recovery.persisted-legacy-head.v2',
+    'arc.recovery.persisted-legacy-head.v3',
+    'arc.recovery.persisted-legacy-head.v4',
     'source_main_commit', 'inspector_binary_sha256',
     'network_quarantine_receipt_sha256', 'capture_source_sha256',
     'source_data_index_sha256', 'state_wal_size', 'snapshot_size',
@@ -3634,6 +3635,10 @@ for exact in (
     'details.st_nlink!=1', 'stat.S_IMODE(details.st_mode)!=0o400',
     'openat/O_NOFOLLOW FD identity differs', 'export-source/state.wal',
     'candidate.inspect.json', 'inspect_summary_sha256', 'wal_boundary_sha256',
+    'legacy-dag-round-inspection.json', 'legacy_dag_round',
+    'VERIFIED_STOPPED_DAG_CURSOR', 'namespace_sha256',
+    'trusted-anchor-inspection.json', 'trusted_anchor_ancestry',
+    'valid_anchor_descendant', 'below_trusted_anchor',
     '"allow_unbound_legacy_wal":True,"read_only":True',
     'os.dup(13)', 'os.dup(12)', 'export summary exact key set differs',
     'snapshot pathname changed after held-FD open',
@@ -3713,7 +3718,7 @@ persisted_head_partial_truncations_are_resumable() {
     python3 - <<'PY'
 import json
 canonical=lambda value:(json.dumps(value,sort_keys=True,separators=(",",":"))+"\n").encode()
-payload=canonical({"schema":"arc.recovery.persisted-legacy-head.v1",
+payload=canonical({"schema":"arc.recovery.persisted-legacy-head.v3",
                    "completed_at":"2026-08-31T12:34:56Z","head":{"height":99}})
 completed=payload.index(b"completed_at")
 for cut in (0,1,completed-1,completed+3,completed+30,len(payload)-1):

--- a/tests/release/recovery_archive_contract_test.sh
+++ b/tests/release/recovery_archive_contract_test.sh
@@ -4017,6 +4017,45 @@ assert 'arc.recovery.shared-input-source.v1' in t
 PY
 )
 
+canonical_source_preselection_is_an_exact_shared_input() {
+    python3 - "$ORCHESTRATOR" <<'PY' || return 1
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+required_extractions = (
+    'canonical_source_preselection="$(manifest_field "$manifest" artifacts.canonical_source_preselection.path)"',
+    'canonical_source_preselection_sha="$(manifest_field "$manifest" artifacts.canonical_source_preselection.sha256)"',
+    'canonical_source_preselection_sidecar="$(manifest_field "$manifest" artifacts.canonical_source_preselection_sidecar.path)"',
+    'canonical_source_preselection_sidecar_sha="$(manifest_field "$manifest" artifacts.canonical_source_preselection_sidecar.sha256)"',
+)
+required_registrations = (
+    'register_shared_input "$canonical_source_preselection" "$canonical_source_preselection_sha" \\\n+        "$shared_root" canonical-source-preselection.json',
+    'register_shared_input "$canonical_source_preselection_sidecar" \\\n+        "$canonical_source_preselection_sidecar_sha" "$shared_root" \\\n+        canonical-source-preselection.json.sha256',
+)
+for fragment in (*required_extractions, *required_registrations):
+    assert text.count(fragment) == 1, fragment
+
+extraction_start = text.index(required_extractions[0])
+evidence = text.index(
+    'maintenance_evidence_bundle_sidecar="$(manifest_field "$manifest" artifacts.legacy_maintenance_evidence_bundle_sidecar.path)"'
+)
+boundary = text.index(
+    'maintenance_boundary="$(manifest_field "$manifest" artifacts.legacy_maintenance_boundary.path)"'
+)
+assert evidence < extraction_start < boundary
+
+registration_start = text.index(required_registrations[0])
+evidence_registration = text.index(
+    'register_shared_input "$maintenance_evidence_bundle_sidecar"'
+)
+boundary_registration = text.index(
+    'register_shared_input "$maintenance_boundary" "$maintenance_boundary_sha"'
+)
+assert evidence_registration < registration_start < boundary_registration
+PY
+}
+
 archive_scripts_are_lintable() {
     [ -x "$REPO_ROOT/scripts/recovery/normalize-legacy-wal.py" ] &&
         bash -n "$NODE_HELPER" "$ORCHESTRATOR" &&
@@ -4096,5 +4135,6 @@ run_test 'persisted-head truncated partials resume at every completed-at offset'
 run_test 'stateful fake nft/systemctl quarantine crash matrix is fail-closed' stateful_fake_nft_systemctl_quarantine_contract
 run_test 'quarantine retirement is exact, one-way, read-only on status, and crash-resumable' quarantine_retirement_is_one_way_resumable_and_exact
 run_test 'shared archive inputs stream without work-root materialization' shared_inputs_stream_without_work_root_materialization
+run_test 'canonical source preselection is an exact shared input' canonical_source_preselection_is_an_exact_shared_input
 run_test 'archive scripts pass syntax, lint, and embedded runtime suites' archive_scripts_are_lintable
 finish_tests

--- a/tests/release/recovery_archive_contract_test.sh
+++ b/tests/release/recovery_archive_contract_test.sh
@@ -4030,8 +4030,8 @@ required_extractions = (
     'canonical_source_preselection_sidecar_sha="$(manifest_field "$manifest" artifacts.canonical_source_preselection_sidecar.sha256)"',
 )
 required_registrations = (
-    'register_shared_input "$canonical_source_preselection" "$canonical_source_preselection_sha" \\\n+        "$shared_root" canonical-source-preselection.json',
-    'register_shared_input "$canonical_source_preselection_sidecar" \\\n+        "$canonical_source_preselection_sidecar_sha" "$shared_root" \\\n+        canonical-source-preselection.json.sha256',
+    'register_shared_input "$canonical_source_preselection" "$canonical_source_preselection_sha" \\\n        "$shared_root" canonical-source-preselection.json',
+    'register_shared_input "$canonical_source_preselection_sidecar" \\\n        "$canonical_source_preselection_sidecar_sha" "$shared_root" \\\n        canonical-source-preselection.json.sha256',
 )
 for fragment in (*required_extractions, *required_registrations):
     assert text.count(fragment) == 1, fragment

--- a/tests/release/release_assembly_test.sh
+++ b/tests/release/release_assembly_test.sh
@@ -227,7 +227,7 @@ assert set(descriptor) == {
     "approved_validators", "canonical_inspection", "capture_id", "checkpoint_file",
     "checkpoint_certificate", "freeze_plan_sha256", "inspector_binary_sha256",
     "recovery_manifest_sha256", "release_commit", "release_tag", "repository",
-    "schema_version", "verified_quorum",
+    "schema_version", "verified_quorum", "canonical_source",
 }
 
 assert descriptor["schema_version"] == "arc-recovery-checkpoint-descriptor/v1"
@@ -252,12 +252,30 @@ assert identity["format_version"] == 1
 assert identity["chain_id"] == "0x415243"
 assert re.fullmatch(r"[0-9a-f]{64}", identity["payload_hash"])
 assert identity["community_rewards_v1_activation_height"] == 137146
-assert identity["source_height"] == 137145
-assert identity["transition_height"] == 137146
+assert identity["source_height"] >= 137145
+assert identity["transition_height"] == identity["source_height"] + 1
 assert identity["recovery_epoch"] == 1
 assert identity["validator_set_id"] == 1
 assert identity["validator_count"] == 6
 assert identity["protocol_version"] == "3.0.0"
+canonical_source = descriptor["canonical_source"]
+assert set(canonical_source) == {
+    "node", "source_height", "source_block_hash", "source_state_root",
+    "source_consensus_round", "snapshot_sha256", "wal_sha256",
+    "persisted_head_sha256", "legacy_dag_round_inspection_sha256",
+    "legacy_dag_wal_namespace_sha256",
+}
+assert canonical_source["node"] in {"nyc", "lax", "ams", "lhr", "nrt", "sgp"}
+for field in (
+    "source_height", "source_block_hash", "source_state_root", "source_consensus_round"
+):
+    assert canonical_source[field] == identity[field]
+for field in (
+    "source_block_hash", "source_state_root", "snapshot_sha256", "wal_sha256",
+    "persisted_head_sha256", "legacy_dag_round_inspection_sha256",
+    "legacy_dag_wal_namespace_sha256",
+):
+    assert re.fullmatch(r"[0-9a-f]{64}", canonical_source[field])
 certificate = descriptor["checkpoint_certificate"]
 assert set(certificate) == {"signatures", "signing_hash", "validators"}
 assert re.fullmatch(r"[0-9a-f]{64}", certificate["signing_hash"])
@@ -292,8 +310,11 @@ assert policy["release_tag"] == "v0.8.0"
 assert policy["release_commit"] == "9" * 40
 assert policy["recovery_checkpoint_descriptor_sha256"] == hashlib.sha256(descriptor_raw).hexdigest()
 assert policy["recovery_checkpoint_file_sha256"] == descriptor["checkpoint_file"]["sha256"]
-assert policy["canonical_boundary_height"] == identity["source_height"] == 137145
-assert policy["required_post_cutover_min_height"] == identity["transition_height"] == 137146
+assert policy["canonical_boundary_height"] == identity["source_height"]
+assert policy["required_post_cutover_min_height"] == identity["transition_height"]
+assert policy["legacy_observed_cutoff_height"] >= identity["source_height"]
+assert policy["legacy_continuity_safety_margin"] == 128
+assert policy["legacy_public_max_height"] == policy["legacy_observed_cutoff_height"] + 128
 assert policy["required_recovery_epoch"] == identity["recovery_epoch"] == 1
 assert policy["required_validator_set_id"] == identity["validator_set_id"] == 1
 assert policy["required_validator_count"] == identity["validator_count"] == 6

--- a/tests/release/static_contract_test.sh
+++ b/tests/release/static_contract_test.sh
@@ -2974,14 +2974,18 @@ macos_pretag_community_canary_is_exact_private_and_fail_closed() {
 owner_emergency_recovery_authorization_is_durable_and_exact() {
     local required
     for required in \
-        'RECEIPT_SCHEMA = "arc.recovery.owner-emergency-recovery.v2"' \
+        'RECEIPT_SCHEMA = "arc.recovery.owner-emergency-recovery.v3"' \
         'REPOSITORY = "FerrumVir/arc-chain"' \
         'WORKFLOW_PATH = ".github/workflows/owner-emergency-recovery-approval.yml"' \
         'AUTHORIZATION_KIND = "owner_emergency_recovery"' \
         'authenticated by an exact GitHub' \
         'REASON_CODE = "legacy_fleet_divergence_history_preserving_v080_cutover"' \
-        'SOURCE_HEIGHT = 137_145' \
-        'TRANSITION_HEIGHT = 137_146' \
+        'TRUSTED_ANCHOR_HEIGHT = 137_145' \
+        'COMMUNITY_REWARDS_V1_ACTIVATION_HEIGHT = 137_146' \
+        'CONTINUITY_SAFETY_MARGIN = 128' \
+        'authorization transition height must equal source height plus one' \
+        'authorization source height exceeds the maximum observed legacy cutoff' \
+        'authorization reopening floor must equal observed cutoff plus 128' \
         'RECOVERY_EPOCH = 1' \
         'VALIDATOR_SET_ID = 1' \
         'SIGNATURES_REQUIRED = 5' \
@@ -3006,13 +3010,19 @@ owner_emergency_recovery_authorization_is_durable_and_exact() {
         }
     done
     for required in \
-        '"const": "arc.recovery.owner-emergency-recovery.v2"' \
+        '"const": "arc.recovery.owner-emergency-recovery.v3"' \
         '"const": ".github/workflows/owner-emergency-recovery-approval.yml"' \
         '"const": "workflow_dispatch"' \
         '"const": "owner_emergency_recovery"' \
         '"const": "legacy_fleet_divergence_history_preserving_v080_cutover"' \
-        '"const": 137145' \
-        '"const": 137146' \
+        '"minimum": 137145' \
+        '"minimum": 137146' \
+        '"source_block_hash"' \
+        '"source_state_root"' \
+        '"source_consensus_round"' \
+        '"observed_cutoff_height"' \
+        '"reopening_floor_height"' \
+        '"legacy_maintenance_boundary_sha256"' \
         '"const": 5' \
         '"const": 40000000' \
         '"const": "FerrumVir"' \
@@ -3033,6 +3043,15 @@ owner_emergency_recovery_authorization_is_durable_and_exact() {
         'actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT' \
         '.actor.login == "FerrumVir" and .actor.id == 111036403' \
         '.triggering_actor.login == "FerrumVir"' \
+        'SOURCE_HEIGHT: ${{ inputs.source_height }}' \
+        'TRANSITION_HEIGHT: ${{ inputs.transition_height }}' \
+        'SOURCE_BLOCK_HASH: ${{ inputs.source_block_hash }}' \
+        'SOURCE_STATE_ROOT: ${{ inputs.source_state_root }}' \
+        'SOURCE_CONSENSUS_ROUND: ${{ inputs.source_consensus_round }}' \
+        'OBSERVED_CUTOFF_HEIGHT: ${{ inputs.observed_cutoff_height }}' \
+        'REOPENING_FLOOR_HEIGHT: ${{ inputs.reopening_floor_height }}' \
+        'LEGACY_MAINTENANCE_BOUNDARY_SHA256: ${{ inputs.legacy_maintenance_boundary_sha256 }}' \
+        'HASH=$SOURCE_BLOCK_HASH STATE=$SOURCE_STATE_ROOT ROUND=$SOURCE_CONSENSUS_ROUND' \
         'overwrite: false' \
         'retention-days: 90'
     do

--- a/tests/release/test_cutover_handoff_commit.py
+++ b/tests/release/test_cutover_handoff_commit.py
@@ -56,7 +56,7 @@ def replace_exact(value, old: str, new: str):
         return {key: replace_exact(item, old, new) for key, item in value.items()}
     if isinstance(value, list):
         return [replace_exact(item, old, new) for item in value]
-    return value.replace(old, new) if isinstance(value, str) else value
+    return new if value == old else value
 
 
 class GitFixture(unittest.TestCase):
@@ -194,6 +194,14 @@ class CutoverHandoffCreationCommandTests(GitFixture):
         manifest = json.loads(manifest_path.read_bytes())
         original_source_commit = manifest["provenance"]["source_main_commit"]
         manifest = replace_exact(manifest, original_source_commit, self.main_commit)
+        for group in manifest["provenance"]["protected_pretag_artifact"]["groups"]:
+            for window in ("initial", "final"):
+                live = group[window]["live"]
+                live["artifact_name"] = (
+                    f"arc-pretag-{group['kind']}-{group['platform']}-"
+                    f"{self.main_commit}-{live['run_id']}-{live['run_attempt']}-"
+                    f"{group[window]['artifact']['archive_sha256']}"
+                )
         boundary["source_main_commit"] = self.main_commit
         boundary_payload = canonical(boundary)
         boundary_path.chmod(0o600)

--- a/tests/release/test_postrelease_public_truth.py
+++ b/tests/release/test_postrelease_public_truth.py
@@ -71,7 +71,18 @@ class Fixture:
 
         self.manifest = {
             "mode": "production",
+            "rollout_id": "arc-v080-recovery-fixture",
             "provenance": {"source_main_commit": self.source_sha},
+            "archive": {
+                "capture_id": "a" * 64,
+                "prearchive_rollout_sha256": "b" * 64,
+                "archive_manifest_sha256": "c" * 64,
+                "complete_sha256": "d" * 64,
+            },
+            "artifacts": {
+                "checkpoint": {"sha256": "3" * 64},
+                "legacy_late_fork_interlock_tool": {"sha256": "a" * 64},
+            },
             "checks": {
                 "reward": {
                     "mode": "receipt",
@@ -80,11 +91,23 @@ class Fixture:
                 }
             },
             "chain": {
+                "chain_id": TRUTH.CHAIN_ID,
+                "protocol_version": "3.0.0",
+                "recovery_epoch": 1,
+                "validator_set_id": 1,
                 "source_height": 137_145,
                 "transition_height": 137_146,
+                "legacy_observed_cutoff_height": 141_000,
+                "legacy_continuity_safety_margin": 128,
                 "legacy_public_max_height": 141_128,
                 "source_block_hash": "2" * 64,
                 "source_state_root": "3" * 64,
+                "transition_block_hash": "5" * 64,
+                "full_state_root": "6" * 64,
+                "recovery_domain": "7" * 64,
+                "approved_checkpoint_manifest_hash": "4" * 64,
+                "legacy_maintenance_boundary_sha256": "9" * 64,
+                "legacy_late_fork_source_set_sha256": "8" * 64,
                 "canonical_source": {
                     "node": "nyc",
                 },
@@ -133,7 +156,7 @@ class Fixture:
                 "kind": "v3",
                 "baseUrl": f"https://{host}",
                 "enabled": True,
-                "replicaGroup": "rollout",
+                "replicaGroup": self.manifest["rollout_id"],
             }
             for name, host in TRUTH.PRODUCTION_FLEET
         ]
@@ -160,9 +183,9 @@ class Fixture:
                     "inventorySha256": "f" * 64,
                     "bindingIndexSha256": "1" * 64,
                     "bindingSha256": "2" * 64,
-                    "checkpointSha256": "3" * 64,
-                    "checkpointManifestHash": "4" * 64,
-                    "checkpointPayloadHash": "5" * 64,
+                    "checkpointSha256": format(index, "x") * 64,
+                    "checkpointManifestHash": format(index + 5, "x") * 64,
+                    "checkpointPayloadHash": format(index + 10, "x") * 64,
                     "canonicalCheckpointHeight": 137145,
                     "sourceHeight": 141000,
                     "sourceBlockHash": "6" * 64,
@@ -170,7 +193,7 @@ class Fixture:
                     "provenancePath": "/provenance",
                 },
             }
-            for name, host in TRUTH.PRODUCTION_FLEET
+            for index, (name, host) in enumerate(TRUTH.PRODUCTION_FLEET[1:], 1)
         )
         self.config = {
             "schema": TRUTH.NETWORK_SCHEMA,
@@ -185,6 +208,8 @@ class Fixture:
                 "manifestHash": "4" * 64,
                 "boundaryBlockHash": "5" * 64,
                 "boundaryStateRoot": "6" * 64,
+                "checkpointFileSha256": "3" * 64,
+                "checkpointPayloadHash": "e" * 64,
                 "recoveryEpoch": 1,
                 "validatorSetId": 1,
                 "protocolVersion": "3.0.0",
@@ -930,13 +955,32 @@ class PublicTruthTests(unittest.TestCase):
         self.temporary = tempfile.TemporaryDirectory()
         self.root = Path(self.temporary.name)
         self.fixture = Fixture(self.root)
-        self.recovery_calls: list[tuple[Path, Path]] = []
+        self.recovery_calls: list[tuple[Path, Path, Path]] = []
         self.product_calls: list[tuple[Path, Path, Path, str]] = []
         self.appimage_calls: list[tuple[Path, Path]] = []
 
-        def verified(manifest, reward, manifest_raw, reward_raw, temporary_root):
-            self.recovery_calls.append((manifest, reward))
-            return {"manifestSha256": digest(manifest_raw), "rewardEvidenceSha256": digest(reward_raw), "stdoutSha256": "9" * 64, "verifierPath": TRUTH.RECOVERY_VERIFIER_RELATIVE.as_posix(), "verifierSha256": "8" * 64}
+        def verified(
+            manifest,
+            reward,
+            config,
+            manifest_raw,
+            reward_raw,
+            config_raw,
+            temporary_root,
+        ):
+            self.recovery_calls.append((manifest, reward, config))
+            TRUTH.require_exact_frontend_projection(
+                config_raw, TRUTH.canonical_json(self.fixture.config)
+            )
+            return {
+                "frontendConfigSha256": digest(config_raw),
+                "frontendProjectionSidecarSha256": "7" * 64,
+                "manifestSha256": digest(manifest_raw),
+                "rewardEvidenceSha256": digest(reward_raw),
+                "stdoutSha256": "9" * 64,
+                "verifierPath": TRUTH.RECOVERY_VERIFIER_RELATIVE.as_posix(),
+                "verifierSha256": "8" * 64,
+            }
 
         self.recovery_patch = mock.patch.object(TRUTH, "run_recovery_verify", side_effect=verified)
         self.recovery_patch.start()
@@ -1000,9 +1044,245 @@ class PublicTruthTests(unittest.TestCase):
         manifest["chain"]["canonical_source"]["node"] = "lax"
         config["checkpoint"]["legacySourceId"] = "v3-lax"
         config["checkpoint"]["v3SourceId"] = "v3-lax"
+        config["sources"] = [
+            row for row in config["sources"] if row["id"] != "legacy-fork-lax"
+        ]
 
         checkpoint = TRUTH.validate_network(config, self.fixture.source_sha, manifest)
         self.assertEqual(checkpoint["legacySourceId"], "v3-lax")
+
+    def test_network_rejects_frontend_identity_not_bound_to_sealed_manifest(self) -> None:
+        def every_v3(value: dict[str, object], field: str, replacement: object) -> None:
+            for row in value["sources"]:
+                if row["kind"] == "v3":
+                    row[field] = replacement
+
+        def every_archive(
+            value: dict[str, object], field: str, replacement: object
+        ) -> None:
+            for row in value["sources"]:
+                if row["kind"] == "legacy-fork":
+                    row["archive"][field] = replacement
+
+        def capture(value: dict[str, object]) -> None:
+            every_archive(value, "captureId", "0" * 64)
+            for row in value["sources"]:
+                if row["kind"] == "legacy-fork":
+                    row["replicaGroup"] = "legacy-capture-" + "0" * 64
+
+        def checkpoint_manifest(value: dict[str, object]) -> None:
+            value["checkpoint"]["manifestHash"] = "0" * 64
+            every_archive(value, "checkpointManifestHash", "0" * 64)
+
+        mutations = (
+            (
+                "boundary block",
+                lambda value: value["checkpoint"].__setitem__(
+                    "boundaryBlockHash", "0" * 64
+                ),
+            ),
+            (
+                "boundary state",
+                lambda value: value["checkpoint"].__setitem__(
+                    "boundaryStateRoot", "0" * 64
+                ),
+            ),
+            (
+                "recovery domain",
+                lambda value: value["checkpoint"].__setitem__(
+                    "recoveryDomain", "0" * 64
+                ),
+            ),
+            ("coordinated checkpoint manifest", checkpoint_manifest),
+            (
+                "canonical checkpoint file",
+                lambda value: value["checkpoint"].__setitem__(
+                    "checkpointFileSha256", "0" * 64
+                ),
+            ),
+            (
+                "v3 rollout identity",
+                lambda value: every_v3(value, "replicaGroup", "attacker-rollout"),
+            ),
+            ("archive capture", capture),
+            (
+                "prearchive rollout root",
+                lambda value: every_archive(
+                    value, "rolloutManifestSha256", "0" * 64
+                ),
+            ),
+            (
+                "archive manifest root",
+                lambda value: every_archive(
+                    value, "archiveManifestSha256", "0" * 64
+                ),
+            ),
+            (
+                "archive complete root",
+                lambda value: every_archive(
+                    value, "completeSha256", "0" * 64
+                ),
+            ),
+            (
+                "interlock source set",
+                lambda value: value["services"]["maintenanceInterlock"].__setitem__(
+                    "sourceSetSha256", "0" * 64
+                ),
+            ),
+            (
+                "interlock boundary",
+                lambda value: value["services"]["maintenanceInterlock"].__setitem__(
+                    "boundarySha256", "0" * 64
+                ),
+            ),
+            (
+                "interlock tool",
+                lambda value: value["services"]["maintenanceInterlock"].__setitem__(
+                    "toolSha256", "0" * 64
+                ),
+            ),
+            (
+                "interlock cutoff",
+                lambda value: value["services"]["maintenanceInterlock"].__setitem__(
+                    "observedCutoffHeight", 140_999
+                ),
+            ),
+        )
+        for label, mutate in mutations:
+            config = copy.deepcopy(self.fixture.config)
+            mutate(config)
+            with self.subTest(label=label), self.assertRaises(TRUTH.TruthError):
+                TRUTH.validate_network(config, self.fixture.source_sha, self.fixture.manifest)
+
+    def test_exact_projection_rejects_coordinated_candidate_checkpoint_mutations(self) -> None:
+        # The sealed rollout schema intentionally does not duplicate this
+        # candidate-specific identity. The final verifier derives every fork
+        # row from immutable archive provenance and compares complete bytes.
+        for field in (
+            "checkpointSha256",
+            "checkpointManifestHash",
+            "checkpointPayloadHash",
+        ):
+            mutated = copy.deepcopy(self.fixture.config)
+            for row in mutated["sources"]:
+                if row["kind"] == "legacy-fork":
+                    row["archive"][field] = "0" * 64
+            with self.subTest(field=field), self.assertRaisesRegex(
+                TRUTH.TruthError, "exact capture-bound"
+            ):
+                TRUTH.require_exact_frontend_projection(
+                    TRUTH.canonical_json(mutated),
+                    TRUTH.canonical_json(self.fixture.config),
+                )
+
+    def test_network_accepts_exact_zero_one_or_multiple_noncanonical_forks(self) -> None:
+        v3 = self.fixture.config["sources"][:6]
+        forks = self.fixture.config["sources"][6:]
+        for count in (0, 1, len(forks)):
+            config = copy.deepcopy(self.fixture.config)
+            config["sources"] = copy.deepcopy(v3 + forks[:count])
+            with self.subTest(count=count):
+                checkpoint = TRUTH.validate_network(
+                    config, self.fixture.source_sha, self.fixture.manifest
+                )
+                self.assertEqual(checkpoint["legacyForkCount"], count)
+                self.assertEqual(
+                    checkpoint["legacyForkNodes"],
+                    [row["archive"]["node"] for row in forks[:count]],
+                )
+
+    def test_network_rejects_wrong_fork_order_or_canonical_capture_as_fork(self) -> None:
+        reordered = copy.deepcopy(self.fixture.config)
+        reordered["sources"][6], reordered["sources"][7] = (
+            reordered["sources"][7],
+            reordered["sources"][6],
+        )
+        with self.assertRaises(TRUTH.TruthError):
+            TRUTH.validate_network(
+                reordered, self.fixture.source_sha, self.fixture.manifest
+            )
+
+        canonical_fork = copy.deepcopy(self.fixture.config)
+        row = canonical_fork["sources"][6]
+        row["id"] = "legacy-fork-nyc"
+        row["name"] = "Preserved legacy fork · NYC"
+        row["region"] = "NYC"
+        row["baseUrl"] = "https://149.28.32.76/legacy/nyc"
+        row["archive"]["node"] = "nyc"
+        with self.assertRaises(TRUTH.TruthError):
+            TRUTH.validate_network(
+                canonical_fork, self.fixture.source_sha, self.fixture.manifest
+            )
+
+    def test_recovery_gate_uses_exact_frontend_projection_without_duplicate_verify(self) -> None:
+        self.recovery_patch.stop()
+        commands: list[list[str]] = []
+
+        def projected(command, **kwargs):
+            commands.append(command)
+            self.assertIn("frontend-config", command)
+            self.assertNotIn("verify", command)
+            self.assertGreaterEqual(kwargs["timeout"], 24 * 60 * 60)
+            output = Path(command[command.index("--output") + 1])
+            raw = TRUTH.canonical_json(self.fixture.config)
+            output.write_bytes(raw)
+            output.with_name(output.name + ".sha256").write_text(
+                f"{digest(raw)}  {output.name}\n", encoding="ascii"
+            )
+            kwargs["stdout"].write(
+                (
+                    f"FRONTEND CONFIG {output} sha256={digest(raw)} "
+                    f"rollout_sha256={self.fixture.manifest_sha256}\n"
+                ).encode()
+            )
+            return TRUTH.subprocess.CompletedProcess(command, 0)
+
+        try:
+            mutated_config = copy.deepcopy(self.fixture.config)
+            for row in mutated_config["sources"]:
+                if row["kind"] == "legacy-fork":
+                    row["archive"]["checkpointPayloadHash"] = "0" * 64
+            mutated_config_path = self.root / "payload-mutated-config.json"
+            mutated_config_raw = write_json(mutated_config_path, mutated_config)
+            with (
+                tempfile.TemporaryDirectory() as temporary,
+                tempfile.TemporaryDirectory() as rejected_temporary,
+                mock.patch.object(TRUTH.subprocess, "run", side_effect=projected),
+            ):
+                receipt = TRUTH.run_recovery_verify(
+                    self.fixture.manifest_path,
+                    self.fixture.reward_path,
+                    self.fixture.config_path,
+                    self.fixture.manifest_path.read_bytes(),
+                    self.fixture.reward_path.read_bytes(),
+                    self.fixture.config_path.read_bytes(),
+                    Path(temporary),
+                )
+                with self.assertRaisesRegex(TRUTH.TruthError, "exact capture-bound"):
+                    TRUTH.run_recovery_verify(
+                        self.fixture.manifest_path,
+                        self.fixture.reward_path,
+                        mutated_config_path,
+                        self.fixture.manifest_path.read_bytes(),
+                        self.fixture.reward_path.read_bytes(),
+                        mutated_config_raw,
+                        Path(rejected_temporary),
+                    )
+            self.assertEqual(receipt["frontendConfigSha256"], digest(
+                self.fixture.config_path.read_bytes()
+            ))
+            self.assertEqual(len(commands), 2)
+        finally:
+            self.recovery_patch.start()
+
+    def test_network_rejects_nonstandard_margin_even_when_f_matches(self) -> None:
+        manifest = copy.deepcopy(self.fixture.manifest)
+        config = copy.deepcopy(self.fixture.config)
+        manifest["chain"]["legacy_continuity_safety_margin"] = 127
+        manifest["chain"]["legacy_observed_cutoff_height"] = 141_001
+        config["services"]["maintenanceInterlock"]["observedCutoffHeight"] = 141_001
+        with self.assertRaisesRegex(TRUTH.TruthError, "exactly 128"):
+            TRUTH.validate_network(config, self.fixture.source_sha, manifest)
 
     def test_builds_v2_receipt_and_claims_from_raw_evidence(self) -> None:
         output = self.root / "output"
@@ -1014,6 +1294,12 @@ class PublicTruthTests(unittest.TestCase):
         readme = readme_path.read_text(encoding="utf-8")
         self.assertIn("published Linux x86_64 component proved", readme)
         self.assertIn(f"ARC_INSTALL_SHA256={self.fixture.installer_sha}", readme)
+        self.assertIn("C=**141,000**", readme)
+        self.assertIn("**128 blocks**", readme)
+        self.assertIn("F=C+128=**141,128**", readme)
+        self.assertIn("recovery domain `" + "7" * 64 + "`", readme)
+        self.assertIn("epoch **1**, validator set **1**", readme)
+        self.assertIn("**5** divergent captured history views are available", readme)
         acceptance_raw = acceptance_path.read_bytes()
         acceptance = json.loads(acceptance_raw)
         self.assertEqual(acceptance["schema"], "arc.post-release-acceptance.v2")
@@ -1036,7 +1322,33 @@ class PublicTruthTests(unittest.TestCase):
         )
         self.assertEqual(status["pages"]["acceptedConfigCommit"], self.fixture.frontend_sha)
         self.assertEqual(status["rewards"]["demonstratedGrossBase"], 5_000_000_000)
-        self.assertEqual(self.recovery_calls, [(self.fixture.manifest_path, self.fixture.reward_path)])
+        self.assertEqual(status["checkpoint"]["legacyObservedCutoffHeight"], 141_000)
+        self.assertEqual(status["checkpoint"]["legacyContinuitySafetyMargin"], 128)
+        self.assertEqual(status["checkpoint"]["legacyPublicMaxHeight"], 141_128)
+        self.assertEqual(status["checkpoint"]["legacyReopeningFormula"], "F=C+128")
+        self.assertEqual(status["checkpoint"]["boundaryBlockHash"], "5" * 64)
+        self.assertEqual(status["checkpoint"]["boundaryStateRoot"], "6" * 64)
+        self.assertEqual(status["checkpoint"]["recoveryDomain"], "7" * 64)
+        self.assertEqual(status["checkpoint"]["recoveryEpoch"], 1)
+        self.assertEqual(status["checkpoint"]["validatorSetId"], 1)
+        self.assertEqual(status["checkpoint"]["checkpointFileSha256"], "3" * 64)
+        self.assertEqual(status["checkpoint"]["checkpointPayloadHash"], "e" * 64)
+        self.assertEqual(status["fleet"]["legacyForkCount"], 5)
+        self.assertEqual(
+            status["fleet"]["legacyForkNodes"],
+            [name for name, _host in TRUTH.PRODUCTION_FLEET[1:]],
+        )
+        self.assertEqual(
+            status["fleet"]["rolloutId"], self.fixture.manifest["rollout_id"]
+        )
+        self.assertEqual(
+            self.recovery_calls,
+            [(
+                self.fixture.manifest_path,
+                self.fixture.reward_path,
+                self.fixture.config_path,
+            )],
+        )
         self.assertEqual(
             self.product_calls,
             [(

--- a/tests/release/test_postrelease_public_truth.py
+++ b/tests/release/test_postrelease_public_truth.py
@@ -79,6 +79,16 @@ class Fixture:
                     "expected_worker": "0x" + "c" * 64,
                 }
             },
+            "chain": {
+                "source_height": 137_145,
+                "transition_height": 137_146,
+                "legacy_public_max_height": 141_128,
+                "source_block_hash": "2" * 64,
+                "source_state_root": "3" * 64,
+                "canonical_source": {
+                    "node": "nyc",
+                },
+            },
         }
         self.manifest_path = root / "manifest.json"
         manifest_raw = write_json(self.manifest_path, self.manifest)
@@ -169,7 +179,7 @@ class Fixture:
             "checkpoint": {
                 "height": 137145,
                 "recoveryHeight": 137146,
-                "legacyPublicMaxHeight": 141000,
+                "legacyPublicMaxHeight": 141128,
                 "blockHash": "2" * 64,
                 "stateRoot": "3" * 64,
                 "manifestHash": "4" * 64,
@@ -977,6 +987,22 @@ class PublicTruthTests(unittest.TestCase):
         self.product_patch.stop()
         self.recovery_patch.stop()
         self.temporary.cleanup()
+
+    def test_network_accepts_prefixed_manifest_hashes_and_non_nyc_canonical_source(self) -> None:
+        manifest = copy.deepcopy(self.fixture.manifest)
+        config = copy.deepcopy(self.fixture.config)
+        manifest["chain"]["source_block_hash"] = "0x" + manifest["chain"][
+            "source_block_hash"
+        ]
+        manifest["chain"]["source_state_root"] = "0x" + manifest["chain"][
+            "source_state_root"
+        ]
+        manifest["chain"]["canonical_source"]["node"] = "lax"
+        config["checkpoint"]["legacySourceId"] = "v3-lax"
+        config["checkpoint"]["v3SourceId"] = "v3-lax"
+
+        checkpoint = TRUTH.validate_network(config, self.fixture.source_sha, manifest)
+        self.assertEqual(checkpoint["legacySourceId"], "v3-lax")
 
     def test_builds_v2_receipt_and_claims_from_raw_evidence(self) -> None:
         output = self.root / "output"

--- a/tests/release/test_postrelease_public_truth.py
+++ b/tests/release/test_postrelease_public_truth.py
@@ -185,7 +185,7 @@ class Fixture:
                     "bindingSha256": "2" * 64,
                     "checkpointSha256": format(index, "x") * 64,
                     "checkpointManifestHash": format(index + 5, "x") * 64,
-                    "checkpointPayloadHash": format(index + 10, "x") * 64,
+                    "checkpointPayloadHash": format(index + 9, "x") * 64,
                     "canonicalCheckpointHeight": 137145,
                     "sourceHeight": 141000,
                     "sourceBlockHash": "6" * 64,
@@ -193,7 +193,7 @@ class Fixture:
                     "provenancePath": "/provenance",
                 },
             }
-            for index, (name, host) in enumerate(TRUTH.PRODUCTION_FLEET[1:], 1)
+            for index, (name, host) in enumerate(TRUTH.PRODUCTION_FLEET, 1)
         )
         self.config = {
             "schema": TRUTH.NETWORK_SCHEMA,
@@ -1191,7 +1191,7 @@ class PublicTruthTests(unittest.TestCase):
                     [row["archive"]["node"] for row in forks[:count]],
                 )
 
-    def test_network_rejects_wrong_fork_order_or_canonical_capture_as_fork(self) -> None:
+    def test_network_rejects_wrong_fork_order(self) -> None:
         reordered = copy.deepcopy(self.fixture.config)
         reordered["sources"][6], reordered["sources"][7] = (
             reordered["sources"][7],
@@ -1202,18 +1202,6 @@ class PublicTruthTests(unittest.TestCase):
                 reordered, self.fixture.source_sha, self.fixture.manifest
             )
 
-        canonical_fork = copy.deepcopy(self.fixture.config)
-        row = canonical_fork["sources"][6]
-        row["id"] = "legacy-fork-nyc"
-        row["name"] = "Preserved legacy fork · NYC"
-        row["region"] = "NYC"
-        row["baseUrl"] = "https://149.28.32.76/legacy/nyc"
-        row["archive"]["node"] = "nyc"
-        with self.assertRaises(TRUTH.TruthError):
-            TRUTH.validate_network(
-                canonical_fork, self.fixture.source_sha, self.fixture.manifest
-            )
-
     def test_recovery_gate_uses_exact_frontend_projection_without_duplicate_verify(self) -> None:
         self.recovery_patch.stop()
         commands: list[list[str]] = []
@@ -1222,7 +1210,7 @@ class PublicTruthTests(unittest.TestCase):
             commands.append(command)
             self.assertIn("frontend-config", command)
             self.assertNotIn("verify", command)
-            self.assertGreaterEqual(kwargs["timeout"], 24 * 60 * 60)
+            self.assertEqual(kwargs["timeout"], 72 * 60 * 60)
             output = Path(command[command.index("--output") + 1])
             raw = TRUTH.canonical_json(self.fixture.config)
             output.write_bytes(raw)
@@ -1299,7 +1287,7 @@ class PublicTruthTests(unittest.TestCase):
         self.assertIn("F=C+128=**141,128**", readme)
         self.assertIn("recovery domain `" + "7" * 64 + "`", readme)
         self.assertIn("epoch **1**, validator set **1**", readme)
-        self.assertIn("**5** divergent captured history views are available", readme)
+        self.assertIn("**6** divergent captured history views are available", readme)
         acceptance_raw = acceptance_path.read_bytes()
         acceptance = json.loads(acceptance_raw)
         self.assertEqual(acceptance["schema"], "arc.post-release-acceptance.v2")
@@ -1333,10 +1321,10 @@ class PublicTruthTests(unittest.TestCase):
         self.assertEqual(status["checkpoint"]["validatorSetId"], 1)
         self.assertEqual(status["checkpoint"]["checkpointFileSha256"], "3" * 64)
         self.assertEqual(status["checkpoint"]["checkpointPayloadHash"], "e" * 64)
-        self.assertEqual(status["fleet"]["legacyForkCount"], 5)
+        self.assertEqual(status["fleet"]["legacyForkCount"], 6)
         self.assertEqual(
             status["fleet"]["legacyForkNodes"],
-            [name for name, _host in TRUTH.PRODUCTION_FLEET[1:]],
+            [name for name, _host in TRUTH.PRODUCTION_FLEET],
         )
         self.assertEqual(
             status["fleet"]["rolloutId"], self.fixture.manifest["rollout_id"]

--- a/tests/release/test_validator_vault_restore.py
+++ b/tests/release/test_validator_vault_restore.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import copy
 import base64
 import contextlib
+import datetime as dt
 import hashlib
 import importlib.util
 import io
@@ -29,6 +30,7 @@ from unittest import mock
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HELPER = REPO_ROOT / "scripts" / "release" / "restore-validator-vault.py"
 FREEZE_TEST = REPO_ROOT / "scripts" / "recovery" / "test_recovery_freeze.py"
+QUARANTINE_TEST = REPO_ROOT / "scripts" / "recovery" / "test_quarantine_rounds.py"
 SOURCE_COMMIT = "a" * 40
 NODES = (
     ("NYC", "adf4ff16f997c871c16f3897e67881311d08f975f28ebdcf79e86ea9e3b99d0f", 6_666_667),
@@ -200,6 +202,16 @@ def fake_live_proof(helper, kwargs: dict):
 
 def load_freeze_fixture_module():
     spec = importlib.util.spec_from_file_location("arc_vault_freeze_fixture", FREEZE_TEST)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_quarantine_fixture_module():
+    spec = importlib.util.spec_from_file_location(
+        "arc_vault_quarantine_fixture", QUARANTINE_TEST
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -537,10 +549,79 @@ class Fixture:
                     "stopped_status_argv_sha256": hashlib.sha256(canonical(argv)).hexdigest(),
                 }
             )
-        first_quarantine = "2026-08-28T12:00:00Z"
-        all_stopped = "2026-08-28T12:02:30Z"
         challenge = "9" * 64
         public_receipt_sha = "8" * 64
+        quarantine_fixture = load_quarantine_fixture_module()
+        quarantine_fixture.CAPTURE = capture_id
+        quarantine_fixture.FREEZE = plan_sha
+        quarantine_fixture.SOURCE = SOURCE_COMMIT
+        quarantine_fixture.BASE = dt.datetime(
+            2026, 8, 28, 11, 50, tzinfo=dt.timezone.utc
+        )
+        drive_value = {"schema": "arc.fixture.drive-prefreeze.v1"}
+        drive_wrapper = {
+            "path": "/private/arc-fixture/drive-prefreeze.json",
+            "sha256": hashlib.sha256(canonical(drive_value)).hexdigest(),
+            "value": drive_value,
+        }
+        observation_generation = "7" * 64
+        generation_receipt = {
+            "schema": "arc.recovery.legacy-live-observation-generation.v1",
+            "source_main_commit": SOURCE_COMMIT,
+            "freeze_plan_sha256": plan_sha,
+            "capture_id": capture_id,
+            "observation_generation": observation_generation,
+            "created_at": "2026-08-28T11:56:40.000000Z",
+            "max_selection_age_seconds": 300,
+            "drive_prefreeze_receipt": drive_wrapper,
+        }
+        generation_sha = hashlib.sha256(canonical(generation_receipt)).hexdigest()
+        selection = {
+            "schema": "arc.recovery.legacy-live-observation-selection.v1",
+            "source_main_commit": SOURCE_COMMIT,
+            "freeze_plan_sha256": plan_sha,
+            "capture_id": capture_id,
+            "observation_generation": observation_generation,
+            "observation_generation_receipt": generation_receipt,
+            "observation_generation_receipt_path": (
+                f"/private/arc-fixture/{observation_generation}.json"
+            ),
+            "observation_generation_receipt_sha256": generation_sha,
+            "drive_prefreeze_receipt_path": drive_wrapper["path"],
+            "drive_prefreeze_receipt_sha256": drive_wrapper["sha256"],
+            "generation_created_at": generation_receipt["created_at"],
+            "selected_at": "2026-08-28T11:56:42.000000Z",
+            "max_selection_age_seconds": 300,
+            "labels": ["diagnostic", "noncanonical", "nonreward"],
+            "nodes": [
+                {
+                    "node": row["name"],
+                    "created_at": "2026-08-28T11:56:40.000000Z",
+                    "completed_at": "2026-08-28T11:56:41.000000Z",
+                    "root_sha256": f"{700 + index:064x}",
+                    "receipt_sha256": f"{800 + index:064x}",
+                }
+                for index, row in enumerate(value["nodes"])
+            ],
+        }
+        selection_sha = hashlib.sha256(canonical(selection)).hexdigest()
+        quarantine_fixture.H["91"] = selection_sha
+        quarantine_fixture.H["92"] = observation_generation
+        quarantine_fixture.H["93"] = generation_sha
+        quarantine_fixture.H["94"] = drive_wrapper["sha256"]
+        ledger = quarantine_fixture.ledger_for_first_successes(0)
+        quarantine_fixture.qr.validate_generation_ledger(ledger)
+        first_quarantine = ledger["first_secured_at"]
+        all_stopped = "2026-08-28T12:02:30Z"
+        transition_wrappers = {
+            wrapper["value"]["node"]: wrapper
+            for round_row in ledger["rounds"]
+            for wrapper in round_row["result"]["value"]["transitions"]
+        }
+        transition_projections = {
+            node: quarantine_fixture.qr.validate_node_transition(wrapper["value"])
+            for node, wrapper in transition_wrappers.items()
+        }
         authenticated_rows = []
         for row in value["nodes"]:
             auth_proof = {
@@ -576,6 +657,60 @@ class Fixture:
             "capture_id": capture_id,
             "challenge": challenge,
         }
+        ledger_sha = hashlib.sha256(canonical(ledger)).hexdigest()
+        active_roots = [
+            {"node": row["name"], "sha256": transition_wrappers[row["name"]]["sha256"]}
+            for row in value["nodes"]
+        ]
+        stability_rows = []
+        stability_heads = []
+        for index, row in enumerate(value["nodes"]):
+            head = transition_projections[row["name"]]["stable_head"]
+            samples = []
+            for sample_index in (0, 1):
+                sample = {
+                    "schema": "arc.recovery.legacy-network-quarantine-stability-sample.v1",
+                    "capture_id": capture_id,
+                    "node": row["name"],
+                    "freeze_plan_sha256": plan_sha,
+                    "challenge": challenge,
+                    "sample_index": sample_index,
+                    "started_at": "2026-08-28T12:00:03Z",
+                    "completed_at": "2026-08-28T12:00:04Z",
+                    "quarantine_status_before": {},
+                    "quarantine_status_before_sha256": "1" * 64,
+                    "quarantine_status_after": {},
+                    "quarantine_status_after_sha256": "2" * 64,
+                    "writer": {"state": "fixture-stopped"},
+                    "listener_ownership": [],
+                    "head": {
+                        **head,
+                        "response_sha256": {
+                            "info_before": "3" * 64,
+                            "latest": "4" * 64,
+                            "exact": "5" * 64,
+                            "info_after": "6" * 64,
+                        },
+                        "stable_attempt": 1,
+                    },
+                    "output_deny_packets": 10 + sample_index,
+                    "ss_sha256": "7" * 64,
+                    "global_absence_claimed": False,
+                }
+                samples.append(
+                    {"value": sample, "sha256": hashlib.sha256(canonical(sample)).hexdigest()}
+                )
+            stability_rows.append(
+                {
+                    "node": row["name"],
+                    "host": row["host"],
+                    "samples": samples,
+                    "output_deny_packets": {"sample_0": 10, "sample_1": 11},
+                }
+            )
+            stability_heads.append(
+                {"node": row["name"], "host": row["host"], "head": head}
+            )
         stability = {
             "schema": "arc.recovery.legacy-network-quarantine-stability.v1",
             "source_main_commit": SOURCE_COMMIT,
@@ -587,13 +722,11 @@ class Fixture:
             "started_at": "2026-08-28T12:00:03Z",
             "completed_at": "2026-08-28T12:02:03Z",
             "monotonic_elapsed_ns": 120_000_000_000,
-            "fleet_heads": [
-                {"node": row["name"], "host": row["host"]} for row in value["nodes"]
-            ],
-            "nodes": [
-                {"node": row["name"], "host": row["host"]} for row in value["nodes"]
-            ],
+            "fleet_heads": stability_heads,
+            "nodes": stability_rows,
             "global_absence_claimed": False,
+            "quarantine_generation_ledger_sha256": ledger_sha,
+            "active_transition_sha256s": active_roots,
         }
         inventory = []
 
@@ -606,6 +739,12 @@ class Fixture:
         authenticated_sealed = sealed(
             authenticated, "fleet", "authenticated-prefence-height-cross-proof"
         )
+        selection_sealed = sealed(
+            selection, "fleet", "live-observation-selection"
+        )
+        ledger_sealed = sealed(
+            ledger, "fleet", "quarantine-generation-ledger"
+        )
         challenge_sealed = sealed(
             quarantine_challenge, "fleet", "network-quarantine-challenge"
         )
@@ -617,15 +756,44 @@ class Fixture:
             node = plan_row["name"]
             host = plan_row["host"]
             stopped_status = json.loads((status_root / f"{host}.json").read_text())
+            transition_wrapper = transition_wrappers[node]
+            network_wrapper = transition_wrapper["value"]["network_quarantine_receipt"]
+            head = transition_projections[node]["stable_head"]
             quarantine_status = {
                 "schema": "arc.recovery.legacy-network-quarantine-status.v1",
                 "capture_id": capture_id,
                 "node": node,
                 "freeze_plan_sha256": plan_sha,
+                "receipt_sha256": network_wrapper["sha256"],
+                "table": {},
+                "rule_counters": {},
+                "counter_snapshot_sha256": "1" * 64,
+                "owned_ruleset_stateless_sha256": "2" * 64,
+                "listener_inventory": [],
+                "loopback_head": {},
+                "quarantine_policy": {},
                 "active": True,
                 "enabled": True,
             }
             post_status = dict(quarantine_status)
+            monitor = {
+                "schema": "arc.recovery.legacy-network-quarantine-monitor.v1",
+                "capture_id": capture_id,
+                "node": node,
+                "freeze_plan_sha256": plan_sha,
+                "network_quarantine_receipt_sha256": network_wrapper["sha256"],
+                "monitor_contract_sha256": "3" * 64,
+                "semantic_interpreter": {},
+                "firewall_loader_inventory": [],
+                "file_sha256": {},
+                "unit": {},
+                "legacy_exec_start_pre": {},
+                "incident_latched": False,
+                "continuous_fail_closed": True,
+                "automatic_unfence": False,
+                "global_absence_claimed": False,
+            }
+            status_sha = hashlib.sha256(canonical(quarantine_status)).hexdigest()
             external = {
                 "schema": "arc.recovery.legacy-network-quarantine-external-proof.v1",
                 "capture_id": capture_id,
@@ -633,6 +801,11 @@ class Fixture:
                 "host": host,
                 "freeze_plan_sha256": plan_sha,
                 "challenge": challenge,
+                "network_quarantine_receipt_sha256": network_wrapper["sha256"],
+                "before_status_sha256": status_sha,
+                "after_status": post_status,
+                "after_status_sha256": hashlib.sha256(canonical(post_status)).hexdigest(),
+                "ssh_status_reproved": True,
                 "global_absence_claimed": False,
             }
             public_cross = {
@@ -641,25 +814,80 @@ class Fixture:
                 "node": node,
                 "freeze_plan_sha256": plan_sha,
                 "challenge": challenge,
+                "network_quarantine_receipt_sha256": network_wrapper["sha256"],
+                "quarantine_status": quarantine_status,
+                "quarantine_status_sha256": status_sha,
+                "fenced_head_covers_public_info_after": True,
+                "public_latest_hash_matches": True,
                 "global_absence_claimed": False,
             }
+            namespace = {
+                "schema": "arc.recovery.legacy-dag-wal-namespace.v1",
+                "segment_names": ["wal-00000000.bin"],
+                "inspected_tail": [
+                    {"name": "wal-00000000.bin", "sha256": "4" * 64, "size": 128}
+                ],
+            }
+            namespace_sha = hashlib.sha256(
+                json.dumps(namespace, sort_keys=True, separators=(",", ":")).encode()
+            ).hexdigest()
+            dag_inspection = {
+                "schema": "arc.recovery.legacy-dag-round-inspection.v1",
+                "status": "VERIFIED_STOPPED_DAG_CURSOR",
+                "source_consensus_round": 9_999,
+                "first_segment": 0,
+                "last_segment": 0,
+                "segment_count": 1,
+                "inspected_first_segment": 0,
+                "inspected_segment_count": 1,
+                "inspected_entry_count": 1,
+                "namespace_sha256": namespace_sha,
+                "namespace": namespace,
+                "read_only": True,
+            }
             persisted = {
-                "schema": "arc.recovery.persisted-legacy-head.v1",
+                "schema": "arc.recovery.persisted-legacy-head.v3",
                 "source_main_commit": SOURCE_COMMIT,
                 "capture_id": capture_id,
                 "node": node,
+                "host": host,
                 "freeze_plan_sha256": plan_sha,
+                "source_pair_role": "post-quarantine-final-export",
+                "selected_source_head": head,
+                "head": head,
+                "final_source_capture_sha256": "5" * 64,
+                "stop_after_round_receipt_sha256": "6" * 64,
                 "writer_stopped": True,
                 "restart_barrier_active": True,
                 "network_quarantine_active": True,
                 "global_absence_claimed": False,
+                "legacy_dag_round": {
+                    "source_consensus_round": 9_999,
+                    "namespace_sha256": namespace_sha,
+                    "inspection": dag_inspection,
+                    "inspection_sha256": hashlib.sha256(canonical(dag_inspection)).hexdigest(),
+                },
+                "trusted_anchor_ancestry": {
+                    "anchor_height": 137145,
+                    "anchor_block_hash": "8fac459a8de0164b28e30d3f67adf6aefe01054912a3d1ae5c53765e59935a90",
+                    "anchor_state_root": "d300a2bb8dbe7f6da9596b550f31efd36eb842a1861e294c25740a19c8e3bc6d",
+                    "classification": "below_trusted_anchor",
+                    "inspection": None,
+                    "inspection_sha256": hashlib.sha256(canonical(None)).hexdigest(),
+                },
             }
             bundle_nodes.append(
                 {
                     "node": node,
                     "host": host,
                     "stopped_status": sealed(stopped_status, node, "stopped-status"),
+                    "network_quarantine_receipt": sealed(
+                        network_wrapper["value"], node, "network-quarantine-receipt"
+                    ),
                     "quarantine_status": sealed(quarantine_status, node, "quarantine-status"),
+                    "quarantine_monitor": sealed(
+                        monitor, node, "network-quarantine-monitor"
+                    ),
                     "post_proof_quarantine_status": sealed(
                         post_status, node, "post-proof-quarantine-status"
                     ),
@@ -686,7 +914,9 @@ class Fixture:
             "first_quarantine_started_at": first_quarantine,
             "all_controlled_stopped_at": all_stopped,
             "challenge": challenge,
+            "live_observation_selection": selection_sealed,
             "authenticated_prefence_height_cross_proof": authenticated_sealed,
+            "quarantine_generation_ledger": ledger_sealed,
             "network_quarantine_challenge": challenge_sealed,
             "quarantine_stability_proof": stability_sealed,
             "nodes": bundle_nodes,
@@ -751,6 +981,11 @@ class Fixture:
                 "observed_max_height": 100,
             },
             "authenticated_prefence_height_cross_proof_sha256": authenticated_sealed["sha256"],
+            "legacy_live_observation_selection_sha256": selection_sealed["sha256"],
+            "legacy_live_observation_generation": observation_generation,
+            "observation_generation_receipt_sha256": generation_sha,
+            "drive_prefreeze_receipt_sha256": drive_wrapper["sha256"],
+            "quarantine_generation_ledger_sha256": ledger_sealed["sha256"],
             "legacy_maintenance_evidence_bundle_sha256": bundle_sha,
             "network_quarantine_stability_proof_sha256": stability_sealed["sha256"],
             "network_quarantine_challenge": challenge,
@@ -820,6 +1055,11 @@ class Fixture:
             "legacy_maintenance_boundary": boundary,
             "legacy_maintenance_boundary_sha256": boundary_sha,
             "legacy_maintenance_evidence_bundle_sha256": bundle_sha,
+            "legacy_live_observation_selection_sha256": selection_sealed["sha256"],
+            "legacy_live_observation_generation": observation_generation,
+            "observation_generation_receipt_sha256": generation_sha,
+            "drive_prefreeze_receipt_sha256": drive_wrapper["sha256"],
+            "quarantine_generation_ledger_sha256": ledger_sealed["sha256"],
             "nodes": evidence_rows,
         }
         proof_path = self.root / "offline-stop-evidence.json"
@@ -1084,6 +1324,221 @@ class ValidatorVaultRestoreTests(unittest.TestCase):
         self.assertIn(expected, result.stderr)
         self.assertFalse(self.fixture.output.exists())
 
+    def maintenance_union_bundle(
+        self, stopped_names: set[str]
+    ) -> tuple[object, Path, str, dict, dict]:
+        """Rewrite the valid active fixture as a sealed tagged-union bundle."""
+
+        plan, plan_sha, bundle_path, _bundle_sha, *_rest = self.fixture.write_freeze_inputs()
+        helper = load_helper_module()
+        bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+        ledger = bundle["quarantine_generation_ledger"]["value"]
+        result = ledger["rounds"][0]["result"]["value"]
+        transitions = {
+            wrapper["value"]["node"]: wrapper for wrapper in result["transitions"]
+        }
+        rows = {row["node"]: row for row in bundle["nodes"]}
+
+        def wrap(value: dict) -> dict:
+            return {"value": value, "sha256": hashlib.sha256(canonical(value)).hexdigest()}
+
+        for node in stopped_names:
+            persisted = copy.deepcopy(rows[node]["persisted_head"]["value"])
+            persisted["schema"] = "arc.recovery.persisted-legacy-head-stopped-precommit.v2"
+            persisted["source_pair_role"] = "preauthorization-boundary"
+            persisted["network_quarantine_active"] = False
+            persisted_wrapper = wrap(persisted)
+            fence = wrap({"schema": "arc.fixture.restart-fence.v1", "node": node})
+            precommit = wrap({"schema": "arc.fixture.precommit.v1", "node": node})
+            transition = {
+                "schema": helper.quarantine_rounds.NODE_STOPPED_PRECOMMIT_SCHEMA,
+                "source_main_commit": SOURCE_COMMIT,
+                "capture_id": bundle["capture_id"],
+                "freeze_plan_sha256": bundle["freeze_plan_sha256"],
+                "node": node,
+                "host": rows[node]["host"],
+                "stable_head": persisted["head"],
+                "secured_at": ledger["first_secured_at"],
+                "persistent_restart_fence": fence,
+                "precommit_status": precommit,
+                "persisted_head": persisted_wrapper,
+            }
+            transition_wrapper = wrap(transition)
+            transitions[node] = transition_wrapper
+            current = {
+                "schema": "arc.recovery.quarantine-prior-persistently-stopped-status.v1",
+                "capture_id": bundle["capture_id"],
+                "freeze_plan_sha256": bundle["freeze_plan_sha256"],
+                "node": node,
+                "host": rows[node]["host"],
+                "node_transition_receipt_sha256": transition_wrapper["sha256"],
+                "transition_schema": helper.quarantine_rounds.NODE_STOPPED_PRECOMMIT_SCHEMA,
+                "transitioned_at": ledger["first_secured_at"],
+                "observed_at": "2026-08-28T12:02:20Z",
+                "writer_state": "persistently-stopped",
+                "current_boot_id": "00000000-0000-0000-0000-000000000001",
+                "stable_head": persisted["head"],
+                "persistent_restart_fence_sha256": fence["sha256"],
+                "precommit_status_sha256": precommit["sha256"],
+                "source_inputs": {},
+                "nft_table_absent": True,
+                "applied_commit_absent": True,
+                "active_selector_absent": True,
+                "fence_unit_enabled": True,
+                "fence_unit_active": False,
+                "automatic_legacy_restart": False,
+            }
+            rows[node] = {
+                "node": node,
+                "host": rows[node]["host"],
+                "transition_kind": helper.quarantine_rounds.STOPPED_PRECOMMIT_TRANSITION_KIND,
+                "transition_receipt": transition_wrapper,
+                "current_status": wrap(current),
+                "persisted_head": persisted_wrapper,
+            }
+
+        result["transitions"] = [
+            transitions[node.lower()] for node, _address, _stake in NODES
+        ]
+        ledger["rounds"][0]["result"] = wrap(result)
+        bundle["quarantine_generation_ledger"] = wrap(ledger)
+        active_names = [
+            node.lower() for node, _address, _stake in NODES
+            if node.lower() not in stopped_names
+        ]
+        stability = bundle["quarantine_stability_proof"]["value"]
+        stability["nodes"] = [row for row in stability["nodes"] if row["node"] in active_names]
+        stability["fleet_heads"] = [
+            row for row in stability["fleet_heads"] if row["node"] in active_names
+        ]
+        stability["quarantine_generation_ledger_sha256"] = bundle[
+            "quarantine_generation_ledger"
+        ]["sha256"]
+        stability["active_transition_sha256s"] = [
+            {"node": node, "sha256": transitions[node]["sha256"]}
+            for node in active_names
+        ]
+        stability["interval_seconds"] = 120 if active_names else 0
+        stability["sample_count"] = 2 if active_names else 0
+        stability["monotonic_elapsed_ns"] = 120_000_000_000 if active_names else 0
+        bundle["quarantine_stability_proof"] = wrap(stability)
+        bundle["nodes"] = [rows[node.lower()] for node, _address, _stake in NODES]
+
+        inventory = []
+
+        def reseal(field: str, node: str, role: str) -> None:
+            wrapper = bundle[field] if node == "fleet" else rows[node][field]
+            wrapper["sha256"] = hashlib.sha256(canonical(wrapper["value"])).hexdigest()
+            inventory.append(
+                {
+                    "node": node,
+                    "role": role,
+                    "sha256": wrapper["sha256"],
+                    "size": len(canonical(wrapper["value"])),
+                }
+            )
+
+        for field, role in (
+            ("authenticated_prefence_height_cross_proof", "authenticated-prefence-height-cross-proof"),
+            ("live_observation_selection", "live-observation-selection"),
+            ("quarantine_generation_ledger", "quarantine-generation-ledger"),
+            ("network_quarantine_challenge", "network-quarantine-challenge"),
+            ("quarantine_stability_proof", "network-quarantine-stability-proof"),
+        ):
+            reseal(field, "fleet", role)
+        for upper_node, _address, _stake in NODES:
+            node = upper_node.lower()
+            if node in stopped_names:
+                specs = (
+                    ("transition_receipt", "persistently-stopped-transition"),
+                    ("current_status", "stopped-current-status"),
+                    ("persisted_head", "persisted-head"),
+                )
+            else:
+                specs = (
+                    ("stopped_status", "stopped-status"),
+                    ("network_quarantine_receipt", "network-quarantine-receipt"),
+                    ("quarantine_status", "quarantine-status"),
+                    ("quarantine_monitor", "network-quarantine-monitor"),
+                    ("post_proof_quarantine_status", "post-proof-quarantine-status"),
+                    ("external_quarantine_proof", "external-quarantine-proof"),
+                    ("public_cross_proof", "public-cross-proof"),
+                    ("persisted_head", "persisted-head"),
+                )
+            for field, role in specs:
+                reseal(field, node, role)
+        bundle["object_inventory"] = inventory
+        bundle["aggregate_root_sha256"] = hashlib.sha256(
+            canonical(
+                {
+                    "schema": "arc.recovery.legacy-maintenance-evidence-inventory.v1",
+                    "objects": inventory,
+                }
+            )
+        ).hexdigest()
+        bundle_path.chmod(0o600)
+        create(bundle_path, canonical(bundle), 0o400)
+        bundle_sha = digest(bundle_path)
+        sidecar = bundle_path.with_name(bundle_path.name + ".sha256")
+        sidecar.chmod(0o600)
+        create(sidecar, f"{bundle_sha}  {bundle_path.name}\n".encode(), 0o400)
+        return plan, bundle_path, bundle_sha, bundle, helper
+
+    def validate_union_bundle(
+        self, stopped_names: set[str]
+    ) -> tuple[dict, dict[str, dict], object]:
+        plan, path, root, bundle, helper = self.maintenance_union_bundle(stopped_names)
+        selection = bundle["live_observation_selection"]
+        state = {
+            "capture_id": bundle["capture_id"],
+            "freeze_plan_sha256": bundle["freeze_plan_sha256"],
+            "all_nodes_secured_at": dt.datetime(
+                2026, 8, 28, 12, 2, 0, tzinfo=dt.timezone.utc
+            ),
+            "live_observation_selection_sha256": selection["sha256"],
+            "live_observation_generation": selection["value"]["observation_generation"],
+            "observation_generation_receipt_sha256": selection["value"][
+                "observation_generation_receipt_sha256"
+            ],
+            "drive_prefreeze_receipt_sha256": selection["value"][
+                "drive_prefreeze_receipt_sha256"
+            ],
+        }
+
+        def projection(transition: dict) -> dict:
+            stopped = transition["node"] in stopped_names
+            return {
+                "kind": (
+                    helper.quarantine_rounds.STOPPED_PRECOMMIT_TRANSITION_KIND
+                    if stopped else helper.quarantine_rounds.ACTIVE_TRANSITION_KIND
+                ),
+                "source_main_commit": SOURCE_COMMIT,
+                "stable_head": transition["stable_head"],
+            }
+
+        with (
+            mock.patch.object(
+                helper.quarantine_rounds, "validate_generation_ledger", return_value=state
+            ),
+            mock.patch.object(
+                helper.quarantine_rounds, "validate_node_transition", side_effect=projection
+            ),
+            mock.patch.object(
+                helper.quarantine_rounds,
+                "validate_prior_fenced_status",
+                return_value=dt.datetime(2026, 8, 28, 12, 2, 20, tzinfo=dt.timezone.utc),
+            ),
+        ):
+            parsed, nodes, _ = helper.load_legacy_maintenance_evidence_bundle(
+                path,
+                path.with_name(path.name + ".sha256"),
+                root,
+                source_commit=SOURCE_COMMIT,
+                freeze_sha256=bundle["freeze_plan_sha256"],
+                freeze_plan=plan,
+            )
+        return parsed, nodes, helper
+
     def test_restore_produces_only_six_keys_public_manifest_and_private_receipt(self) -> None:
         result = self.fixture.restore()
         self.assertIn("six reviewed identities verified", result.stdout)
@@ -1304,6 +1759,83 @@ class ValidatorVaultRestoreTests(unittest.TestCase):
         result = run(linked, success=False)
         self.assertIn("single-link, non-writable regular file", result.stderr)
         self.assertFalse(self.fixture.output.exists())
+
+    def test_maintenance_bundle_accepts_mixed_active_and_persistently_stopped_union(self) -> None:
+        stopped = {"lhr", "nrt", "sgp"}
+        bundle, nodes, helper = self.validate_union_bundle(stopped)
+        self.assertEqual(
+            [row["node"] for row in bundle["quarantine_stability_proof"]["value"]["nodes"]],
+            ["nyc", "lax", "ams"],
+        )
+        for node in stopped:
+            self.assertEqual(
+                nodes[node.upper()]["transition_kind"],
+                helper.quarantine_rounds.STOPPED_PRECOMMIT_TRANSITION_KIND,
+            )
+        for node in {"nyc", "lax", "ams"}:
+            self.assertEqual(
+                nodes[node.upper()]["transition_kind"],
+                helper.quarantine_rounds.ACTIVE_TRANSITION_KIND,
+            )
+
+    def test_maintenance_bundle_accepts_all_stopped_zero_sample_union(self) -> None:
+        stopped = {node.lower() for node, _address, _stake in NODES}
+        bundle, nodes, helper = self.validate_union_bundle(stopped)
+        stability = bundle["quarantine_stability_proof"]["value"]
+        self.assertEqual(stability["nodes"], [])
+        self.assertEqual(stability["fleet_heads"], [])
+        self.assertEqual(stability["active_transition_sha256s"], [])
+        self.assertEqual(stability["interval_seconds"], 0)
+        self.assertEqual(stability["sample_count"], 0)
+        self.assertEqual(stability["monotonic_elapsed_ns"], 0)
+        self.assertTrue(
+            all(
+                row["transition_kind"]
+                == helper.quarantine_rounds.STOPPED_PRECOMMIT_TRANSITION_KIND
+                for row in nodes.values()
+            )
+        )
+
+    def test_maintenance_bundle_rejects_resealed_embedded_dag_tamper(self) -> None:
+        plan, plan_sha, bundle_path, _bundle_sha, *_rest = self.fixture.write_freeze_inputs()
+        helper = load_helper_module()
+        bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+        row = bundle["nodes"][0]
+        persisted = row["persisted_head"]["value"]
+        persisted["legacy_dag_round"]["inspection"]["source_consensus_round"] += 1
+        # Re-seal every outer layer an attacker controls, but deliberately
+        # leave the independently recomputed embedded inspection root intact.
+        persisted_raw = canonical(persisted)
+        row["persisted_head"]["sha256"] = hashlib.sha256(persisted_raw).hexdigest()
+        inventory_row = next(
+            item for item in bundle["object_inventory"]
+            if item["node"] == "nyc" and item["role"] == "persisted-head"
+        )
+        inventory_row["sha256"] = row["persisted_head"]["sha256"]
+        inventory_row["size"] = len(persisted_raw)
+        bundle["aggregate_root_sha256"] = hashlib.sha256(
+            canonical(
+                {
+                    "schema": "arc.recovery.legacy-maintenance-evidence-inventory.v1",
+                    "objects": bundle["object_inventory"],
+                }
+            )
+        ).hexdigest()
+        bundle_path.chmod(0o600)
+        create(bundle_path, canonical(bundle), 0o400)
+        bundle_sha = digest(bundle_path)
+        sidecar = bundle_path.with_name(bundle_path.name + ".sha256")
+        sidecar.chmod(0o600)
+        create(sidecar, f"{bundle_sha}  {bundle_path.name}\n".encode(), 0o400)
+        with self.assertRaisesRegex(helper.VaultError, "persisted DAG round differs"):
+            helper.load_legacy_maintenance_evidence_bundle(
+                bundle_path,
+                sidecar,
+                bundle_sha,
+                source_commit=SOURCE_COMMIT,
+                freeze_sha256=plan_sha,
+                freeze_plan=plan,
+            )
 
     def test_install_rejects_transport_hash_and_wrong_host_before_any_remote_operation(self) -> None:
         self.fixture.restore()


### PR DESCRIPTION
## Outcome

- Derive the canonical checkpoint from the stopped six-validator DAG and bind H, H+1, C, the 128-block safety margin, and F=C+128.
- Preserve every stopped capture and publish only authenticated immutable noncanonical fork views.
- Make quarantine, capture, Drive archive, validator-vault restore, and rollout resumable and fail closed.
- Keep all six public edges in maintenance until a fresh exact convergence proof; reclose every edge on any partial or post-promotion failure.
- Bind dashboard, explorer, inference, reward, earnings, release, and README public claims to exact rollout and post-release evidence.
- Retain GUI-free Linux/community install and update contracts across supported platforms.

## Local verification

Focused recovery, archive, public-truth, release/security, and documentation gates pass. The complete release aggregate is running in parallel with protected CI.

## Production discipline

No validator is mutated by this PR. Production materialization and rollout will use only the final protected-main commit and fresh create-only evidence.