### PR TITLE
fix(recovery): resume applied quarantine captures safely

### DIFF
--- a/scripts/recovery/archive-fleet-to-drive.sh
+++ b/scripts/recovery/archive-fleet-to-drive.sh
@@ -5307,8 +5307,396 @@ run_sealed_source_status_exact() {
         "$(freeze_node_field "$freeze_plan" "$node" data_dir)"
 }
 
+active_quarantine_round_candidates() {
+    [ "$#" -eq 4 ] || \
+        die "active quarantine candidates require round root, capture, freeze, and node"
+    local round_root="$1" capture_id="$2" freeze_sha="$3" node="$4"
+    python3 - "$round_root" "$capture_id" "$freeze_sha" "$node" <<'PY'
+import hashlib,json,os,pathlib,re,stat,sys
+
+root=pathlib.Path(sys.argv[1]);capture,freeze,node=sys.argv[2:]
+canonical=lambda value:(json.dumps(value,sort_keys=True,separators=(",",":"))+"\n").encode()
+hash_re=re.compile(r"[0-9a-f]{64}")
+fleet=("nyc","lax","ams","lhr","nrt","sgp")
+if not os.path.lexists(root):raise SystemExit(0)
+details=root.lstat()
+if (root.is_symlink() or not stat.S_ISDIR(details.st_mode)
+        or details.st_uid!=os.geteuid() or stat.S_IMODE(details.st_mode)!=0o700):
+    raise SystemExit("active quarantine round root is unsafe")
+def locked(path,label):
+    fd=os.open(path,os.O_RDONLY|getattr(os,"O_NOFOLLOW",0))
+    try:
+        details=os.fstat(fd)
+        if (not stat.S_ISREG(details.st_mode) or details.st_uid!=os.geteuid()
+                or details.st_nlink!=1 or stat.S_IMODE(details.st_mode)!=0o400
+                or not 0<details.st_size<=32*1024*1024):
+            raise SystemExit(f"active quarantine {label} is unsafe")
+        raw=os.read(fd,32*1024*1024+1);value=json.loads(raw)
+        if len(raw)!=details.st_size or raw!=canonical(value) or not isinstance(value,dict):
+            raise SystemExit(f"active quarantine {label} differs")
+        return value,raw
+    finally:os.close(fd)
+candidates=[]
+for round_path in sorted(root.glob("round-*")):
+    match=re.fullmatch(r"round-([1-6])",round_path.name)
+    if match is None:continue
+    round_number=int(match.group(1))
+    round_details=round_path.lstat()
+    if (round_path.is_symlink() or not stat.S_ISDIR(round_details.st_mode)
+            or round_details.st_uid!=os.geteuid()
+            or stat.S_IMODE(round_details.st_mode)!=0o700):
+        raise SystemExit("active quarantine round directory is unsafe")
+    for attempt in sorted(round_path.glob("attempt.*")):
+        attempt_details=attempt.lstat()
+        if (attempt.is_symlink() or not stat.S_ISDIR(attempt_details.st_mode)
+                or attempt_details.st_uid!=os.geteuid()
+                or stat.S_IMODE(attempt_details.st_mode)!=0o700):
+            raise SystemExit("active quarantine attempt directory is unsafe")
+        release_path=attempt/"zero-progress-release.json"
+        if os.path.lexists(release_path):
+            # A released dispatch has a separately validated fleet-wide proof
+            # that it produced no transition. It can never classify an active
+            # host, and malformed release bytes still fail closed here.
+            locked(release_path,"zero-progress release")
+            continue
+        auth_path=attempt/"authorization.json";readiness_path=attempt/"readiness.json"
+        dispatch_path=attempt/"mutation-dispatch.json"
+        if not all(os.path.lexists(path) for path in (
+                auth_path,readiness_path,dispatch_path)):continue
+        auth,auth_raw=locked(auth_path,"authorization")
+        auth_sha=hashlib.sha256(auth_raw).hexdigest()
+        targets=auth.get("targets")
+        if (auth.get("schema")!="arc.recovery.quarantine-round-authorization.v1"
+                or (auth.get("capture_id"),auth.get("freeze_plan_sha256"),
+                    auth.get("round_number"))!=(capture,freeze,round_number)
+                or not isinstance(targets,list)):
+            raise SystemExit("active quarantine authorization identity differs")
+        target_names=[row.get("node") for row in targets if isinstance(row,dict)]
+        if (len(target_names)!=len(targets) or len(target_names)!=len(set(target_names))
+                or any(name not in fleet for name in target_names) or node not in target_names):
+            continue
+        readiness,readiness_raw=locked(readiness_path,"readiness")
+        readiness_sha=hashlib.sha256(readiness_raw).hexdigest()
+        ready_targets=readiness.get("targets")
+        ready_names=[row.get("node") for row in ready_targets] \
+            if isinstance(ready_targets,list) and all(isinstance(row,dict) for row in ready_targets) else []
+        if (readiness.get("schema")!="arc.recovery.quarantine-round-readiness.v1"
+                or (readiness.get("capture_id"),readiness.get("freeze_plan_sha256"),
+                    readiness.get("round_number"),readiness.get("round_authorization_sha256"))
+                    !=(capture,freeze,round_number,auth_sha)
+                or ready_names!=target_names):
+            raise SystemExit("active quarantine readiness identity differs")
+        dispatch,dispatch_raw=locked(dispatch_path,"mutation dispatch")
+        dispatch_targets=dispatch.get("targets")
+        expected_dispatch_targets=[
+            {"node":row.get("node"),"host":row.get("host")} for row in targets
+        ]
+        dispatch_fields={"schema","capture_id","freeze_plan_sha256","round_number",
+            "round_authorization_sha256","round_readiness_sha256",
+            "live_observation_selection_sha256","live_observation_generation",
+            "observation_generation_receipt_sha256","drive_prefreeze_receipt_sha256",
+            "targets","dispatched_at"}
+        if (set(dispatch)!=dispatch_fields
+                or dispatch.get("schema")!="arc.recovery.quarantine-mutation-dispatch.v1"
+                or (dispatch.get("capture_id"),dispatch.get("freeze_plan_sha256"),
+                    dispatch.get("round_number"),dispatch.get("round_authorization_sha256"),
+                    dispatch.get("round_readiness_sha256"),dispatch_targets)
+                    !=(capture,freeze,round_number,auth_sha,readiness_sha,
+                       expected_dispatch_targets)
+                or any(dispatch.get(label)!=auth.get(label) for label in (
+                    "live_observation_selection_sha256","live_observation_generation",
+                    "observation_generation_receipt_sha256",
+                    "drive_prefreeze_receipt_sha256"))):
+            raise SystemExit("active quarantine mutation dispatch identity differs")
+        try:
+            import datetime
+            datetime.datetime.strptime(dispatch.get("dispatched_at",""),
+                                       "%Y-%m-%dT%H:%M:%SZ")
+        except (TypeError,ValueError):
+            raise SystemExit("active quarantine mutation dispatch time differs")
+        local_applied="-";applied_path=attempt/"node-transitions"/f"{node}.json"
+        if os.path.lexists(applied_path):
+            applied,applied_raw=locked(applied_path,"local applied receipt")
+            if (applied.get("schema")!="arc.recovery.quarantine-node-nft-applied.v1"
+                    or (applied.get("capture_id"),applied.get("freeze_plan_sha256"),
+                        applied.get("round_number"),applied.get("round_authorization_sha256"),
+                        applied.get("round_readiness_sha256"),applied.get("node"))
+                        !=(capture,freeze,round_number,auth_sha,readiness_sha,node)):
+                raise SystemExit("active quarantine local applied receipt differs")
+            local_applied=hashlib.sha256(applied_raw).hexdigest()
+        result_path=attempt/"result.json"
+        if os.path.lexists(result_path):
+            result,result_raw=locked(result_path,"round result")
+            transitions=result.get("transitions")
+            result_fields={"schema","capture_id","freeze_plan_sha256","round_number",
+                "round_authorization_sha256","target_readiness","transitions",
+                "mutation_dispatch","remaining_target_inert_proofs",
+                "remaining_targets","completed_at"}
+            if (set(result)!=result_fields
+                    or result.get("schema")!="arc.recovery.quarantine-round-result.v3"
+                    or (result.get("capture_id"),result.get("freeze_plan_sha256"),
+                        result.get("round_number"),
+                        result.get("round_authorization_sha256"))
+                        !=(capture,freeze,round_number,auth_sha)
+                    or not isinstance(transitions,list)):
+                raise SystemExit("active quarantine round result identity differs")
+            def exact_wrapper(wrapper,value,expected_sha,label):
+                if (not isinstance(wrapper,dict) or set(wrapper)!={"sha256","value"}
+                        or wrapper.get("value")!=value
+                        or wrapper.get("sha256")!=expected_sha
+                        or hashlib.sha256(canonical(wrapper.get("value"))).hexdigest()
+                            !=expected_sha):
+                    raise SystemExit(f"active quarantine result {label} differs")
+            exact_wrapper(result.get("target_readiness"),readiness,readiness_sha,
+                          "readiness")
+            dispatch_sha=hashlib.sha256(dispatch_raw).hexdigest()
+            exact_wrapper(result.get("mutation_dispatch"),dispatch,dispatch_sha,
+                          "mutation dispatch")
+            matching=[]
+            transitioned=[]
+            for wrapper in transitions:
+                if (not isinstance(wrapper,dict) or set(wrapper)!={"sha256","value"}
+                        or not isinstance(wrapper.get("value"),dict)
+                        or hashlib.sha256(canonical(wrapper["value"])).hexdigest()
+                            !=wrapper.get("sha256")):
+                    raise SystemExit("active quarantine result transition differs")
+                item=wrapper["value"];item_node=item.get("node")
+                if (item_node not in target_names or item_node in transitioned
+                        or (item.get("capture_id"),item.get("freeze_plan_sha256"),
+                            item.get("round_number"),
+                            item.get("round_authorization_sha256"),
+                            item.get("round_readiness_sha256"))
+                            !=(capture,freeze,round_number,auth_sha,readiness_sha)):
+                    raise SystemExit("active quarantine result transition identity differs")
+                transition_path=attempt/"node-transitions"/f"{item_node}.json"
+                if not os.path.lexists(transition_path):
+                    raise SystemExit("active quarantine result transition file is missing")
+                transition,transition_raw=locked(
+                    transition_path,f"{item_node} result transition")
+                if (transition!=item
+                        or hashlib.sha256(transition_raw).hexdigest()!=wrapper["sha256"]):
+                    raise SystemExit("active quarantine result transition file differs")
+                transitioned.append(item_node)
+                if item_node==node:matching.append(wrapper)
+            if transitioned != [name for name in target_names if name in set(transitioned)]:
+                raise SystemExit("active quarantine result transition order differs")
+            remaining=[name for name in target_names if name not in set(transitioned)]
+            if result.get("remaining_targets")!=remaining:
+                raise SystemExit("active quarantine result remaining targets differ")
+            inert=result.get("remaining_target_inert_proofs")
+            if not isinstance(inert,list):
+                raise SystemExit("active quarantine result inert proofs differ")
+            inert_nodes=[]
+            for wrapper in inert:
+                if (not isinstance(wrapper,dict) or set(wrapper)!={"sha256","value"}
+                        or not isinstance(wrapper.get("value"),dict)
+                        or hashlib.sha256(canonical(wrapper["value"])).hexdigest()
+                            !=wrapper.get("sha256")):
+                    raise SystemExit("active quarantine result inert proof differs")
+                inert_nodes.append(wrapper["value"].get("node"))
+            if inert_nodes not in ([],remaining):
+                raise SystemExit("active quarantine result inert proof order differs")
+            if not matching:
+                continue
+            if (len(matching)!=1 or local_applied=="-"
+                    or matching[0].get("sha256")!=local_applied):
+                raise SystemExit("active quarantine result/local transition differs")
+        candidates.append((round_number,auth_sha,readiness_sha,local_applied))
+for row in candidates:print(*row)
+PY
+}
+
+validate_active_quarantine_round_status() {
+    [ "$#" -eq 15 ] || die "active quarantine round status arguments differ"
+    python3 - "$@" <<'PY'
+import datetime,hashlib,importlib.util,json,re,sys
+
+(capture,freeze,node,host,round_raw,auth_sha,readiness_sha,local_applied_sha,
+ boot,pid_raw,start_raw,cgroup_sha,applied_raw,status_raw,module_path)=sys.argv[1:]
+round_number=int(round_raw);pid=int(pid_raw);start=int(start_raw)
+canonical=lambda value:json.dumps(value,sort_keys=True,separators=(",",":"))
+digest=lambda raw:hashlib.sha256((raw+"\n").encode()).hexdigest()
+hash_re=re.compile(r"[0-9a-f]{64}")
+def parse(raw,label):
+    try:value=json.loads(raw)
+    except (UnicodeDecodeError,json.JSONDecodeError):raise SystemExit(f"{label} is invalid JSON")
+    if not isinstance(value,dict) or raw!=canonical(value):raise SystemExit(f"{label} is noncanonical")
+    return value
+applied=parse(applied_raw,"active quarantine applied receipt")
+spec=importlib.util.spec_from_file_location("arc_active_quarantine_rounds",module_path)
+if spec is None or spec.loader is None:
+    raise SystemExit("active quarantine validator module cannot be loaded")
+rounds=importlib.util.module_from_spec(spec);sys.modules[spec.name]=rounds
+spec.loader.exec_module(rounds)
+try:rounds.validate_node_applied(applied,authorization_sha256=auth_sha,node=node)
+except Exception as error:
+    raise SystemExit(f"active quarantine applied receipt is invalid: {error}") from error
+applied_fields={"schema","capture_id","freeze_plan_sha256","round_authorization_sha256",
+ "round_readiness_sha256","round_number","node","host","boot_id","writer_pid",
+ "writer_start_ticks","writer_cgroup_sha256","nft_policy_source_sha256",
+ "owned_ruleset_stateless_sha256","nft_applied_at","nft_deadline_gate",
+ "network_quarantine_receipt","network_quarantine_receipt_sha256","stable_head",
+ "authorization_ancestry_proof","persistent_restart_fence_sha256"}
+applied_sha=digest(applied_raw)
+if (set(applied)!=applied_fields
+        or applied.get("schema")!="arc.recovery.quarantine-node-nft-applied.v1"
+        or (applied.get("capture_id"),applied.get("freeze_plan_sha256"),
+            applied.get("round_number"),applied.get("round_authorization_sha256"),
+            applied.get("round_readiness_sha256"),applied.get("node"),applied.get("host"),
+            applied.get("boot_id"),applied.get("writer_pid"),
+            applied.get("writer_start_ticks"),applied.get("writer_cgroup_sha256"))
+            !=(capture,freeze,round_number,auth_sha,readiness_sha,node,host,
+               boot,pid,start,cgroup_sha)
+        or (local_applied_sha!="-" and local_applied_sha!=applied_sha)):
+    raise SystemExit("active quarantine applied receipt identity differs")
+for label in ("writer_cgroup_sha256","nft_policy_source_sha256",
+              "owned_ruleset_stateless_sha256","network_quarantine_receipt_sha256",
+              "persistent_restart_fence_sha256"):
+    if hash_re.fullmatch(str(applied.get(label))) is None:
+        raise SystemExit(f"active quarantine applied {label} differs")
+def unwrap(wrapper,label):
+    if not isinstance(wrapper,dict) or set(wrapper)!={"sha256","value"} \
+            or not isinstance(wrapper.get("value"),dict):
+        raise SystemExit(f"active quarantine {label} wrapper differs")
+    root=hashlib.sha256((canonical(wrapper["value"])+"\n").encode()).hexdigest()
+    if wrapper.get("sha256")!=root:raise SystemExit(f"active quarantine {label} root differs")
+    return wrapper["value"],root
+unwrap(applied["nft_deadline_gate"],"nft gate")
+network,network_sha=unwrap(applied["network_quarantine_receipt"],"network receipt")
+unwrap(applied["authorization_ancestry_proof"],"ancestry")
+if (network_sha!=applied["network_quarantine_receipt_sha256"]
+        or (network.get("capture_id"),network.get("freeze_plan_sha256"),
+            network.get("round_number"),network.get("round_authorization_sha256"),
+            network.get("round_readiness_sha256"),network.get("node"),network.get("host"))
+            !=(capture,freeze,round_number,auth_sha,readiness_sha,node,host)
+        or network.get("owned_ruleset_stateless_sha256")
+            !=applied["owned_ruleset_stateless_sha256"]):
+    raise SystemExit("active quarantine network receipt binding differs")
+head=applied.get("stable_head")
+if (not isinstance(head,dict) or set(head)!={"height","block_hash","state_root"}
+        or isinstance(head.get("height"),bool) or not isinstance(head.get("height"),int)
+        or head["height"]<1 or hash_re.fullmatch(str(head.get("block_hash"))) is None
+        or hash_re.fullmatch(str(head.get("state_root"))) is None):
+    raise SystemExit("active quarantine applied head differs")
+status=parse(status_raw,"active quarantine round status")
+status_fields={"schema","capture_id","freeze_plan_sha256","node","host",
+ "node_applied_receipt_sha256","observed_at","writer_state","boot_id","writer_pid",
+ "writer_start_ticks","writer_cgroup_sha256","network_quarantine_receipt_sha256",
+ "owned_ruleset_stateless_sha256","stable_head","active","enabled",
+ "persistent_restart_fence_sha256"}
+if (set(status)!=status_fields
+        or status.get("schema")!="arc.recovery.quarantine-prior-fenced-status.v1"
+        or (status.get("capture_id"),status.get("freeze_plan_sha256"),status.get("node"),
+            status.get("host"),status.get("node_applied_receipt_sha256"),
+            status.get("writer_state"),status.get("boot_id"),status.get("writer_pid"),
+            status.get("writer_start_ticks"),status.get("writer_cgroup_sha256"),
+            status.get("network_quarantine_receipt_sha256"),
+            status.get("owned_ruleset_stateless_sha256"),status.get("stable_head"),
+            status.get("persistent_restart_fence_sha256"),status.get("active"),
+            status.get("enabled"))!=(capture,freeze,node,host,applied_sha,
+                "exact-live-fenced",boot,pid,start,cgroup_sha,
+                applied["network_quarantine_receipt_sha256"],
+                applied["owned_ruleset_stateless_sha256"],head,None,True,True)):
+    raise SystemExit("active quarantine round status identity differs")
+try:datetime.datetime.strptime(status.get("observed_at",""),"%Y-%m-%dT%H:%M:%SZ")
+except ValueError:raise SystemExit("active quarantine round status time differs")
+print(applied_sha)
+PY
+}
+
+compare_active_quarantine_round_statuses() {
+    [ "$#" -eq 2 ] || die "active quarantine round comparison requires before and after"
+    python3 - "$1" "$2" <<'PY'
+import json,sys
+before,after=map(json.loads,sys.argv[1:])
+if any(before.get(label)!=after.get(label) for label in set(before)-{"observed_at"}):
+    raise SystemExit("active quarantine round changed during readiness proof")
+PY
+}
+
+stdin_sha256() {
+    python3 -c 'import hashlib,sys;print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())'
+}
+
+active_quarantine_applied_prestop_ready() {
+    [ "$#" -eq 5 ] || \
+        die "active quarantine readiness requires capture, freeze, plan, node, and round root"
+    local capture_id="$1" freeze_sha="$2" freeze_plan="$3" node="$4" round_root="$5"
+    local host pid start_ticks boot_id writer_cgroup_sha writer_supervision_mode unit
+    local executable_path exe_sha argv_sha data_dir model_path model_sha model_size
+    local candidates round authorization_sha readiness_sha local_applied_sha
+    local applied_raw applied_sha status_before status_after matches=0
+    local selected_applied selected_status selected_round selected_auth selected_readiness
+    host="$(host_for "$node")"
+    pid="$(freeze_node_field "$freeze_plan" "$node" writer_pid)"
+    start_ticks="$(freeze_node_field "$freeze_plan" "$node" writer_start_ticks)"
+    boot_id="$(freeze_node_field "$freeze_plan" "$node" boot_id)"
+    writer_cgroup_sha="$(freeze_node_field "$freeze_plan" "$node" writer_cgroup_sha256)"
+    writer_supervision_mode="$(freeze_node_field "$freeze_plan" "$node" writer_supervision_mode)"
+    unit="$(freeze_node_field "$freeze_plan" "$node" supervisor_unit)"
+    executable_path="$(freeze_node_field "$freeze_plan" "$node" executable_path)"
+    exe_sha="$(freeze_node_field "$freeze_plan" "$node" executable_sha256)"
+    argv_sha="$(freeze_node_field "$freeze_plan" "$node" argv_sha256)"
+    data_dir="$(freeze_node_field "$freeze_plan" "$node" data_dir)"
+    model_path="$(freeze_node_field "$freeze_plan" "$node" model_path)"
+    model_sha="$(freeze_node_field "$freeze_plan" "$node" model_sha256)"
+    model_size="$(freeze_node_field "$freeze_plan" "$node" model_size_bytes)"
+    if candidates="$(active_quarantine_round_candidates \
+            "$round_root" "$capture_id" "$freeze_sha" "$node")"; then
+        :
+    else
+        return 1
+    fi
+    [ -n "$candidates" ] || return 1
+    while read -r round authorization_sha readiness_sha local_applied_sha; do
+        [ -n "$round" ] || continue
+        applied_raw="$(run_remote "$node" quarantine-round-applied-status \
+            "$capture_id" "$node" "$freeze_sha" "$round" \
+            "$authorization_sha" "$readiness_sha" 2>/dev/null)" || continue
+        applied_sha="$(printf '%s\n' "$applied_raw" | stdin_sha256)" || continue
+        status_before="$(run_remote "$node" quarantine-round-status \
+            "$capture_id" "$node" "$freeze_sha" "$round" \
+            "$authorization_sha" "$readiness_sha" "$applied_sha" 2>/dev/null)" || continue
+        if ! validate_active_quarantine_round_status "$capture_id" "$freeze_sha" \
+                "$node" "$host" "$round" "$authorization_sha" "$readiness_sha" \
+                "$local_applied_sha" "$boot_id" "$pid" "$start_ticks" \
+                "$writer_cgroup_sha" "$applied_raw" "$status_before" \
+                "$QUARANTINE_ROUND_MODULE" >/dev/null 2>&1; then
+            continue
+        fi
+        matches=$((matches + 1))
+        [ "$matches" -eq 1 ] || return 1
+        selected_applied="$applied_raw"
+        selected_status="$status_before"
+        selected_round="$round"
+        selected_auth="$authorization_sha"
+        selected_readiness="$readiness_sha"
+    done <<< "$candidates"
+    [ "$matches" -eq 1 ] || return 1
+
+    ssh_remote_exact "$host" /bin/sh -c \
+        'set -eu; capture=$1 pid=$2 start=$3 boot=$4 writer_cgroup_sha=$5 writer_mode=$6 unit=$7 executable=$8 exe_sha=$9 argv_sha=${10} data=${11} model=${12} model_sha=${13} model_size=${14}; test "$(cat /proc/sys/kernel/random/boot_id)" = "$boot"; test -d "/proc/$pid"; test "$(awk '\''{print $22}'\'' "/proc/$pid/stat")" = "$start"; test "$(cat "/proc/$pid/comm")" = arc-node; test "$(pgrep -x arc-node)" = "$pid"; test "$(sha256sum "/proc/$pid/cgroup" | cut -d" " -f1)" = "$writer_cgroup_sha"; case "$writer_mode" in systemd-unit) grep -Fq "$unit" "/proc/$pid/cgroup";; detached-root-session) ! grep -Fq "$unit" "/proc/$pid/cgroup" && test "$(awk '\''{print $4}'\'' "/proc/$pid/stat")" = 1;; *) exit 1;; esac; test "$(readlink "/proc/$pid/exe")" = "$executable"; test "$(sha256sum "/proc/$pid/exe" | cut -d" " -f1)" = "$exe_sha"; test "$(sha256sum "/proc/$pid/cmdline" | cut -d" " -f1)" = "$argv_sha"; for source in arc-self-heal.service arc-node.service arc-node-update.service arc-node-update.timer; do active=$(systemctl show "$source" --property=ActiveState --value); job=$(systemctl show "$source" --property=Job --value); main=$(systemctl show "$source" --property=MainPID --value); main=${main:-0}; case "$active" in inactive|failed) :;; *) exit 1;; esac; case "$job" in ""|0) :;; *) exit 1;; esac; test "$main" = 0; done; test -d "$data" && test ! -L "$data" && test -s "$data/state.wal"; test -f "$model" && test ! -L "$model"; test "$(stat -c %s "$model")" = "$model_size"; test "$(sha256sum "$model" | cut -d" " -f1)" = "$model_sha"; command -v curl >/dev/null; command -v python3 >/dev/null; command -v sha256sum >/dev/null; command -v zstd >/dev/null; command -v tar >/dev/null; command -v systemctl >/dev/null; test ! -e /root/arc-recovery-captures || { test -d /root/arc-recovery-captures && test ! -L /root/arc-recovery-captures; }; { test ! -e "$capture" || { test -d "$capture" && test ! -L "$capture"; }; }; bytes=$(du -s -B1 "$data" | cut -f1); files=$(find "$data" -type f | wc -l); wal_bytes=$(stat -c %s "$data/state.wal"); snapshot_bytes=0; for snapshot in "$data/state.snapshot.lz4" "$data.snapshot.lz4"; do if test -f "$snapshot" && test ! -L "$snapshot"; then snapshot_bytes=$((snapshot_bytes + $(stat -c %s "$snapshot"))); fi; done; binding_bytes=$((wal_bytes + snapshot_bytes)); test "$binding_bytes" -ge "$bytes" || binding_bytes=$bytes; binding_bytes=$((binding_bytes + 2147483648)); required_bytes=$((bytes + binding_bytes)); required_inodes=$((files + 10000)); free_bytes=$(df -PB1 /root | awk '\''NR==2 {print $4}'\''); free_inodes=$(df -Pi /root | awk '\''NR==2 {print $4}'\''); test "$free_bytes" -ge "$required_bytes"; test "$free_inodes" -ge "$required_inodes"' \
+        /bin/sh "/root/arc-recovery-captures/$capture_id/$node" \
+        "$pid" "$start_ticks" "$boot_id" "$writer_cgroup_sha" \
+        "$writer_supervision_mode" "$unit" "$executable_path" \
+        "$exe_sha" "$argv_sha" "$data_dir" "$model_path" \
+        "$model_sha" "$model_size" >/dev/null 2>&1 || return 1
+    applied_sha="$(printf '%s\n' "$selected_applied" | stdin_sha256)" || return 1
+    status_after="$(run_remote "$node" quarantine-round-status \
+        "$capture_id" "$node" "$freeze_sha" "$selected_round" \
+        "$selected_auth" "$selected_readiness" "$applied_sha" 2>/dev/null)" || return 1
+    validate_active_quarantine_round_status "$capture_id" "$freeze_sha" \
+        "$node" "$host" "$selected_round" "$selected_auth" "$selected_readiness" \
+        - "$boot_id" "$pid" "$start_ticks" "$writer_cgroup_sha" \
+        "$selected_applied" "$status_after" "$QUARANTINE_ROUND_MODULE" \
+        >/dev/null 2>&1 || return 1
+    compare_active_quarantine_round_statuses \
+        "$selected_status" "$status_after" >/dev/null 2>&1
+}
+
 remote_readiness_node() {
     local capture_id="$1" freeze_sha="$2" freeze_plan="$3" node="$4"
+    local quarantine_round_root="$5"
     local host pid start_ticks boot_id writer_cgroup_sha writer_supervision_mode
     local unit unit_main_pid supervisor_start_ticks
     local supervisor_executable_path supervisor_executable_sha supervisor_argv_sha
@@ -5344,8 +5732,19 @@ remote_readiness_node() {
         printf '  exact live writer/disk ready: %s %s pid=%s data=%s\n' "$node" "$host" "$pid" "$data_dir"
         return 0
     fi
+    # A crashed capture can resume after a round's durable commit but before
+    # its local transition receipt or the original writer stop. Resolve only
+    # exact local dispatch roots; recover/validate the hash-bound remote
+    # applied receipt; and bracket the slow writer/content check with the
+    # existing round-status proof.
+    if active_quarantine_applied_prestop_ready "$capture_id" "$freeze_sha" \
+            "$freeze_plan" "$node" "$quarantine_round_root"; then
+        printf '  exact active applied-prestop quarantine/disk ready: %s %s pid=%s data=%s\n' \
+            "$node" "$host" "$pid" "$data_dir"
+        return 0
+    fi
     run_stopped_status_exact "$freeze_plan" "$freeze_sha" "$capture_id" "$node" >/dev/null || \
-        die "$node is neither the exact sealed live writer nor an exact persistently fenced stop"
+        die "$node is neither the exact sealed live writer, an exact active applied-prestop quarantine, nor an exact persistently fenced stop"
     local readiness_state=stopped
     if run_remote "$node" status "$capture_id" "$node" >/dev/null 2>&1; then
         readiness_state=captured
@@ -5358,8 +5757,10 @@ remote_readiness_node() {
 }
 
 remote_readiness() {
-    [ "$#" -eq 4 ] || die "remote readiness requires capture, freeze, plan, and log root"
+    [ "$#" -eq 5 ] || \
+        die "remote readiness requires capture, freeze, plan, log root, and round root"
     local capture_id="$1" freeze_sha="$2" freeze_plan="$3" log_root="$4"
+    local quarantine_round_root="$5"
     local readiness_log_root failed=0 index node
     local pids=() names=()
     [ -d "$log_root" ] && [ ! -L "$log_root" ] || \
@@ -5374,7 +5775,8 @@ remote_readiness() {
     # and stop the guarded phase with SIGTTIN.
     for node in nyc lax ams lhr nrt sgp; do
         (
-            remote_readiness_node "$capture_id" "$freeze_sha" "$freeze_plan" "$node"
+            remote_readiness_node "$capture_id" "$freeze_sha" "$freeze_plan" \
+                "$node" "$quarantine_round_root"
         ) </dev/null > "$readiness_log_root/$node.log" 2>&1 &
         pids+=("$!")
         names+=("$node")
@@ -5392,7 +5794,8 @@ remote_readiness() {
             /bin/cat -- "$readiness_log_root/$node.log" >&2
         fi
     done
-    [ "$failed" -eq 0 ] || die "one or more exact live/stopped readiness probes failed"
+    [ "$failed" -eq 0 ] || \
+        die "one or more exact live/active-quarantine/stopped readiness probes failed"
 }
 
 stop_after_quarantine_round_exact() {
@@ -9132,7 +9535,8 @@ PY
     # first-quarantine selection and its dual operator clocks are created.
     # Otherwise cold caches can consume the bounded 300-second lease before
     # every node has durably accepted the shared readiness artifact.
-    remote_readiness "$capture_id" "$freeze_sha" "$freeze_plan" "$log_root"
+    remote_readiness "$capture_id" "$freeze_sha" "$freeze_plan" "$log_root" \
+        "$maintenance_input_root/quarantine-rounds"
     observation_selection_sha="$(seal_live_observation_selection "$observation_selection" \
         "$observation_generation_receipt" "$live_observation_statuses" \
         "$freeze_sha" "$capture_id")"

--- a/scripts/recovery/archive-node.sh
+++ b/scripts/recovery/archive-node.sh
@@ -1549,7 +1549,8 @@ if state.exists() or state.is_symlink():
     if (state.is_symlink() or not stat.S_ISDIR(details.st_mode) or details.st_uid!=0
             or details.st_gid!=0 or stat.S_IMODE(details.st_mode)!=0o700):
         raise SystemExit("zero-progress apply state is unsafe")
-    allowed={"authorization.json":0o400,"readiness.json":0o400,"policy.nft":0o400,
+    allowed={"freeze.lock.json":0o400,"authorization.json":0o400,
+             "readiness.json":0o400,"policy.nft":0o400,
              "apply":0o500,"nft":0o500,"table-binding.json":0o400,
              "nft-apply-intent.json":0o400,"persistence-plan.json":0o400,
              "contract.json":0o400}
@@ -1560,7 +1561,7 @@ if state.exists() or state.is_symlink():
     # root-owned, single-link, bounded regular-file identity.  Anything else
     # remains a hard failure.
     partial_re=__import__("re").compile(
-        r"^\.(authorization\.json|readiness\.json|policy\.nft|apply|nft|"
+        r"^\.(freeze\.lock\.json|authorization\.json|readiness\.json|policy\.nft|apply|nft|"
         r"table-binding\.json|nft-apply-intent\.json|persistence-plan\.json|"
         r"contract\.json)\.([1-9][0-9]*)\.([0-9a-f]{16})\.partial$"
     )
@@ -1589,6 +1590,10 @@ if state.exists() or state.is_symlink():
             raise SystemExit("zero-progress apply-state member is unsafe")
     if (state/"authorization.json").exists() and load(state/"authorization.json","state authorization")[1]!=auth_raw:
         raise SystemExit("zero-progress apply-state authorization differs")
+    if (state/"freeze.lock.json").exists() and hashlib.sha256(
+            load(state/"freeze.lock.json","state freeze plan")[1]
+        ).hexdigest()!=freeze:
+        raise SystemExit("zero-progress apply-state freeze plan differs")
     if (state/"readiness.json").exists() and (readiness_raw is None
             or load(state/"readiness.json","state readiness")[1]!=readiness_raw):
         raise SystemExit("zero-progress apply-state readiness differs")
@@ -6913,6 +6918,11 @@ WantedBy=multi-user.target
 
     def persistence_file_roots(dispatcher, unit, dependencies):
         return {
+            "freeze_plan": {
+                "path": str(state / "freeze.lock.json"),
+                "sha256": freeze_sha,
+                "mode": 0o400,
+            },
             "dispatcher": {"path": str(dispatcher_path), "sha256": sha(dispatcher),
                            "mode": 0o500},
             "unit": {"path": str(unit_path), "sha256": sha(unit), "mode": 0o400},
@@ -8572,10 +8582,12 @@ WantedBy=multi-user.target
             fail("fresh stopped durable intent/plan/barrier bytes differ")
         plan_files = plan.get("files")
         if not isinstance(plan_files, dict) or set(plan_files) != {
-                "dispatcher", "unit", "dependencies"
-            }:
+                    "freeze_plan", "dispatcher", "unit", "dependencies"
+                }:
             fail("fresh stopped persistence file inventory differs")
-        file_rows = [plan_files["dispatcher"], plan_files["unit"]]
+        file_rows = [
+            plan_files["freeze_plan"], plan_files["dispatcher"], plan_files["unit"]
+        ]
         dependencies_rows = plan_files.get("dependencies")
         if not isinstance(dependencies_rows, list):
             fail("fresh stopped dependency inventory differs")
@@ -8887,10 +8899,10 @@ WantedBy=multi-user.target
                 fail("applied legacy restart allow path exists")
             files = plan.get("files")
             if not isinstance(files, dict) or set(files) != {
-                    "dispatcher", "unit", "dependencies"
+                    "freeze_plan", "dispatcher", "unit", "dependencies"
                 }:
                 fail("applied persistence file inventory differs")
-            rows = [files["dispatcher"], files["unit"]]
+            rows = [files["freeze_plan"], files["dispatcher"], files["unit"]]
             if not isinstance(files.get("dependencies"), list):
                 fail("applied persistence dependency inventory differs")
             rows.extend(files["dependencies"])
@@ -9927,7 +9939,9 @@ if local_writer!=contract["writer"] or local[0].get("host")!=contract["host"]:fa
 def enforce_monotonic_lease():
  accepted=local_acceptance[0];accepted_ns=accepted.get("accepted_monotonic_ns");accepted_boot=accepted.get("accepted_boot_id");current_boot=pathlib.Path("/proc/sys/kernel/random/boot_id").read_text().strip();current_ns=time.clock_gettime_ns(time.CLOCK_BOOTTIME);lease=ready["max_elapsed_since_acceptance_ns"]
  if accepted_boot!=contract["writer"]["boot_id"] or current_boot!=accepted_boot or isinstance(accepted_ns,bool) or not isinstance(accepted_ns,int) or current_ns<accepted_ns or current_ns-accepted_ns>lease:fail("quarantine monotonic mutation lease expired")
-plan_path=pathlib.Path(f"/root/.arc-recovery-plans/{contract['freeze_plan_sha256']}/freeze.lock.json");plan_raw=read(plan_path,0o400);plan=json.loads(plan_raw)
+plan_path=pathlib.Path(contract.get("freeze_plan_path",""))
+if plan_path!=STATE/"freeze.lock.json":fail("quarantine helper freeze-plan path differs")
+plan_raw=read(plan_path,0o400);plan=json.loads(plan_raw)
 if sha(plan_raw)!=contract["freeze_plan_sha256"] or canonical(plan)!=plan_raw or plan.get("source_commit")!=contract["source_main_commit"]:fail("freeze/source changed at nft gate")
 nft=STATE/"nft";policy=read(STATE/"policy.nft",0o400);rendered=policy.replace(b"__ARC_TABLE_COMMENT__",contract["table_comment"].encode())
 if rendered==policy or rendered.count(contract["table_comment"].encode())!=1:fail("rendered nft policy binding differs")
@@ -10032,6 +10046,77 @@ publish(commit_path,canonical(commit),0o400);result(commit)
     nft_raw = tool_bytes(nft_system)
     nft_sha = sha(nft_raw)
 
+    def load_postcommit_reconciliation():
+        """Return an exact durable commit eligible for receipt reconciliation.
+
+        This is deliberately narrower than the initial apply path.  A durable,
+        hash-bound commit proves the deadline-gated kernel mutation already
+        happened; only then may a retry proceed without the now-inactive
+        supervisor or the expired readiness lease.  Missing or changed STATE
+        inputs fail closed before any systemd or nft operation.
+        """
+        commit_path = state / "applied.commit.json"
+        if not commit_path.exists() and not commit_path.is_symlink():
+            return None
+        secure_dir(state_base.parent, 0o700)
+        secure_dir(state_base, 0o700)
+        secure_dir(state_base / capture_id, 0o700)
+        secure_dir(state, 0o700)
+        persisted_freeze_raw = secure_read(state / "freeze.lock.json", 0o400)
+        if (sha(persisted_freeze_raw) != freeze_sha
+                or parse_canonical(
+                    persisted_freeze_raw, "postcommit persisted freeze plan"
+                ) != plan):
+            fail("postcommit persisted freeze-plan copy differs")
+        commit_raw = secure_read(commit_path, 0o400)
+        commit = parse_canonical(commit_raw, "postcommit applied commit")
+        expected = {
+            "schema": APPLIED_COMMIT_SCHEMA,
+            "capture_id": capture_id, "freeze_plan_sha256": freeze_sha,
+            "round_number": round_number,
+            "round_authorization_sha256": authorization_sha,
+            "round_readiness_sha256": readiness_sha,
+            "node": node, "host": FLEET_MAP[node],
+            "table_binding_sha256": table_binding_sha,
+            "table_comment": table_comment,
+            "apply_helper_sha256": helper_sha,
+            "nft_policy_source_sha256": policy_sha,
+        }
+        if (set(commit) != set(expected) | {
+                "nft_deadline_gate_sha256", "owned_ruleset_stateless_sha256",
+                "nft_applied_at",
+            } or any(commit.get(key) != value for key, value in expected.items())
+                or HASH_RE.fullmatch(str(
+                    commit.get("owned_ruleset_stateless_sha256")
+                )) is None):
+            fail("postcommit applied commit binding differs")
+        gate_raw = secure_read(state / "nft-deadline-gate.json", 0o400)
+        gate = parse_canonical(gate_raw, "postcommit nft deadline gate")
+        gate_expected = {
+            "schema": GATE_SCHEMA, "capture_id": capture_id,
+            "freeze_plan_sha256": freeze_sha,
+            "round_authorization_sha256": authorization_sha,
+            "round_readiness_sha256": readiness_sha,
+            "round_number": round_number, "node": node,
+            "host": FLEET_MAP[node],
+            "authorization_deadline": auth["authorization_deadline"],
+            "apply_helper_sha256": helper_sha, "policy_sha256": policy_sha,
+            "table_binding_sha256": table_binding_sha,
+            "table_comment": table_comment,
+        }
+        if (set(gate) != set(gate_expected) | {"invoked_at"}
+                or any(gate.get(key) != value
+                       for key, value in gate_expected.items())
+                or commit.get("nft_deadline_gate_sha256") != sha(gate_raw)
+                or commit.get("nft_applied_at") != gate.get("invoked_at")):
+            fail("postcommit nft deadline gate binding differs")
+        parse_utc(gate.get("invoked_at"), "postcommit nft deadline gate")
+        selector_value = (str(state) + "\n").encode()
+        if ((active_path.exists() or active_path.is_symlink())
+                and secure_read(active_path, 0o400) != selector_value):
+            fail("postcommit active selector belongs to another round")
+        return commit_raw, commit
+
     def system_table_comment():
         exists_result = subprocess.run(
             [str(nft_system), "list", "table", "inet", table_name],
@@ -10048,18 +10133,34 @@ publish(commit_path,canonical(commit),0o400);result(commit)
             fail("preexisting quarantine table identity is ambiguous")
         return rows[0].get("comment")
 
+    postcommit = load_postcommit_reconciliation()
+
     # Expired attempts with no exact kernel mutation stop here, before any
     # /etc, systemd, STOP_BASE, or nft write.  An exact table is allowed through
     # solely so the post-kernel/pre-receipt crash can be reconciled.
     existing_comment = system_table_comment()
     if existing_comment is None:
-        enforce_monotonic_mutation_lease(readiness, acceptance, target, "apply entry")
-        verify_writer(target)
+        if postcommit is None:
+            enforce_monotonic_mutation_lease(
+                readiness, acceptance, target, "apply entry"
+            )
+            verify_writer(target)
     elif existing_comment != table_comment:
         fail("a nonmatching quarantine table already owns the host")
 
     secure_dir(state_base.parent, 0o700, create=True)
     create_hierarchy(state_base, capture_id, authorization_sha)
+    # The persistent fence keeps ProtectHome=yes.  Materialize the already
+    # hash-verified plan inside the attempt's protected /etc state before any
+    # systemd/drop-in mutation, so boot-time ensure never depends on masked
+    # home-directory bytes.
+    freeze_plan_raw = secure_read(
+        pathlib.Path(f"/root/.arc-recovery-plans/{freeze_sha}/freeze.lock.json"),
+        0o400,
+    )
+    if sha(freeze_plan_raw) != freeze_sha:
+        fail("persistence freeze-plan source hash differs")
+    publish(state / "freeze.lock.json", freeze_plan_raw, 0o400)
     publish(state / "authorization.json", auth_raw, 0o400)
     publish(state / "readiness.json", readiness_raw, 0o400)
     publish(state / "policy.nft", policy_template, 0o400)
@@ -10163,6 +10264,7 @@ publish(commit_path,canonical(commit),0o400);result(commit)
         "persistence_plan_sha256": persistence_plan_sha,
         "pinned_nft_sha256": nft_sha,
         "round_artifact_path": str(attempt),
+        "freeze_plan_path": str(state / "freeze.lock.json"),
         "state_path": str(state),
     }
     publish(state / "contract.json", canonical(contract), 0o400)
@@ -10171,15 +10273,23 @@ publish(commit_path,canonical(commit),0o400);result(commit)
     # fence.  The generic unit therefore exists before the nft batch but has no
     # active selector until an applied.commit is durable.  Its ensure command
     # fails closed while the selector is absent.
-    verify_supervisor(frozen, target)
+    if postcommit is None:
+        verify_supervisor(frozen, target)
+    else:
+        # The applied commit is the completed mutation authority.  The
+        # persistence drop-ins intentionally deactivate the old supervisor,
+        # but the exact original writer must remain alive while its missing
+        # network/ancestry/node-applied receipts are reconstructed.
+        verify_writer(target)
     legacy_start_allow = pathlib.Path(
         persistence_plan["legacy_start_allow_path"]
     )
     if legacy_start_allow.exists() or legacy_start_allow.is_symlink():
         fail("quarantine-round legacy restart allow path unexpectedly exists")
-    enforce_monotonic_mutation_lease(
-        readiness, acceptance, target, "first restart-effective mutation"
-    )
+    if postcommit is None:
+        enforce_monotonic_mutation_lease(
+            readiness, acceptance, target, "first restart-effective mutation"
+        )
     secure_dir(pathlib.Path("/etc/arc-recovery"), 0o700)
     # The selected frozen supervisor dependency is first in insertion order.
     # A crash after this or any later prefix leaves boot activation fail-closed.
@@ -10239,10 +10349,14 @@ publish(commit_path,canonical(commit),0o400);result(commit)
 
     # Re-prove the exact live supervisor plus direct/detached writer immediately
     # before the only initial kernel mutation.
-    verify_supervisor(frozen, target)
+    if postcommit is None:
+        verify_supervisor(frozen, target)
     # The pinned helper owns the exact gate -> nft -> applied.commit sequence.
     # It is the sole command below that may call nft -f.
-    commit_raw = subprocess.check_output([str(state / "apply"), "initial"])
+    helper_mode = "initial"
+    if postcommit is not None:
+        helper_mode = "probe" if existing_comment is not None else "ensure"
+    commit_raw = subprocess.check_output([str(state / "apply"), helper_mode])
     commit = parse_canonical(commit_raw, "quarantine nft applied commit")
     if (commit.get("schema") != APPLIED_COMMIT_SCHEMA
             or commit.get("round_authorization_sha256") != authorization_sha
@@ -10253,6 +10367,8 @@ publish(commit_path,canonical(commit),0o400);result(commit)
     durable_commit_raw = secure_read(state / "applied.commit.json", 0o400)
     if durable_commit_raw != commit_raw:
         fail("quarantine nft applied commit stdout differs from durable bytes")
+    if postcommit is not None and durable_commit_raw != postcommit[0]:
+        fail("postcommit applied commit changed during reconciliation")
     gate_raw = secure_read(state / "nft-deadline-gate.json", 0o400)
     gate = parse_canonical(gate_raw, "quarantine nft deadline gate")
     if sha(gate_raw) != commit.get("nft_deadline_gate_sha256"):

--- a/scripts/recovery/quarantine_rounds.py
+++ b/scripts/recovery/quarantine_rounds.py
@@ -1763,7 +1763,7 @@ def validate_node_applied(
         "nft-apply-intent.json", "policy.nft", "apply", "nft",
         "nft-deadline-gate.json", "applied.commit.json",
         "persistent-restart-fence.json", "rendered-policy.nft",
-        "/usr/local/libexec/arc-legacy-maintenance-fence",
+        "/etc/arc-recovery/network-fence-dispatch",
         "/etc/systemd/system/arc-legacy-maintenance-fence.service",
         "/etc/systemd/system/arc-self-heal.service.d/zzzy-arc-recovery-network-fence.conf",
         "/etc/systemd/system/arc-node.service.d/zzzy-arc-recovery-network-fence.conf",
@@ -2200,15 +2200,26 @@ def validate_node_stopped_precommit(
     ):
         require_hash(supervisor.get(key), f"persistently-stopped supervisor {key}")
     files = plan.get("files")
-    if not isinstance(files, dict) or set(files) != {"dispatcher", "unit", "dependencies"}:
+    if not isinstance(files, dict) or set(files) != {
+        "freeze_plan", "dispatcher", "unit", "dependencies"
+    }:
         fail("persistently-stopped persistence file inventory differs")
+    freeze_plan_file = files.get("freeze_plan")
     dispatcher = files.get("dispatcher")
     unit = files.get("unit")
     dependencies = files.get("dependencies")
     if (
-        not isinstance(dispatcher, dict)
+        not isinstance(freeze_plan_file, dict)
+        or set(freeze_plan_file) != {"path", "sha256", "mode"}
+        or freeze_plan_file.get("path") != (
+            f"/etc/arc-recovery/network-fence-rounds/{capture}/{auth_sha}/"
+            "freeze.lock.json"
+        )
+        or freeze_plan_file.get("sha256") != freeze
+        or freeze_plan_file.get("mode") != 0o400
+        or not isinstance(dispatcher, dict)
         or set(dispatcher) != {"path", "sha256", "mode"}
-        or dispatcher.get("path") != "/usr/local/libexec/arc-legacy-maintenance-fence"
+        or dispatcher.get("path") != "/etc/arc-recovery/network-fence-dispatch"
         or dispatcher.get("mode") != 0o500
         or not isinstance(unit, dict)
         or set(unit) != {"path", "sha256", "mode"}

--- a/scripts/recovery/test_archive_node_quarantine_runtime.py
+++ b/scripts/recovery/test_archive_node_quarantine_runtime.py
@@ -102,6 +102,7 @@ class FakeRuntime:
     boot: int = 1
     sealed_boot: int = 1
     intent: bool = False
+    freeze_copy: bool = False
     persistence_plan: bool = False
     persistence_files: int = 0
     persistence_file_total: int = 6
@@ -130,14 +131,16 @@ class FakeRuntime:
         if self.now > self.deadline and not self.table and not self.commit:
             raise TimeoutError("expired before mutation")
         order = (
-            "intent", "persistence-plan", "supervisor-dropin", "dropin-2",
+            "freeze-copy", "intent", "persistence-plan", "supervisor-dropin", "dropin-2",
             "dropin-3", "dropin-4", "dispatcher", "unit", "daemon-reload",
             "enable", "sync", "barrier", "gate", "nft", "commit",
             "selector", "unit-start",
         )
         target = order.index(name)
         for index, step in enumerate(order[: target + 1]):
-            if step == "intent":
+            if step == "freeze-copy":
+                self.freeze_copy = True
+            elif step == "intent":
                 self.intent = True
             elif step == "persistence-plan":
                 self.persistence_plan = True
@@ -204,6 +207,14 @@ class FakeRuntime:
             self.commit = True
             return True
         return False
+
+    def reconcile_postcommit_receipts(self) -> None:
+        if (not self.commit or not self.freeze_copy or not self.roots_exact
+                or not self.writer_live):
+            raise RuntimeError("exact committed state and original writer required")
+        self.ensure()
+        self.selector = True
+        self.service = True
 
     def stopped_candidate(self) -> bool:
         return (
@@ -774,7 +785,7 @@ class EmbeddedProgramTests(unittest.TestCase):
         for token in (
             "secure_dir(state_base.parent, 0o700, create=True)",
             "systemctl\", \"daemon-reload",
-            "subprocess.check_output([str(state / \"apply\"), \"initial\"])",
+            "commit_raw = subprocess.check_output([str(state / \"apply\"), helper_mode])",
         ):
             self.assertGreater(self.outer.index(token), ready)
 
@@ -841,6 +852,108 @@ class EmbeddedProgramTests(unittest.TestCase):
             self.assertIn(call, self.outer)
         self.assertNotIn("secure_dir(dependency.parent, 0o755", self.outer)
         self.assertNotIn("secure_dir(path.parent, 0o755", self.outer)
+
+    def test_protected_service_uses_only_hash_bound_state_freeze_plan(self) -> None:
+        payloads = self.outer[
+            self.outer.index("def persistence_payloads():"):
+            self.outer.index("def persistence_file_roots(")
+        ]
+        self.assertIn("ProtectHome=yes", payloads)
+        self.assertNotIn("ProtectHome=read-only", payloads)
+        self.assertNotIn("/root/.arc-recovery-plans", self.helper)
+        self.assertIn(
+            'if plan_path!=STATE/"freeze.lock.json":fail(', self.helper
+        )
+        self.assertIn('plan_raw=read(plan_path,0o400)', self.helper)
+        roots = self.outer[
+            self.outer.index("def persistence_file_roots("):
+            self.outer.index('if mode in {"precommit-status", "stopped-precommit"}:')
+        ]
+        for required in (
+            '"freeze_plan"', '"path": str(state / "freeze.lock.json")',
+            '"sha256": freeze_sha', '"mode": 0o400',
+        ):
+            self.assertIn(required, roots)
+        copy_at = self.outer.index('publish(state / "freeze.lock.json", freeze_plan_raw, 0o400)')
+        persistence_at = self.outer.index(
+            "for dependency, dependency_value in dependencies.items():", copy_at
+        )
+        unit_at = self.outer.index("publish(unit_path, unit_value, 0o400)", persistence_at)
+        self.assertLess(copy_at, persistence_at)
+        self.assertLess(copy_at, unit_at)
+
+    def test_helper_freeze_copy_missing_or_tampered_fails_closed(self) -> None:
+        tree = ast.parse(self.helper)
+        start = next(
+            index for index,node in enumerate(tree.body)
+            if isinstance(node, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "plan_path"
+                    for target in node.targets)
+        )
+        end = next(
+            index for index,node in enumerate(tree.body[start:], start)
+            if isinstance(node, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "nft"
+                    for target in node.targets)
+        )
+        fragment = ast.Module(body=tree.body[start:end], type_ignores=[])
+
+        class CopyError(RuntimeError):
+            pass
+
+        def fail(message: str) -> None:
+            raise CopyError(message)
+
+        with tempfile.TemporaryDirectory() as raw:
+            state = pathlib.Path(raw)
+            source = {"source_commit": "a" * 40}
+            canonical = lambda value: (
+                json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n"
+            ).encode()
+            contract = {
+                "freeze_plan_path": str(state / "freeze.lock.json"),
+                "freeze_plan_sha256": hashlib.sha256(canonical(source)).hexdigest(),
+                "source_main_commit": source["source_commit"],
+            }
+
+            def execute() -> None:
+                namespace = {
+                    "STATE": state, "pathlib": pathlib, "contract": contract,
+                    "json": json, "sha": lambda value: hashlib.sha256(value).hexdigest(),
+                    "canonical": canonical, "fail": fail,
+                    "read": lambda path,_mode: path.read_bytes(),
+                }
+                exec(compile(fragment, "helper-freeze-copy", "exec"), namespace)
+
+            with self.assertRaises(FileNotFoundError):
+                execute()
+            (state / "freeze.lock.json").write_bytes(canonical({"source_commit": "b" * 40}))
+            with self.assertRaisesRegex(CopyError, "freeze/source changed"):
+                execute()
+            (state / "freeze.lock.json").write_bytes(canonical(source))
+            execute()
+
+    def test_postcommit_reconciliation_never_reenters_initial_window(self) -> None:
+        reconciliation = self.outer[
+            self.outer.index("def load_postcommit_reconciliation():"):
+            self.outer.index("origin = urllib.parse.urlsplit", self.outer.index(
+                "def load_postcommit_reconciliation():"
+            ))
+        ]
+        for required in (
+            'persisted_freeze_raw = secure_read(state / "freeze.lock.json", 0o400)',
+            'verify_writer(target)',
+            'helper_mode = "probe" if existing_comment is not None else "ensure"',
+            'durable_commit_raw != postcommit[0]',
+        ):
+            self.assertIn(required, reconciliation)
+        postcommit_helper = reconciliation[
+            reconciliation.index('helper_mode = "initial"'):
+            reconciliation.index("commit = parse_canonical", reconciliation.index(
+                'helper_mode = "initial"'
+            ))
+        ]
+        self.assertNotIn('[str(state / "apply"), "initial"]', postcommit_helper)
 
     def test_nft_json_verification_requests_numeric_icmpv6_values(self) -> None:
         tree = ast.parse(self.helper)
@@ -1050,6 +1163,27 @@ class FakeCrashMatrixTests(unittest.TestCase):
         self.assertFalse(value.writer_live)
         self.assertTrue(value.ensure())
         self.assertTrue(value.table)
+
+    def test_expired_postcommit_resume_needs_no_old_supervisor_or_lease(self) -> None:
+        value = self.runtime()
+        value.prefix("commit")
+        value.supervisor_live = False
+        value.now = 10_000
+        value.reconcile_postcommit_receipts()
+        self.assertTrue(value.table and value.selector and value.service)
+
+    def test_postcommit_resume_rejects_missing_or_changed_freeze_copy(self) -> None:
+        for mutate in (
+            lambda value: setattr(value, "freeze_copy", False),
+            lambda value: setattr(value, "roots_exact", False),
+        ):
+            value = self.runtime()
+            value.prefix("commit")
+            value.supervisor_live = False
+            value.now = 10_000
+            mutate(value)
+            with self.assertRaisesRegex(RuntimeError, "exact committed state"):
+                value.reconcile_postcommit_receipts()
 
     def test_wrong_root_fails_before_mutation(self) -> None:
         value = self.runtime()

--- a/scripts/recovery/test_build_production_manifest.py
+++ b/scripts/recovery/test_build_production_manifest.py
@@ -1078,7 +1078,7 @@ print(json.dumps(value,sort_keys=True))
                     "applied.commit.json": builder.quarantine_rounds.digest(round_commit),
                     "persistent-restart-fence.json": round_restart_sha,
                     "rendered-policy.nft": f"{index + 215:064x}",
-                    "/usr/local/libexec/arc-legacy-maintenance-fence": f"{index + 216:064x}",
+                    "/etc/arc-recovery/network-fence-dispatch": f"{index + 216:064x}",
                     "/etc/systemd/system/arc-legacy-maintenance-fence.service": f"{index + 217:064x}",
                     "/etc/systemd/system/arc-self-heal.service.d/zzzy-arc-recovery-network-fence.conf": f"{index + 218:064x}",
                     "/etc/systemd/system/arc-node.service.d/zzzy-arc-recovery-network-fence.conf": f"{index + 219:064x}",

--- a/scripts/recovery/test_quarantine_rounds.py
+++ b/scripts/recovery/test_quarantine_rounds.py
@@ -716,7 +716,7 @@ def applied(auth: dict, name: str, second: int, height: int) -> dict:
         "applied.commit.json": qr.digest(applied_commit),
         "persistent-restart-fence.json": restart_sha,
         "rendered-policy.nft": H["22"],
-        "/usr/local/libexec/arc-legacy-maintenance-fence": H["23"],
+        "/etc/arc-recovery/network-fence-dispatch": H["23"],
         "/etc/systemd/system/arc-legacy-maintenance-fence.service": H["24"],
         "/etc/systemd/system/arc-self-heal.service.d/zzzy-arc-recovery-network-fence.conf": H["25"],
         "/etc/systemd/system/arc-node.service.d/zzzy-arc-recovery-network-fence.conf": H["26"],

--- a/scripts/recovery/test_recovery_rollout.py
+++ b/scripts/recovery/test_recovery_rollout.py
@@ -1480,7 +1480,7 @@ class RecoveryRolloutTests(unittest.TestCase):
                 "applied.commit.json": sha_value(applied_commit),
                 "persistent-restart-fence.json": restart_sha,
                 "rendered-policy.nft": f"{index + 3800:064x}",
-                "/usr/local/libexec/arc-legacy-maintenance-fence": f"{index + 3900:064x}",
+                "/etc/arc-recovery/network-fence-dispatch": f"{index + 3900:064x}",
                 "/etc/systemd/system/arc-legacy-maintenance-fence.service": f"{index + 4000:064x}",
                 "/etc/systemd/system/arc-self-heal.service.d/zzzy-arc-recovery-network-fence.conf": f"{index + 4100:064x}",
                 "/etc/systemd/system/arc-node.service.d/zzzy-arc-recovery-network-fence.conf": f"{index + 4200:064x}",

--- a/tests/release/recovery_archive_contract_test.sh
+++ b/tests/release/recovery_archive_contract_test.sh
@@ -107,7 +107,8 @@ boundary=b.index('create_legacy_maintenance_boundary')
 offline=b.index('create_offline_stop_evidence')
 assert (b.index('capture_all_live_observations') < late_sample < height_cross
         < fresh_capacity < selection < selection_clocks < rounds < first_boundary)
-assert ('remote_readiness "$capture_id" "$freeze_sha" "$freeze_plan" "$log_root"\n'
+assert ('remote_readiness "$capture_id" "$freeze_sha" "$freeze_plan" "$log_root" \\\n'
+        '        "$maintenance_input_root/quarantine-rounds"\n'
         '    observation_selection_sha="$(seal_live_observation_selection' in b)
 assert first_boundary < stop < capture < persisted < boundary < offline
 assert 'ALL SIX CONTROLLED WRITERS HALTED' in b and 'no global halt is claimed' in b
@@ -1095,9 +1096,229 @@ capture_readiness_resumes_stopped_and_indexed_nodes() (
         esac
     }
     remote_readiness "$(printf 'b%.0s' {1..64})" "$(printf 'a%.0s' {1..64})" \
-        /sealed/freeze.json "$f" >/dev/null || return 1
+        /sealed/freeze.json "$f" "$f/absent-rounds" >/dev/null || return 1
     grep -Fq 'nyc stopped-status' "$f/actions" && grep -Fq 'nyc status' "$f/actions" && \
         grep -Fq 'lax stopped-status' "$f/actions" && grep -Fq 'lax status' "$f/actions"
+)
+
+make_active_quarantine_resume_fixture() {
+    local root="$1"
+    python3 - "$root" "$(dirname -- "$ORCHESTRATOR")/test_quarantine_rounds.py" <<'PY'
+import importlib.util,os,pathlib,sys
+root=pathlib.Path(sys.argv[1]);module_path=pathlib.Path(sys.argv[2])
+spec=importlib.util.spec_from_file_location("active_resume_fixture",module_path)
+fixture=importlib.util.module_from_spec(spec);spec.loader.exec_module(fixture)
+names=[name for name,_host in fixture.qr.FLEET]
+authorization=fixture.authorization(1,[],names,0)
+readiness=fixture.target_readiness(authorization)
+dispatch=fixture.mutation_dispatch(authorization,readiness)
+attempt=root/"rounds"/"round-1"/"attempt.fixture"
+applied_root=root/"applied"
+attempt.mkdir(parents=True);applied_root.mkdir()
+for directory in (root/"rounds",attempt.parent,attempt,applied_root):
+    os.chmod(directory,0o700)
+for name,value in (
+    ("authorization.json",authorization),
+    ("readiness.json",readiness),
+    ("mutation-dispatch.json",dispatch),
+):
+    path=attempt/name;path.write_bytes(fixture.qr.canonical_bytes(value));os.chmod(path,0o400)
+for index,name in enumerate(names):
+    value=fixture.applied(
+        authorization,name,20+index,fixture.authorized_height(authorization,name)
+    )
+    path=applied_root/f"{name}.json"
+    path.write_bytes(fixture.qr.canonical_bytes(value));os.chmod(path,0o400)
+PY
+}
+
+active_quarantine_test_host_for() {
+    case "$1" in
+        nyc) printf '149.28.32.76\n' ;; lax) printf '140.82.16.112\n' ;;
+        ams) printf '136.244.109.1\n' ;; lhr) printf '104.238.171.11\n' ;;
+        nrt) printf '202.182.107.41\n' ;; sgp) printf '149.28.153.31\n' ;;
+        *) return 1 ;;
+    esac
+}
+
+active_quarantine_test_freeze_field() {
+    local node="$2" field="$3" index
+    case "$node" in
+        nyc) index=1 ;; lax) index=2 ;; ams) index=3 ;;
+        lhr) index=4 ;; nrt) index=5 ;; sgp) index=6 ;; *) return 1 ;;
+    esac
+    case "$field" in
+        writer_pid) printf '%s\n' "$((1000 + index))" ;;
+        writer_start_ticks) printf '%s\n' "$((2000 + index))" ;;
+        supervisor_main_pid|supervisor_start_ticks) printf '%s\n' "$((3000 + index))" ;;
+        boot_id) printf '00000000-0000-0000-0000-%012d\n' "$index" ;;
+        writer_supervision_mode) printf 'systemd-unit\n' ;;
+        supervisor_unit) printf 'arc-node.service\n' ;;
+        executable_path|supervisor_executable_path|data_dir|model_path)
+            printf '/safe/%s/%s\n' "$node" "$field" ;;
+        executable_sha256|argv_sha256|supervisor_executable_sha256|supervisor_argv_sha256|model_sha256)
+            printf 'a%.0s' {1..64}; printf '\n' ;;
+        writer_cgroup_sha256) printf '%064x\n' "$((10 + index))" ;;
+        model_size_bytes) printf '4081004224\n' ;;
+        *) return 1 ;;
+    esac
+}
+
+active_quarantine_test_ssh() {
+    local host="$1"
+    if [ ! -e "$f/$host-live-classifier" ]; then
+        : > "$f/$host-live-classifier"
+        return 1
+    fi
+    printf '%s\n' "$host" >> "$f/active-content-probes"
+}
+
+active_quarantine_test_run_remote() {
+    local node="$1" action="$2" active_mode="${mode:-valid}"
+    printf '%s %s\n' "$node" "$action" >> "$f/actions"
+    case "$action" in
+        quarantine-round-applied-status)
+            python3 - "$f/applied/$node.json" "$active_mode" <<'PY'
+import json,pathlib,sys
+value=json.loads(pathlib.Path(sys.argv[1]).read_bytes());mode=sys.argv[2]
+if mode=="wrong-capture":value["capture_id"]="9"*64
+elif mode=="wrong-freeze":value["freeze_plan_sha256"]="8"*64
+elif mode=="malformed-applied":value["owned_ruleset_stateless_sha256"]="not-a-hash"
+print(json.dumps(value,sort_keys=True,separators=(",",":")))
+PY
+            ;;
+        quarantine-round-status)
+            local count=0
+            [ ! -f "$f/$node-status-count" ] || count="$(cat "$f/$node-status-count")"
+            count=$((count + 1)); printf '%s\n' "$count" > "$f/$node-status-count"
+            python3 - "$f/applied/$node.json" "$active_mode" <<'PY'
+import hashlib,json,pathlib,sys
+value=json.loads(pathlib.Path(sys.argv[1]).read_bytes());mode=sys.argv[2]
+if mode=="wrong-capture":value["capture_id"]="9"*64
+elif mode=="wrong-freeze":value["freeze_plan_sha256"]="8"*64
+elif mode=="malformed-applied":value["owned_ruleset_stateless_sha256"]="not-a-hash"
+raw=(json.dumps(value,sort_keys=True,separators=(",",":"))+"\n").encode()
+status={"schema":"arc.recovery.quarantine-prior-fenced-status.v1",
+ "capture_id":value["capture_id"],"freeze_plan_sha256":value["freeze_plan_sha256"],
+ "node":value["node"],"host":value["host"],
+ "node_applied_receipt_sha256":hashlib.sha256(raw).hexdigest(),
+ "observed_at":"2026-08-31T12:01:00Z","writer_state":"exact-live-fenced",
+ "boot_id":value["boot_id"],"writer_pid":value["writer_pid"],
+ "writer_start_ticks":value["writer_start_ticks"],
+ "writer_cgroup_sha256":value["writer_cgroup_sha256"],
+ "network_quarantine_receipt_sha256":value["network_quarantine_receipt_sha256"],
+ "owned_ruleset_stateless_sha256":value["owned_ruleset_stateless_sha256"],
+ "stable_head":value["stable_head"],"active":True,"enabled":True,
+ "persistent_restart_fence_sha256":None}
+if mode=="wrong-status":status["writer_state"]="persistently-stopped"
+print(json.dumps(status,sort_keys=True,separators=(",",":")))
+PY
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+capture_readiness_resumes_active_applied_prestop_nodes() (
+    # shellcheck source=/dev/null
+    . "$ORCHESTRATOR" >/dev/null
+    local f capture_id freeze_sha node mode=valid
+    f="$(mktemp -d)"; trap 'rm -rf -- "$f"' EXIT
+    capture_id="$(printf '0%.0s' {1..63})1"
+    freeze_sha="$(printf '0%.0s' {1..63})2"
+    make_active_quarantine_resume_fixture "$f"
+    # shellcheck disable=SC2317,SC2329
+    host_for() { active_quarantine_test_host_for "$@"; }
+    # shellcheck disable=SC2317,SC2329
+    freeze_node_field() { active_quarantine_test_freeze_field "$@"; }
+    # shellcheck disable=SC2317,SC2329
+    ssh_remote_exact() { active_quarantine_test_ssh "$@"; }
+    # shellcheck disable=SC2317,SC2329
+    run_remote() { active_quarantine_test_run_remote "$@"; }
+    # shellcheck disable=SC2317,SC2329
+    run_stopped_status_exact() { : > "$f/stopped-classifier-reached"; return 1; }
+
+    remote_readiness "$capture_id" "$freeze_sha" /sealed/freeze.json "$f" \
+        "$f/rounds" > "$f/readiness.out" || return 1
+    [ "$(grep -c 'active applied-prestop quarantine/disk ready' "$f/readiness.out")" -eq 6 ] && \
+        [ "$(grep -c 'quarantine-round-applied-status' "$f/actions")" -eq 6 ] && \
+        [ "$(grep -c 'quarantine-round-status' "$f/actions")" -eq 12 ] && \
+        [ "$(wc -l < "$f/active-content-probes" | tr -d ' ')" -eq 6 ] && \
+        [ ! -e "$f/stopped-classifier-reached" ]
+)
+
+capture_readiness_rejects_wrong_or_malformed_active_quarantine() (
+    # shellcheck source=/dev/null
+    . "$ORCHESTRATOR" >/dev/null
+    local f capture_id freeze_sha mode attempt active_status
+    f="$(mktemp -d)"; trap 'rm -rf -- "$f"' EXIT
+    capture_id="$(printf '0%.0s' {1..63})1"
+    freeze_sha="$(printf '0%.0s' {1..63})2"
+    # shellcheck disable=SC2317,SC2329
+    host_for() { active_quarantine_test_host_for "$@"; }
+    # shellcheck disable=SC2317,SC2329
+    freeze_node_field() { active_quarantine_test_freeze_field "$@"; }
+    # shellcheck disable=SC2317,SC2329
+    ssh_remote_exact() { active_quarantine_test_ssh "$@"; }
+    # shellcheck disable=SC2317,SC2329
+    run_remote() { active_quarantine_test_run_remote "$@"; }
+    for mode in wrong-capture wrong-freeze malformed-applied wrong-status \
+            malformed-dispatch contradictory-result-prefix \
+            contradictory-result-dispatch ambiguous-attempt released-attempt; do
+        rm -rf -- "$f/rounds" "$f/applied"
+        rm -f -- "$f"/*-live-classifier "$f"/*-status-count \
+            "$f/stopped-classifier-reached" "$f/actions" "$f/active-content-probes"
+        make_active_quarantine_resume_fixture "$f"
+        attempt="$f/rounds/round-1/attempt.fixture"
+        case "$mode" in
+            malformed-dispatch)
+                chmod 600 "$attempt/mutation-dispatch.json"
+                python3 - "$attempt/mutation-dispatch.json" <<'PY'
+import json,pathlib,sys
+path=pathlib.Path(sys.argv[1]);value=json.loads(path.read_bytes())
+value["round_readiness_sha256"]="f"*64
+path.write_text(json.dumps(value,sort_keys=True,separators=(",",":"))+"\n")
+PY
+                chmod 400 "$attempt/mutation-dispatch.json"
+                ;;
+            contradictory-result-prefix|contradictory-result-dispatch)
+                python3 - "$attempt" \
+                    "$(dirname -- "$ORCHESTRATOR")/test_quarantine_rounds.py" \
+                    "$mode" <<'PY'
+import importlib.util,json,os,pathlib,sys
+attempt=pathlib.Path(sys.argv[1]);module_path=pathlib.Path(sys.argv[2]);mode=sys.argv[3]
+spec=importlib.util.spec_from_file_location("active_result_fixture",module_path)
+fixture=importlib.util.module_from_spec(spec);spec.loader.exec_module(fixture)
+auth=json.loads((attempt/"authorization.json").read_bytes())
+item=fixture.applied(auth,"nyc",20,fixture.authorized_height(auth,"nyc"))
+transitions=attempt/"node-transitions";transitions.mkdir();os.chmod(transitions,0o700)
+path=transitions/"nyc.json";path.write_bytes(fixture.qr.canonical_bytes(item));os.chmod(path,0o400)
+result=fixture.result(auth,[item],30)
+if mode=="contradictory-result-prefix":
+    result["remaining_targets"]=[row["node"] for row in auth["targets"]]
+else:
+    result["mutation_dispatch"]["sha256"]="f"*64
+path=attempt/"result.json";path.write_bytes(fixture.qr.canonical_bytes(result));os.chmod(path,0o400)
+PY
+                ;;
+            ambiguous-attempt)
+                cp -R "$attempt" "$f/rounds/round-1/attempt.duplicate"
+                chmod 700 "$f/rounds/round-1/attempt.duplicate"
+                ;;
+            released-attempt)
+                python3 - "$attempt/zero-progress-release.json" <<'PY'
+import json,os,pathlib,sys
+path=pathlib.Path(sys.argv[1]);path.write_text(json.dumps({},separators=(",",":"))+"\n")
+os.chmod(path,0o400)
+PY
+                ;;
+        esac
+        set +e
+        active_quarantine_applied_prestop_ready "$capture_id" "$freeze_sha" \
+            /sealed/freeze.json nyc "$f/rounds" >/dev/null 2>&1
+        active_status=$?
+        set -e
+        [ "$active_status" -ne 0 ] || return 1
+    done
 )
 
 capture_readiness_fans_out_all_slow_host_probes() (
@@ -1143,6 +1364,7 @@ capture_readiness_fans_out_all_slow_host_probes() (
         /bin/sleep "$delay"
     }
     remote_readiness "$capture_id" "$freeze_sha" /sealed/freeze.json "$f" \
+        "$f/absent-rounds" \
         > "$f/readiness.out" || return 1
     for node in nyc lax ams lhr nrt sgp; do
         [ -f "$f/$node.started" ] || return 1
@@ -1208,6 +1430,7 @@ stale_freeze_capacity_cannot_cross_current_readiness_gate() (
     }
 
     if ( remote_readiness "$capture_id" "$freeze_sha" /sealed/stale-freeze.json "$f" \
+        "$f/absent-rounds" \
         >/dev/null 2>&1; : > "$f/quarantine-mutation-reached" ); then
         return 1
     fi
@@ -2442,7 +2665,7 @@ proof=text[text.index("quarantine_round_zero_progress_proof()"):
            text.index("legacy_height_bracket()")]
 assert proof.index("partial_re=") < proof.index("for member in state.iterdir():")
 for exact in (
-    "authorization\\.json|readiness\\.json|policy\\.nft|apply|nft|",
+    "freeze\\.lock\\.json|authorization\\.json|readiness\\.json|policy\\.nft|apply|nft|",
     "table-binding\\.json|nft-apply-intent\\.json|persistence-plan\\.json|",
     "item.st_size<0 or item.st_size>16*1024*1024",
     "stat.S_IMODE(item.st_mode) not in {0o600,expected_mode}",
@@ -2451,11 +2674,12 @@ for exact in (
     assert exact in proof, exact
 
 # Crash-before-rename model for the exact reviewed random temporary namespace.
-allowed={"authorization.json":0o400,"readiness.json":0o400,"policy.nft":0o400,
+allowed={"freeze.lock.json":0o400,"authorization.json":0o400,
+         "readiness.json":0o400,"policy.nft":0o400,
          "apply":0o500,"nft":0o500,"table-binding.json":0o400,
          "nft-apply-intent.json":0o400,"persistence-plan.json":0o400,
          "contract.json":0o400}
-pattern=re.compile(r"^\.(authorization\.json|readiness\.json|policy\.nft|apply|nft|"
+pattern=re.compile(r"^\.(freeze\.lock\.json|authorization\.json|readiness\.json|policy\.nft|apply|nft|"
                    r"table-binding\.json|nft-apply-intent\.json|persistence-plan\.json|"
                    r"contract\.json)\.([1-9][0-9]*)\.([0-9a-f]{16})\.partial$")
 with tempfile.TemporaryDirectory() as raw:
@@ -4163,6 +4387,8 @@ run_test 'v5 freeze transaction is fault-closed' v5_freeze_transaction_is_fault_
 run_test 'v5 stop journal semantics are fault-closed' v5_stop_journal_semantics_are_fault_closed
 run_test 'classification requires each node once' classification_requires_each_node_once
 run_test 'capture readiness resumes exact stopped state' capture_readiness_resumes_stopped_and_indexed_nodes
+run_test 'capture readiness resumes exact active applied-prestop state' capture_readiness_resumes_active_applied_prestop_nodes
+run_test 'capture readiness rejects wrong or malformed active quarantine' capture_readiness_rejects_wrong_or_malformed_active_quarantine
 run_test 'capture readiness fans out all slow host probes' capture_readiness_fans_out_all_slow_host_probes
 run_test 'stale freeze capacity cannot cross current readiness gate' stale_freeze_capacity_cannot_cross_current_readiness_gate
 run_test 'fleet observation retry rejects any stopped writer' fleet_live_observation_retry_rejects_any_stopped_writer


### PR DESCRIPTION
## Summary
- classify and resume exact applied/pre-stop quarantine attempts without weakening the initial mutation gate
- persist the sealed freeze plan where the boot-time fence can read it under systemd hardening
- validate canonical mutation dispatch/result prefixes and the deployed network-fence path
- add crash-prefix and runtime regression coverage

## Validation
- quarantine_rounds: 26/26
- archive-node runtime: 44/44 (+1 skipped)
- production manifest: 39/39
- recovery rollout: 82/82
- recovery archive contract: 58/58
- shell syntax, shellcheck, py_compile, and diff-check green

This is the permanent generic hardening. The in-flight production capture remains bound to protected commit 047e62581cbb33215637fd9a13fd05c2e432be9f and is recovered separately without rewriting chain history.