### PR TITLE
Fix production quarantine runtime compatibility

### DIFF
--- a/scripts/recovery/archive-node.sh
+++ b/scripts/recovery/archive-node.sh
@@ -5612,6 +5612,28 @@ def secure_dir(path, mode_value, *, create=False):
             or stat.S_IMODE(details.st_mode) != mode_value):
         fail(f"unsafe quarantine-round directory: {path}")
 
+def secure_systemd_dropin_dir(path, *, create=False):
+    """Accept root-private or conventionally traversable systemd drop-in dirs.
+
+    The remote helper runs under umask 077, so ``mkdir(..., 0o755)`` may
+    legitimately materialize as 0700.  Existing administrator-created drop-in
+    directories are commonly 0755.  Both are safe here: the security boundary
+    is root ownership plus the absence of group/world write permission, while
+    owner rwx is required for the create-only publications below.
+    """
+    if create and not path.exists() and not path.is_symlink():
+        try:
+            os.mkdir(path, 0o755)
+            fsync_dir(path.parent)
+        except FileExistsError:
+            pass
+    details = path.lstat()
+    permissions = stat.S_IMODE(details.st_mode)
+    if (path.is_symlink() or not stat.S_ISDIR(details.st_mode)
+            or details.st_uid != 0 or details.st_gid != 0
+            or permissions & 0o700 != 0o700 or permissions & 0o022):
+        fail(f"unsafe quarantine-round systemd drop-in directory: {path}")
+
 def secure_read(path, mode_value, *, maximum=16 * 1024 * 1024):
     descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
     try:
@@ -7099,7 +7121,7 @@ WantedBy=multi-user.target
         # Same order as initial apply: the selected live supervisor barrier is
         # the first effective mutation; a missing dispatcher also fails closed.
         for dependency, dependency_value in dependencies.items():
-            secure_dir(dependency.parent, 0o755, create=True)
+            secure_systemd_dropin_dir(dependency.parent, create=True)
             publish(dependency, dependency_value, 0o400)
         publish(dispatcher_path, dispatcher_raw_value, 0o500)
         publish(unit_path, unit_value, 0o400)
@@ -9429,7 +9451,7 @@ WantedBy=multi-user.target
             publish(stop_intent_path, stop_intent_raw, 0o400)
 
         for path, raw in stop_dropins.items():
-            secure_dir(path.parent, 0o755, create=True)
+            secure_systemd_dropin_dir(path.parent, create=True)
             publish(path, raw, 0o400)
         if allow_marker.exists() or allow_marker.is_symlink():
             if marker_identity() != marker_before:
@@ -9833,7 +9855,7 @@ def normalize_nonowned(value):
   answer.append(scrub(entry))
  return answer
 def nft_json(nft,*args):
- raw=subprocess.check_output([str(nft),"--json",*args]);value=json.loads(raw)
+ raw=subprocess.check_output([str(nft),"--json","--numeric",*args]);value=json.loads(raw)
  if not isinstance(value,dict) or not isinstance(value.get("nftables"),list):fail("nft JSON differs")
  return value,raw
 def exists(nft):return subprocess.run([str(nft),"list","table","inet",TABLE],stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL).returncode==0
@@ -10162,7 +10184,7 @@ publish(commit_path,canonical(commit),0o400);result(commit)
     # The selected frozen supervisor dependency is first in insertion order.
     # A crash after this or any later prefix leaves boot activation fail-closed.
     for dependency, dependency_value in dependencies.items():
-        secure_dir(dependency.parent, 0o755)
+        secure_systemd_dropin_dir(dependency.parent)
         publish(dependency, dependency_value, 0o400)
     publish(dispatcher_path, dispatcher_raw_value, 0o500)
     publish(unit_path, unit_value, 0o400)

--- a/scripts/recovery/test_archive_node_quarantine_runtime.py
+++ b/scripts/recovery/test_archive_node_quarantine_runtime.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 import ast
 import dataclasses
 import hashlib
+import json
 import os
 import pathlib
 import re
 import socket
+import stat
 import sys
 import tempfile
 import unittest
@@ -775,6 +777,115 @@ class EmbeddedProgramTests(unittest.TestCase):
             "subprocess.check_output([str(state / \"apply\"), \"initial\"])",
         ):
             self.assertGreater(self.outer.index(token), ready)
