### PR TITLE
release: rotate the expired operator vault-restore certificate

### DIFF
--- a/.github/workflows/validator-vault-rewrap.yml
+++ b/.github/workflows/validator-vault-rewrap.yml
@@ -71,7 +71,7 @@ jobs:
             echo "::error::Typed source ciphertext SHA-256 is not the retained validator vault."
             exit 1
           }
-          [ "$EXPECTED_RESTORE_CERT_SHA256" = 6707f8b1dbc1f2d37d9a873a7e3d2c870d2b46db36f15a6df5293547680bfd43 ] || {
+          [ "$EXPECTED_RESTORE_CERT_SHA256" = 7af66885356183b7c4ce4fc23f05c0c1f6a3f3a141c44db779b0678c848773d2 ] || {
             echo "::error::Typed restore-certificate SHA-256 is not the approved operator certificate."
             exit 1
           }

--- a/scripts/recovery/README.md
+++ b/scripts/recovery/README.md
@@ -327,7 +327,7 @@ not inner release archives. The PATH is intentional: the enclave's reviewed
 SHA with source-ciphertext SHA-256
 `bdb2dd477fe10e06e63123d6080f321fce4a251479a5af8a59ae2b47814ed7e9`,
 restore-certificate SHA-256
-`6707f8b1dbc1f2d37d9a873a7e3d2c870d2b46db36f15a6df5293547680bfd43`,
+`7af66885356183b7c4ce4fc23f05c0c1f6a3f3a141c44db779b0678c848773d2`,
 and confirmation `REWRAP ARC VALIDATOR VAULT <protected-main-sha>`. After the
 release-environment approval and successful completion, record its exact run
 ID and attempt. The procedure proves that workflow/run/commit tuple and the
@@ -575,7 +575,7 @@ test -f /secure/operator/restore.key.pem \
 test "$(/usr/bin/stat --format='%a:%h' /secure/operator/restore.cert.pem)" = 600:1
 test "$(/usr/bin/stat --format='%a:%h' /secure/operator/restore.key.pem)" = 600:1
 printf '%s  %s\n' \
-  6707f8b1dbc1f2d37d9a873a7e3d2c870d2b46db36f15a6df5293547680bfd43 \
+  7af66885356183b7c4ce4fc23f05c0c1f6a3f3a141c44db779b0678c848773d2 \
   /secure/operator/restore.cert.pem | /usr/bin/sha256sum --check --strict
 
 unset GH_TOKEN GITHUB_TOKEN
@@ -644,7 +644,7 @@ jq -e \
     "repos/FerrumVir/arc-chain/actions/runs/$vault_rewrap_run_id/artifacts?per_page=100" \
     --jq '.artifacts[]' | jq -s '{artifacts: .}' > "$rewrap_artifacts_json"
 )
-rewrap_artifact_prefix="arc-validator-vault-rewrap-$protected_main_sha-6707f8b1dbc1f2d37d9a873a7e3d2c870d2b46db36f15a6df5293547680bfd43-"
+rewrap_artifact_prefix="arc-validator-vault-rewrap-$protected_main_sha-7af66885356183b7c4ce4fc23f05c0c1f6a3f3a141c44db779b0678c848773d2-"
 rewrap_artifact_json="$(
   jq -cer \
     --arg prefix "$rewrap_artifact_prefix" \
@@ -710,7 +710,7 @@ expected_names = {
     "REWRAP-RECEIPT.json": 64 * 1024,
     "SHA256SUMS": 1024,
 }
-expected_cert = "6707f8b1dbc1f2d37d9a873a7e3d2c870d2b46db36f15a6df5293547680bfd43"
+expected_cert = "7af66885356183b7c4ce4fc23f05c0c1f6a3f3a141c44db779b0678c848773d2"
 expected_source = "bdb2dd477fe10e06e63123d6080f321fce4a251479a5af8a59ae2b47814ed7e9"
 expected_cms = artifact_name.rsplit("-", 1)[-1]
 if len(expected_cms) != 64 or any(c not in "0123456789abcdef" for c in expected_cms):

--- a/tests/release/documentation_contract_test.sh
+++ b/tests/release/documentation_contract_test.sh
@@ -1544,7 +1544,7 @@ PY
         'status --porcelain=v1 --untracked-files=all' \
         '.github/workflows/validator-vault-rewrap.yml' \
         'bdb2dd477fe10e06e63123d6080f321fce4a251479a5af8a59ae2b47814ed7e9' \
-        '6707f8b1dbc1f2d37d9a873a7e3d2c870d2b46db36f15a6df5293547680bfd43' \
+        '7af66885356183b7c4ce4fc23f05c0c1f6a3f3a141c44db779b0678c848773d2' \
         '/secure/operator/pretag-materialized-v0.8.0/headless-linux-x86_64/arc-node-linux-x86_64' \
         '/secure/operator/pretag-materialized-v0.8.0/headless-linux-x86_64/genesis.toml' \
         'scripts/recovery/legacy-validator-set-40m.json.sha256' \

--- a/tests/release/validator_vault_rewrap_contract_test.sh
+++ b/tests/release/validator_vault_rewrap_contract_test.sh
@@ -32,7 +32,7 @@ one_shot_workflow_is_exact_main_protected_and_create_only() {
         '[ "$EXPECTED_MAIN_SHA" = "$DISPATCH_SHA" ]' \
         'REWRAP ARC VALIDATOR VAULT $EXPECTED_MAIN_SHA' \
         'bdb2dd477fe10e06e63123d6080f321fce4a251479a5af8a59ae2b47814ed7e9' \
-        '6707f8b1dbc1f2d37d9a873a7e3d2c870d2b46db36f15a6df5293547680bfd43' \
+        '7af66885356183b7c4ce4fc23f05c0c1f6a3f3a141c44db779b0678c848773d2' \
         'ARC_VALIDATOR_VAULT_CIPHERTEXT_B64' \
         'ARC_VALIDATOR_VAULT_PASSPHRASE' \
         'ARC_VALIDATOR_VAULT_RESTORE_CERT_B64' \


### PR DESCRIPTION
## Why
`validator-vault-rewrap` failed at 7828c0d2 (exit 1) and again at 34cb36b3 (exit 2) in the decrypt step with inputs identical to the run that passed on 2026-09-10 08:22Z, and no vault secret had changed since 2026-08-28. Exit 1 is the `-checkend 86400` margin, exit 2 is `openssl verify`: the operator restore certificate pinned at `6707f8b1…` expired on 2026-09-11.

## What
- Pin the replacement RSA-4096 self-signed restore certificate `7af66885356183b7c4ce4fc23f05c0c1f6a3f3a141c44db779b0678c848773d2` (valid 2026-09-11 → 2027-09-11) in the workflow authorize gate, `scripts/recovery/README.md` (four occurrences), and both contract tests.
- The `release` environment secret `ARC_VALIDATOR_VAULT_RESTORE_CERT_B64` was rotated to the same bytes (decoded SHA-256 verified locally). The private key stays with the operator.

## Checks
- `actionlint` on the workflow, `bash -n` on both tests, `git diff --check` clean.
- Old hash: 0 occurrences left; new hash: 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqXs5BHiV4YEkp2z79NrJd