+
+    def test_systemd_dropin_directory_contract_accepts_umask_private_mode(self) -> None:
+        tree = ast.parse(self.outer)
+        function = next(
+            node for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "secure_systemd_dropin_dir"
+        )
+
+        def fail(message: str) -> None:
+            raise RuntimeError(message)
+
+        namespace = {"os": os, "stat": stat, "fail": fail}
+        exec(compile(ast.Module(body=[function], type_ignores=[]),
+                     "secure-systemd-dropin-dir", "exec"), namespace)
+        validate = namespace["secure_systemd_dropin_dir"]
+
+        class FakePath:
+            def __init__(self, mode: int, *, uid: int = 0, gid: int = 0,
+                         symlink: bool = False, directory: bool = True) -> None:
+                self.mode = mode
+                self.uid = uid
+                self.gid = gid
+                self.symlink = symlink
+                self.directory = directory
+
+            def exists(self) -> bool:
+                return True
+
+            def is_symlink(self) -> bool:
+                return self.symlink
+
+            def lstat(self):
+                file_type = stat.S_IFDIR if self.directory else stat.S_IFREG
+                return os.stat_result((file_type | self.mode, 0, 0, 1,
+                                       self.uid, self.gid, 0, 0, 0, 0))
+
+            def __str__(self) -> str:
+                return "/etc/systemd/system/arc-self-heal.service.d"
+
+        # 0700 is what mkdir(0755) produces under archive-node.sh's umask 077;
+        # 0750 and 0755 are also safe pre-existing administrator layouts.
+        for mode in (0o700, 0o750, 0o755):
+            with self.subTest(accepted=oct(mode)):
+                validate(FakePath(mode))
+
+        rejected = (
+            FakePath(0o770), FakePath(0o707), FakePath(0o600),
+            FakePath(0o700, uid=1), FakePath(0o700, gid=1),
+            FakePath(0o700, symlink=True), FakePath(0o700, directory=False),
+        )
+        for path in rejected:
+            with self.subTest(rejected=vars(path)), self.assertRaisesRegex(
+                    RuntimeError, "unsafe quarantine-round systemd drop-in directory"):
+                validate(path)
+
+        for call in (
+            "secure_systemd_dropin_dir(dependency.parent, create=True)",
+            "secure_systemd_dropin_dir(path.parent, create=True)",
+            "secure_systemd_dropin_dir(dependency.parent)",
+        ):
+            self.assertIn(call, self.outer)
+        self.assertNotIn("secure_dir(dependency.parent, 0o755", self.outer)
+        self.assertNotIn("secure_dir(path.parent, 0o755", self.outer)
+
+    def test_nft_json_verification_requests_numeric_icmpv6_values(self) -> None:
+        tree = ast.parse(self.helper)
+        functions = {
+            node.name: node for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name in {"nft_json", "extract"}
+        }
+        calls: list[list[str]] = []
+        numeric_types = [2, 133, 134, 135, 136]
+        symbolic_types = [
+            "packet-too-big", "nd-router-solicit", "nd-router-advert",
+            "nd-neighbor-solicit", "nd-neighbor-advert",
+        ]
+
+        class FakeSubprocess:
+            def check_output(self, argv: list[str]) -> bytes:
+                calls.append(argv)
+                values = numeric_types if "--numeric" in argv else symbolic_types
+                return json.dumps({"nftables": [{"rule": {"expr": [{
+                    "match": {
+                        "left": {"payload": {"protocol": "icmpv6", "field": "type"}},
+                        "op": "==", "right": {"set": values},
+                    },
+                }]}}]}).encode()
+
+        def fail(message: str, code: int = 1) -> None:
+            raise RuntimeError(f"{code}: {message}")
+
+        namespace = {"json": json, "subprocess": FakeSubprocess(), "fail": fail}
+        exec(compile(ast.Module(body=[functions["nft_json"], functions["extract"]],
+                                    type_ignores=[]),
+                     "numeric-nft-json", "exec"), namespace)
+        value, _raw = namespace["nft_json"](
+            "/pinned/nft", "list", "table", "inet", "arc_legacy_maintenance_v1",
+        )
+        self.assertEqual(calls, [[
+            "/pinned/nft", "--json", "--numeric", "list", "table", "inet",
+            "arc_legacy_maintenance_v1",
+        ]])
+        expression = value["nftables"][0]["rule"]["expr"]
+        self.assertEqual(
+            namespace["extract"](expression, "iifname"),
+            (None, [("icmpv6", "type", numeric_types)], None, False),
+        )
 
     def test_intent_precedes_restart_affecting_paths(self) -> None:
         intent = self.outer.index("publish(intent_path, intent_raw, 0o400)")


### PR DESCRIPTION
Production recovery exposed two fail-closed integration seams before any chain-state copy or validator replacement: systemd drop-in directories created under umask 077 are mode 0700 while the quarantine path required exact 0755, and nftables 1.0.9 renders ICMPv6 names symbolically unless numeric JSON is requested.

This change accepts only root-owned, owner-accessible, non-group/world-writable drop-in directories; explicitly requests numeric nft JSON; and adds focused regression coverage for both production behaviors.

Validation: bash -n; shellcheck; 39 quarantine-runtime tests (1 skipped); 8 prepare-runtime tests (1 skipped); 26 quarantine-round tests; git diff --check.

No blockchain data, consensus rules, validator keys, or history semantics change.